### PR TITLE
Foundry Data Sync - Spinda Base Species Fix

### DIFF
--- a/packs/core-species/spinda.json
+++ b/packs/core-species/spinda.json
@@ -610,8 +610,12 @@
       "name": "spinda",
       "details": null,
       "evolutions": [],
-      "uuid": null,
-      "methods": []
+      "uuid": "Compendium.ptr2e.core-species.Item.DN39HBQfR7lFM73H",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "_migration": {
       "version": null,


### PR DESCRIPTION
Busted evo menu wasn't allowing Spinda's perk web to render correctly. Fixes that.
- Update Species: spinda