### PR TITLE
Foundry Data Sync - Laslock Category Fix

### DIFF
--- a/packs/core-gear/silphco-laslock-rifle.json
+++ b/packs/core-gear/silphco-laslock-rifle.json
@@ -36,7 +36,7 @@
         "types": [
           "untyped"
         ],
-        "category": "physical",
+        "category": "special",
         "power": 65,
         "accuracy": 100,
         "free": true
@@ -59,7 +59,8 @@
     "fling": {
       "type": "untyped",
       "power": 40,
-      "accuracy": 100
+      "accuracy": 100,
+      "hide": null
     },
     "quantity": 1,
     "rarity": "common",
@@ -74,11 +75,11 @@
     },
     "weaponType": "Rifle (Energy)",
     "weaponPp": 8,
-    "weaponRange": "25"
+    "weaponRange": "25",
+    "slug": "silphco-laslock-rifle"
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [],
   "folder": "V4skAU6G3OH5fXaf",
-  "flags": {},
   "_id": "fhfuptGmpadYy37I"
 }


### PR DESCRIPTION
Rifle was phys and shouldn't have been.
- Update Weapon: SilphCo Laslock Rifle