### PR TITLE
Foundry Data Sync - Perk Fix - Skirmish

### DIFF
--- a/packs/core-perks/skirmish.json
+++ b/packs/core-perks/skirmish.json
@@ -9,7 +9,7 @@
       {
         "name": "Skirmish",
         "slug": "skirmish",
-        "description": "<p>The user gains +2 SPD stages for 5 Activations, or removed early if the user takes damage.</p>",
+        "description": "<p>The user may spend 2PP to advance their action forward at the beginning of combat. Ideally this should be done prior to the GM pressing the 'Begin Combat' button.</p>",
         "traits": [
           "interrupt-2"
         ],
@@ -17,21 +17,17 @@
         "cost": {
           "activation": "free",
           "powerPoints": 2,
-          "trigger": "The user enters Combat.",
-          "delay": null,
-          "priority": null
+          "trigger": "The user enters Combat."
         },
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "systems/ptr2e/img/perk-icons/Ninja.svg"
       }
     ],
     "slug": "skirmish",
-    "description": "<p>Upon entering combat, as a Free Action at [Interrupt 2], you may spend 2 PP to gain +2 SPD stages for 5 Activations, or until you take damage.</p>",
+    "description": "<p>Upon entering combat, as a Free Action at [Interrupt 2], you may advance forward your AV by 40%.</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 2,
@@ -63,9 +59,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },


### PR DESCRIPTION
Corrects the effect text of Skirmish from speed stages for X activations or until hit, to 40% action advancement at the beginning of combat.
- Update Perk: Skirmish