### PR TITLE
Rename references from `root-node` to `root-1`

### DIFF
--- a/packs/core-perks/acrobat.json
+++ b/packs/core-perks/acrobat.json
@@ -30,7 +30,7 @@
             "i": -17,
             "j": 3,
             "connected": [
-                "root-perk",
+                "root-1",
                 "adhesive-digits",
                 "fisherman",
                 "snare",

--- a/packs/core-perks/adhesive-digits.json
+++ b/packs/core-perks/adhesive-digits.json
@@ -30,7 +30,7 @@
             "i": -21,
             "j": -1,
             "connected": [
-                "root-perk",
+                "root-1",
                 "acrobat",
                 "drifter",
                 "fearsome-defense",

--- a/packs/core-perks/aura-user.json
+++ b/packs/core-perks/aura-user.json
@@ -32,7 +32,7 @@
             "connected": [
                 "aura-projection",
                 "aura-haze",
-                "root-perk",
+                "root-1",
                 "aura-channeling"
             ],
             "config": {

--- a/packs/core-perks/beastmaster.json
+++ b/packs/core-perks/beastmaster.json
@@ -30,7 +30,7 @@
             "i": 9,
             "j": -12,
             "connected": [
-                "root-perk",
+                "root-1",
                 "root-2",
                 "groomer",
                 "breeder",

--- a/packs/core-perks/dead-eye.json
+++ b/packs/core-perks/dead-eye.json
@@ -31,7 +31,7 @@
             "i": -16,
             "j": 6,
             "connected": [
-                "root-perk",
+                "root-1",
                 "dead-to-rights",
                 "drifter",
                 "firefly",

--- a/packs/core-perks/dead-to-rights.json
+++ b/packs/core-perks/dead-to-rights.json
@@ -32,7 +32,7 @@
             "j": -7,
             "connected": [
                 "dead-eye",
-                "root-perk",
+                "root-1",
                 "bug-catcher",
                 "down-the-sights",
                 "firefly",

--- a/packs/core-perks/firefly.json
+++ b/packs/core-perks/firefly.json
@@ -30,7 +30,7 @@
             "i": 3,
             "j": 2,
             "connected": [
-                "root-perk",
+                "root-1",
                 "dead-to-rights",
                 "dead-eye",
                 "down-the-sights",

--- a/packs/core-perks/fisherman.json
+++ b/packs/core-perks/fisherman.json
@@ -33,7 +33,7 @@
                 "dead-eye",
                 "acrobat",
                 "firefly",
-                "root-perk",
+                "root-1",
                 "potent-venom",
                 "silver-bullet",
                 "snare",

--- a/packs/core-perks/groomer.json
+++ b/packs/core-perks/groomer.json
@@ -30,7 +30,7 @@
             "i": 0,
             "j": -12,
             "connected": [
-                "root-perk",
+                "root-1",
                 "beastmaster",
                 "breeder",
                 "mobilize",

--- a/packs/core-perks/mobilize.json
+++ b/packs/core-perks/mobilize.json
@@ -31,7 +31,7 @@
             "i": -2,
             "j": -16,
             "connected": [
-                "root-perk",
+                "root-1",
                 "groomer",
                 "breeder",
                 "nurturing-shoots",

--- a/packs/core-perks/strong-style.json
+++ b/packs/core-perks/strong-style.json
@@ -34,7 +34,7 @@
                 "fearsome-defense",
                 "adhesive-digits",
                 "aura-haze",
-                "root-perk"
+                "root-1"
             ],
             "config": {
                 "alpha": null,

--- a/packs/core-perks/walking-dead.json
+++ b/packs/core-perks/walking-dead.json
@@ -36,7 +36,7 @@
                 "nurturing-shoots",
                 "pack-alpha",
                 "groomer",
-                "root-perk"
+                "root-1"
             ],
             "config": {
                 "alpha": null,


### PR DESCRIPTION
This isn't the end of the world as nodes check bi-directionally and the root perk still has the reference, but to stop future warning spam in the console lets merge this in next time.
