### PR TITLE
Foundry Data Sync - Fox Fixes 09/01/2025

### DIFF
--- a/packs/core-abilities/illusion.json
+++ b/packs/core-abilities/illusion.json
@@ -50,16 +50,16 @@
             "toggleable": true,
             "count": false,
             "label": "Illusion",
-            "state": false,
             "alwaysActive": false,
             "mode": 2,
             "priority": null,
             "ignored": false,
-            "suboptions": []
+            "suboptions": [],
+            "state": false
           },
           {
             "type": "basic",
-            "key": "system.battleStats.evasion.Stage",
+            "key": "system.battleStats.evasion.stage",
             "value": 1,
             "predicate": [
               "state:illusion"
@@ -97,10 +97,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.2.0",
+        "systemVersion": "0.10.0-alpha.5.0",
         "createdTime": 1730497752850,
-        "modifiedTime": 1730497752850,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+        "modifiedTime": 1736460430090,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
       }
     }
   ]

--- a/packs/core-moves/banshee-shriek.json
+++ b/packs/core-moves/banshee-shriek.json
@@ -4,7 +4,7 @@
   "_id": "H46ay2gSvsLxUn5m",
   "img": "systems/ptr2e/img/svg/ghost_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "banshee-shriek",
     "traits": [
       "sonic"
     ],
@@ -24,43 +24,88 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null
+          "powerPoints": 6
         },
-        "variant": null,
         "types": [
           "ghost"
         ],
         "category": "special",
         "power": 80,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
         "description": "<p>Effect: On hit, all valid targets have a 20% chance of gaining @Affliction[paralysis] 5 and a 20% chance of gaining @Affliction[perish] 5.</p>"
       }
     ],
     "description": "<p>Effect: On hit, all valid targets have a 20% chance of gaining @Affliction[paralysis] 5 and a 20% chance of gaining @Affliction[perish] 5.</p>",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720459500659,
-    "modifiedTime": 1720459632556,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Banshee Shriek",
+      "type": "passive",
+      "_id": "OogzIbRJw2H4QMR6",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "banshee-shriek-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "banshee-shriek-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.perishcondititem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736471183523,
+        "modifiedTime": 1736471239993,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/combat-torque.json
+++ b/packs/core-moves/combat-torque.json
@@ -4,13 +4,7 @@
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
     "slug": "combat-torque",
-    "traits": [
-      "dash",
-      "pass-4",
-      "crash-1-2",
-      "contact",
-      "pp-updated"
-    ],
+    "traits": [],
     "actions": [
       {
         "slug": "combat-torque",
@@ -21,7 +15,8 @@
           "pass-4",
           "crash-1-2",
           "contact",
-          "pp-updated"
+          "pp-updated",
+          "partial-automation"
         ],
         "range": {
           "target": "creature",

--- a/packs/core-moves/coral-break.json
+++ b/packs/core-moves/coral-break.json
@@ -4,10 +4,7 @@
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
     "slug": "coral-break",
-    "description": "",
-    "traits": [
-      "crushing"
-    ],
+    "traits": [],
     "actions": [
       {
         "slug": "coral-break",
@@ -15,7 +12,8 @@
         "type": "attack",
         "traits": [
           "crushing",
-          "pp-updated"
+          "pp-updated",
+          "partial-automation"
         ],
         "range": {
           "target": "wide-line",
@@ -24,10 +22,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "special",
         "power": 80,
@@ -36,14 +31,15 @@
           "water"
         ],
         "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF. Coral Break's Power is doubled against Swimming targets.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/water_icon.svg",
+        "defensiveStat": "def"
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "a8tXijy7zx7TMFz2",
   "effects": []

--- a/packs/core-moves/delta-wave.json
+++ b/packs/core-moves/delta-wave.json
@@ -4,10 +4,8 @@
   "_id": "wamFPzwvhAmEwyBL",
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "legendary"
-    ],
+    "slug": "delta-wave",
+    "traits": [],
     "actions": [
       {
         "name": "Delta Wave",
@@ -15,7 +13,8 @@
         "type": "attack",
         "img": "icons/svg/explosion.svg",
         "traits": [
-          "legendary"
+          "legendary",
+          "partial-automation"
         ],
         "range": {
           "target": "creature",
@@ -24,43 +23,76 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
-        "variant": null,
         "types": [
           "water"
         ],
         "category": "special",
         "power": 90,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
         "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[frostbite] 5. The user also clears any [Hazards] directly adjacent to themself and ends any [Trap] effects the user is affected by.</p>"
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721317451464,
-    "modifiedTime": 1721317567785,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Delta Wave",
+      "type": "passive",
+      "_id": "BFhWkSvdYTy1uLyq",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "delta-wave-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.frostbiteconitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736472313534,
+        "modifiedTime": 1736472339810,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/disaster.json
+++ b/packs/core-moves/disaster.json
@@ -4,12 +4,7 @@
   "img": "systems/ptr2e/img/svg/ghost_icon.svg",
   "system": {
     "slug": "disaster",
-    "description": "",
-    "traits": [
-      "legendary",
-      "blast-2",
-      "explode"
-    ],
+    "traits": [],
     "actions": [
       {
         "slug": "disaster",
@@ -28,10 +23,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "special",
         "power": 100,
@@ -39,16 +31,81 @@
         "types": [
           "ghost"
         ],
-        "description": "<p>Effect: On hit, all valid targets become @Affliction[bound] 5. While @Affliction[bound], they take a 1/4 of their Max HP in Ghost-Type damage at the end of each of their Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "description": "<p>Effect: On hit, all valid targets become @Affliction[bound] 5. While @Affliction[bound], they also suffer from @Affliction[cursed].</p>",
+        "img": "systems/ptr2e/img/svg/ghost_icon.svg"
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "KT79n71DZy0Ms4IF",
-  "effects": []
+  "effects": [
+    {
+      "name": "Disaster",
+      "type": "passive",
+      "_id": "CtNfnTwIlcpUJIHL",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "disaster-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.boundconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "disaster-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.cursedcondititem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736472536136,
+        "modifiedTime": 1736472578155,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/pitch-arrow.json
+++ b/packs/core-moves/pitch-arrow.json
@@ -1,50 +1,101 @@
 {
-    "name": "Pitch Arrow",
-    "type": "move",
-    "img": "systems/ptr2e/img/svg/fire_icon.svg",
-    "system": {
-      "slug": "pitch-arrow",
-      "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[burn] 5.</p>",
-      "traits": [
-        "missile"
-      ],
-      "actions": [
-        {
-          "slug": "pitch-arrow",
-          "name": "Pitch Arrow",
-          "type": "attack",
-          "traits": [
-            "missile",
-            "pp-updated"
-          ],
-          "range": {
-            "target": "creature",
-            "distance": 10,
-            "unit": "m"
-          },
-          "cost": {
-            "activation": "complex",
-            "powerPoints": 3,
-            "delay": null,
+  "name": "Pitch Arrow",
+  "type": "move",
+  "img": "systems/ptr2e/img/svg/fire_icon.svg",
+  "system": {
+    "slug": "pitch-arrow",
+    "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[burn] 5.</p>",
+    "traits": [
+      "missile"
+    ],
+    "actions": [
+      {
+        "slug": "pitch-arrow",
+        "name": "Pitch Arrow",
+        "type": "attack",
+        "traits": [
+          "missile",
+          "pp-updated"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "category": "physical",
+        "power": 60,
+        "accuracy": 90,
+        "types": [
+          "fire"
+        ],
+        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[burn] 5.</p>",
+        "img": "icons/svg/explosion.svg"
+      }
+    ],
+    "grade": "C",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "lFR711cPGcY3M7zk",
+  "effects": [
+    {
+      "name": "Pitch Arrow",
+      "type": "passive",
+      "_id": "H1VP5JKr6Ll8Ar3o",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "pitch-arrow-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "mode": 2,
             "priority": null,
-            "trigger": null
-          },
-          "category": "physical",
-          "power": 60,
-          "accuracy": 90,
-          "types": [
-            "fire"
-          ],
-          "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[burn] 5.</p>",
-          "contestType": "",
-          "contestEffect": "",
-          "free": false,
-          "slot": null
-        }
-      ],
-      "container": null,
-      "grade": "C"
-    },
-    "_id": "lFR711cPGcY3M7zk",
-    "effects": []
-  }
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736463797665,
+        "modifiedTime": 1736463818116,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
+}

--- a/packs/core-moves/stun-arrow.json
+++ b/packs/core-moves/stun-arrow.json
@@ -1,50 +1,101 @@
 {
-    "name": "Stun Arrow",
-    "type": "move",
-    "img": "systems/ptr2e/img/svg/electric_icon.svg",
-    "system": {
-      "slug": "stun-arrow",
-      "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[paralysis] 5.</p>",
-      "traits": [
-        "missile"
-      ],
-      "actions": [
-        {
-          "slug": "stun-arrow",
-          "name": "Stun Arrow",
-          "type": "attack",
-          "traits": [
-            "missile",
-            "pp-updated"
-          ],
-          "range": {
-            "target": "creature",
-            "distance": 10,
-            "unit": "m"
-          },
-          "cost": {
-            "activation": "complex",
-            "powerPoints": 4,
-            "delay": null,
+  "name": "Stun Arrow",
+  "type": "move",
+  "img": "systems/ptr2e/img/svg/electric_icon.svg",
+  "system": {
+    "slug": "stun-arrow",
+    "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[paralysis] 5.</p>",
+    "traits": [
+      "missile"
+    ],
+    "actions": [
+      {
+        "slug": "stun-arrow",
+        "name": "Stun Arrow",
+        "type": "attack",
+        "traits": [
+          "missile",
+          "pp-updated"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "category": "physical",
+        "power": 70,
+        "accuracy": 100,
+        "types": [
+          "electric"
+        ],
+        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[paralysis] 5.</p>",
+        "img": "icons/svg/explosion.svg"
+      }
+    ],
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "lFR536cPGvY3M7zk",
+  "effects": [
+    {
+      "name": "Stun Arrow",
+      "type": "passive",
+      "_id": "aOnDAMfqwKSXOoqA",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "stun-arrow-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
             "priority": null,
-            "trigger": null
-          },
-          "category": "physical",
-          "power": 70,
-          "accuracy": 100,
-          "types": [
-            "electric"
-          ],
-          "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[paralysis] 5.</p>",
-          "contestType": "",
-          "contestEffect": "",
-          "free": false,
-          "slot": null
-        }
-      ],
-      "container": null,
-      "grade": "B"
-    },
-    "_id": "lFR536cPGvY3M7zk",
-    "effects": []
-  }
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736470193427,
+        "modifiedTime": 1736470227713,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
+}

--- a/packs/core-moves/tri-attack.json
+++ b/packs/core-moves/tri-attack.json
@@ -4,7 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "tri-attack",
-    "description": "",
     "traits": [
       "pulse",
       "ray"
@@ -26,10 +25,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "special",
         "power": 80,
@@ -38,15 +34,91 @@
           "normal"
         ],
         "description": "<p>Effect: On hit, the target has a 15% chance of gaining @Affliction[paralysis] 5, a 15% chance of gaining @Affliction[burn] 5, and a 15% chance of gaining @Affliction[frozen] 1.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "yy01fk9ACLAv0lDv",
-  "effects": []
+  "effects": [
+    {
+      "name": "Tri-Attack",
+      "type": "passive",
+      "_id": "Jwpa9OzGmlTm5bgN",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "tri-attack-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 15,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "tri-attack-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 15,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "tri-attack-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.frozencondititem",
+            "predicate": [],
+            "chance": 15,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.yy01fk9ACLAv0lDv.ActiveEffect.ENyym1gv1z8ha8Ni",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736460468181,
+        "modifiedTime": 1736460521969,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/dizzy-daft.json
+++ b/packs/core-perks/dizzy-daft.json
@@ -17,16 +17,12 @@
         "img": "modules/ptr2e-pkmn-sprites/sprites/327.webp",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
-        },
-        "variant": null
+          "powerPoints": 2
+        }
       },
       {
         "name": "Dizzy Daft (Passive)",
@@ -37,17 +33,12 @@
         "img": "modules/ptr2e-pkmn-sprites/sprites/327.webp",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
-        "hidden": true,
-        "variant": null
+        "hidden": true
       }
     ],
     "description": "<p>You can confuse yourself, and avoid the ill-effects.</p>",
@@ -78,15 +69,10 @@
     "webs": [
       "Compendium.ptr2e.core-species.Item.DN39HBQfR7lFM73H"
     ],
-    "global": false,
     "slug": "dizzy-daft",
-    "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "autoUnlock": []
   },
-  "img": "systems/ptr2e/img/icons/feat_icon.webp",
+  "img": "systems/ptr2e/img/perk-icons/Breeder.svg",
   "effects": [],
-  "flags": {},
   "_id": "y3aSWoyIMrXrn0l1"
 }

--- a/packs/core-perks/type-specialist.json
+++ b/packs/core-perks/type-specialist.json
@@ -1,0 +1,63 @@
+{
+  "name": "Type Specialist",
+  "type": "perk",
+  "system": {
+    "prerequisites": [],
+    "cost": 1,
+    "description": "<p>You gain +10 to social interaction Skill Tests when interacting with Pokemon of your preferred type. This perk may be purchased multiple times, each time selecting a new Type.</p>",
+    "actions": [
+      {
+        "name": "Type Specialty",
+        "slug": "type-specialty",
+        "description": "<p>You gain +10 to social interaction Skill Tests when interacting with Pokemon of your preferred type. The cost on this scales with each additional type chosen.</p>",
+        "cost": {
+          "activation": "free"
+        },
+        "type": "passive",
+        "traits": [],
+        "img": "icons/svg/explosion.svg",
+        "range": {
+          "target": "enemy",
+          "unit": "m"
+        }
+      }
+    ],
+    "slug": "type-specialist",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    },
+    "nodes": [
+      {
+        "connected": [
+          "improved-overland-1-1",
+          "stat-iv-booster-1-1",
+          "type-harmony",
+          "type-embodiment-type"
+        ],
+        "config": {
+          "alpha": null,
+          "backgroundColor": "#c0c0c0",
+          "borderColor": null,
+          "borderWidth": null,
+          "texture": "systems/ptr2e/img/perk-icons/Socialite.svg",
+          "tint": "#ffffff",
+          "scale": null
+        },
+        "hidden": false,
+        "type": "normal",
+        "x": 154,
+        "y": 100,
+        "tier": null
+      }
+    ],
+    "autoUnlock": [],
+    "global": true,
+    "webs": []
+  },
+  "_id": "7M9EE1mHIJeoAWhp",
+  "img": "systems/ptr2e/img/perk-icons/Socialite.svg",
+  "effects": [],
+  "folder": "kWG8zov1UnSKOvEQ"
+}

--- a/packs/core-perks/venomous-stinger.json
+++ b/packs/core-perks/venomous-stinger.json
@@ -1,0 +1,79 @@
+{
+  "name": "Venomous Stinger",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.109,
+      "previous": null
+    },
+    "actions": [],
+    "description": "<p>You have an enhanced stinger or set of stingers. Your bug-type moves now gain a +20% chance to inflict Poison.</p>",
+    "traits": [],
+    "prerequisites": [],
+    "autoUnlock": [],
+    "cost": 2,
+    "webs": [
+      "Compendium.ptr2e.core-species.Item.BmuDohMAWcHopUmk"
+    ],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Breeder.svg",
+  "effects": [
+    {
+      "name": "Venomous Stinger",
+      "type": "passive",
+      "_id": "0NOrXxpXK2n4bIcb",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "bug-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "folder": "e9XnhZdjIE7hroYs",
+  "flags": {},
+  "_id": "eZJbjxIaTYUydNy5"
+}


### PR DESCRIPTION
Updates icon for Dizzy Daft
Adds new Perk Venomous Stinger
Adds automation for various moves.
Fixes predicate clash on Type Specialty by renaming it Type Specialist.
- Update Perk: Dizzy Daft
- Update Perk: Venomous Stinger
- Update Ability: Illusion
- Update Move: Tri Attack
- Update Move: Pitch Arrow
- Update Move: Stun Arrow
- Update Perk: Type Specialist
- Update Move: Banshee Shriek
- Update Move: Blade Clash
- Update Move: Combat Torque
- Update Move: Coral Break
- Update Move: Delta Wave
- Update Move: Disaster