### PR TITLE
Foundry Data Sync - Steam Engine Change w/ Partial Automation

### DIFF
--- a/packs/core-abilities/steam-engine.json
+++ b/packs/core-abilities/steam-engine.json
@@ -3,27 +3,11 @@
   "type": "ability",
   "img": "icons/commodities/tech/furnace-modern.webp",
   "system": {
-    "actions": [
-      {
-        "traits": [],
-        "name": "Steam Engine",
-        "slug": "steam-engine",
-        "type": "generic",
-        "cost": {
-          "activation": "free",
-          "powerPoints": 4,
-          "trigger": "<p>The user is hit by a Water- or Fire-Type attack.</p>"
-        },
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "description": "<p>Trigger: The user is hit by a Water- or Fire-Type attack.</p><p>Effect: The user's SPD Stage increases by +3 for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
-      }
+    "actions": [],
+    "description": "<p>Trigger: The user is hit by a Water- or Fire-Type attack.</p><p>Effect: The user's SPD Stages are increased by +6 for 5 activations.<br><br>Note: Effect has to be manually dragged onto the actor at this time.<br><br>@embed[Compendium.ptr2e.core-effects.Item.MK3yA3vNby5Z3Yya.ActiveEffect.Oje9HVS8FwjF5cvR]</p>",
+    "traits": [
+      "partial-automation"
     ],
-    "description": "<p>Trigger: The user is hit by a Water- or Fire-Type attack.</p><p>Effect: The user's SPD Stage increases by +3 for 5 Activations.</p>",
-    "traits": [],
     "slug": "steam-engine",
     "_migration": {
       "version": null,

--- a/packs/core-effects/steam-engine-effect.json
+++ b/packs/core-effects/steam-engine-effect.json
@@ -1,0 +1,71 @@
+{
+  "name": "Steam Engine Effect",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.109,
+      "previous": null
+    },
+    "description": "<p>Increases speed by +6 stages for 5 activations.</p>",
+    "traits": []
+  },
+  "_id": "MK3yA3vNby5Z3Yya",
+  "img": "icons/commodities/tech/furnace-modern.webp",
+  "effects": [
+    {
+      "name": "Steam Engine",
+      "type": "affliction",
+      "_id": "Oje9HVS8FwjF5cvR",
+      "img": "icons/commodities/tech/furnace-modern.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.attributes.spe.stage",
+            "value": 6,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 60,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": 5,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>Increases speed by 6 stages.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.4.2.3",
+        "createdTime": 1735035817253,
+        "modifiedTime": 1735036486621,
+        "lastModifiedBy": "NGSbEbIP7O7ThFIb"
+      }
+    }
+  ],
+  "flags": {}
+}


### PR DESCRIPTION
Steam Engine was massively nerfed compared to the VGs, and on the old speed change model was oppressive. Now gives Rolycoly line the helping hand it desperately needs
- Update Effect: Steam Engine Effect
- Update Ability: Steam Engine