### PR TITLE
Foundry Data Sync - Evolution Stones Wave 1 + Some Automation

### DIFF
--- a/packs/core-abilities/angry-buzz.json
+++ b/packs/core-abilities/angry-buzz.json
@@ -83,7 +83,7 @@
       "sort": 0,
       "flags": {},
       "_stats": {
-        "compendiumSource": null,
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.1JEBnsWeesg69281.ActiveEffect.KvzgWgu9aZP1P2uQ",
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
@@ -91,6 +91,85 @@
         "createdTime": 1722257775308,
         "modifiedTime": 1732924515855,
         "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    },
+    {
+      "name": "Angry Buzz (Aura)",
+      "type": "passive",
+      "_id": "nIyX33wGGd78Cffx",
+      "img": "systems/ptr2e/img/svg/bug_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "aura",
+            "key": "",
+            "value": 0,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "radius": 5,
+            "effects": [
+              {
+                "uuid": "Compendium.ptr2e.core-effects.Item.aK2o7uxDcLpIfTib",
+                "affects": "all",
+                "events": [
+                  "enter"
+                ],
+                "removeOnExit": true,
+                "includesSelf": false,
+                "appliesSelfOnly": false,
+                "predicate": [
+                  "target:trait:bug"
+                ]
+              }
+            ],
+            "appearance": {
+              "border": {
+                "color": "#FF0000",
+                "alpha": 0.75
+              },
+              "highlight": {
+                "color": "user-color",
+                "alpha": 0.25
+              },
+              "texture": null
+            },
+            "mergeExisting": true
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.6o74KpM7eBLJij3Z.ActiveEffect.lckjHwpi6p660QfP",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736370258125,
+        "modifiedTime": 1736370294501,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
       }
     }
   ]

--- a/packs/core-abilities/immunity.json
+++ b/packs/core-abilities/immunity.json
@@ -24,7 +24,8 @@
     ],
     "description": "<p>Effect: The user is immune to the @Affliction[poison] and @Affliction[blight]. The user also resists Poison-Type damage.</p>",
     "traits": [
-      "defensive"
+      "defensive",
+      "partial-automation"
     ],
     "slug": "immunity",
     "_migration": {

--- a/packs/core-gear/dawn-stone.json
+++ b/packs/core-gear/dawn-stone.json
@@ -1,0 +1,49 @@
+{
+  "folder": "V4skAU6G3OH5fXae",
+  "name": "Dawn Stone",
+  "type": "gear",
+  "system": {
+    "_migration": {
+      "version": 0.109,
+      "previous": null
+    },
+    "slug": "dawn-stone",
+    "traits": [
+      "evolution"
+    ],
+    "actions": [],
+    "description": "<p>This stone is a catalyst for several Pokemon species to evolve.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "backpack"
+    },
+    "grade": "E",
+    "fling": {
+      "type": "psychic",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "7FNQ4jF6tg5WCKjx",
+  "img": "systems/ptr2e/img/item-icons/dawn%20stone.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-gear/fire-stone.json
+++ b/packs/core-gear/fire-stone.json
@@ -1,0 +1,50 @@
+{
+  "folder": "V4skAU6G3OH5fXae",
+  "name": "Fire Stone",
+  "type": "gear",
+  "system": {
+    "_migration": {
+      "version": 0.109,
+      "previous": null
+    },
+    "slug": "fire-stone",
+    "traits": [
+      "evolution",
+      "fire"
+    ],
+    "actions": [],
+    "description": "<p>This stone may be used to evolve a number of Fire-type Pokemon.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "backpack"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "fire",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "uncommon",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "88bxi9P2v8wiaflG",
+  "img": "systems/ptr2e/img/item-icons/fire%20stone.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-gear/ice-stone.json
+++ b/packs/core-gear/ice-stone.json
@@ -6,7 +6,10 @@
       "version": 0.108,
       "previous": null
     },
-    "traits": [],
+    "traits": [
+      "evolution",
+      "ice"
+    ],
     "actions": [],
     "description": "<p>An evolution stone used to evolve a number of Ice Pokemon.</p>",
     "crafting": {
@@ -23,7 +26,8 @@
     "fling": {
       "type": "ice",
       "power": 70,
-      "accuracy": 100
+      "accuracy": 100,
+      "hide": false
     },
     "quantity": 1,
     "rarity": "uncommon",
@@ -35,11 +39,11 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "slug": "ice-stone"
   },
   "img": "systems/ptr2e/img/item-icons/ice%20stone.webp",
   "effects": [],
   "folder": "V4skAU6G3OH5fXae",
-  "flags": {},
   "_id": "IrQtjCjQfvEXx1Jp"
 }

--- a/packs/core-gear/leaf-stone.json
+++ b/packs/core-gear/leaf-stone.json
@@ -1,0 +1,49 @@
+{
+  "folder": "V4skAU6G3OH5fXae",
+  "name": "Leaf Stone",
+  "type": "gear",
+  "system": {
+    "_migration": {
+      "version": 0.109,
+      "previous": null
+    },
+    "traits": [
+      "evolution",
+      "grass"
+    ],
+    "actions": [],
+    "description": "<p>This item catalyses evolution for a number of Grass-type Pokemon.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "backpack"
+    },
+    "grade": "E",
+    "fling": {
+      "type": "grass",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "Rt0SxLyROdChPHvE",
+  "img": "systems/ptr2e/img/item-icons/leaf%20stone.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-gear/sun-stone.json
+++ b/packs/core-gear/sun-stone.json
@@ -1,0 +1,49 @@
+{
+  "folder": "V4skAU6G3OH5fXae",
+  "name": "Sun Stone",
+  "type": "gear",
+  "system": {
+    "_migration": {
+      "version": 0.109,
+      "previous": null
+    },
+    "slug": "sun-stone",
+    "traits": [
+      "evolution"
+    ],
+    "actions": [],
+    "description": "<p>A stone which catalyses evolution in a number of Pokemon who resonate with the Sun.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "backpack"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "fire",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "uncommon",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "6qgHYkgl28cFOJG6",
+  "img": "systems/ptr2e/img/item-icons/sun%20stone.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-gear/thunder-stone.json
+++ b/packs/core-gear/thunder-stone.json
@@ -1,0 +1,49 @@
+{
+  "folder": "V4skAU6G3OH5fXae",
+  "name": "Thunder Stone",
+  "type": "gear",
+  "system": {
+    "_migration": {
+      "version": 0.109,
+      "previous": null
+    },
+    "traits": [
+      "evolution",
+      "electric"
+    ],
+    "actions": [],
+    "description": "<p>This stone catalyses evolution in a number of electromagnetic pokemon.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "held"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "electric",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "uncommon",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "PqfiVo6yrFIZEkWg",
+  "img": "systems/ptr2e/img/item-icons/thunder%20stone.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-gear/water-stone.json
+++ b/packs/core-gear/water-stone.json
@@ -1,0 +1,50 @@
+{
+  "folder": "V4skAU6G3OH5fXae",
+  "name": "Water Stone",
+  "type": "gear",
+  "system": {
+    "_migration": {
+      "version": 0.109,
+      "previous": null
+    },
+    "slug": "water-stone",
+    "traits": [
+      "evolution",
+      "water"
+    ],
+    "actions": [],
+    "description": "<p>This stone catalyses evolution in a number of water-type Pokemon.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "backpack"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "water",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "uncommon",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "DbsWyi7ksZtsystW",
+  "img": "systems/ptr2e/img/icons/gear_icon.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-moves/metal-cruncher.json
+++ b/packs/core-moves/metal-cruncher.json
@@ -4,7 +4,6 @@
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
     "slug": "metal-cruncher",
-    "description": "",
     "traits": [
       "jaw",
       "contact"
@@ -26,10 +25,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 6
         },
         "category": "physical",
         "power": 120,
@@ -38,15 +34,69 @@
           "steel"
         ],
         "description": "<p>Effect: On hit, the target has a 50% chance of losing -2 DEF Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "0CAb7rVY0qcgYOFo",
-  "effects": []
+  "effects": [
+    {
+      "name": "Metal Cruncher",
+      "type": "passive",
+      "_id": "yPbjomYAbtW0cNj9",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "metal-cruncher-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.B79G2s6TauIlmsno",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736370927667,
+        "modifiedTime": 1736370953351,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/muddy-water.json
+++ b/packs/core-moves/muddy-water.json
@@ -4,7 +4,6 @@
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
     "slug": "muddy-water",
-    "description": "",
     "traits": [],
     "actions": [
       {
@@ -21,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "special",
         "power": 90,
@@ -33,15 +29,69 @@
           "water"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 30% chance of losing -1 ACC Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "rQtia9zKrd23HcXH",
-  "effects": []
+  "effects": [
+    {
+      "name": "Muddy Water",
+      "type": "passive",
+      "_id": "g89pJV93RbwKtNoF",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "muddy-water-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.wA5oCsgHmZLcHHSn",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.rQtia9zKrd23HcXH.ActiveEffect.g89pJV93RbwKtNoF",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736369568752,
+        "modifiedTime": 1736369592437,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Automation covers some moves and abilities.
- Update Ability: Immunity
- Update Gear: Ice Stone
- Update Gear: Fire Stone
- Update Gear: Dawn Stone
- Update Gear: Leaf Stone
- Update Gear: Sun Stone
- Update Gear: Thunder Stone
- Update Gear: Water Stone
- Update Move: Muddy Water
- Update Ability: Angry Buzz
- Update Move: Metal Cruncher