### PR TITLE
Foundry Data Sync - Fox Fixes and move automations 12/01/2025

### DIFF
--- a/packs/core-gear/devon-corp-exo-rig.json
+++ b/packs/core-gear/devon-corp-exo-rig.json
@@ -24,11 +24,12 @@
       "handsHeld": 0,
       "slot": "backpack"
     },
-    "grade": "E",
+    "grade": "D",
     "fling": {
       "type": "untyped",
       "power": 40,
-      "accuracy": 35
+      "accuracy": 35,
+      "hide": false
     },
     "quantity": 1,
     "rarity": "uncommon",
@@ -40,7 +41,8 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "slug": "devon-corp-exo-rig"
   },
   "img": "systems/ptr2e/img/icons/equipment_icon.webp",
   "effects": [
@@ -106,6 +108,5 @@
     }
   ],
   "folder": "V4skAU6G3OH5fXad",
-  "flags": {},
   "_id": "e9TZKDFHvjfrwDfJ"
 }

--- a/packs/core-moves/magma-storm.json
+++ b/packs/core-moves/magma-storm.json
@@ -4,11 +4,7 @@
   "img": "systems/ptr2e/img/svg/fire_icon.svg",
   "system": {
     "slug": "magma-storm",
-    "description": "",
-    "traits": [
-      "blast-2",
-      "legendary"
-    ],
+    "traits": [],
     "actions": [
       {
         "slug": "magma-storm",
@@ -26,10 +22,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "special",
         "power": 100,
@@ -37,16 +30,83 @@
         "types": [
           "fire"
         ],
-        "description": "<p>Effect: All valid targets become @Affliction[bound] 5. While @Affliction[bound], they take a Tick of HP in Fire-Type damage at the end of each of their Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "description": "<p>Effect: All valid targets become @Affliction[bound] 5 & @Affliction[burn] 5.</p>",
+        "img": "systems/ptr2e/img/svg/fire_icon.svg"
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "8Orxtt3ZLifqWqde",
-  "effects": []
+  "effects": [
+    {
+      "name": "Magma Storm",
+      "type": "passive",
+      "_id": "WoVwRx9iOImd6Ozf",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "magma-storm-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.boundconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "label": "Bound",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "magma-storm-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "label": "Burn",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736712174003,
+        "modifiedTime": 1736712257134,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/malignant-chain.json
+++ b/packs/core-moves/malignant-chain.json
@@ -4,7 +4,6 @@
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
     "slug": "malignant-chain",
-    "description": "",
     "traits": [
       "legendary"
     ],
@@ -24,10 +23,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 6
         },
         "category": "special",
         "power": 100,
@@ -36,15 +32,82 @@
           "poison"
         ],
         "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[blight] 8 and a 50% chance of gaining @Affliction[paralysis] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "fFKx2U3ztyLCAuRH",
-  "effects": []
+  "effects": [
+    {
+      "name": "Malignant Chain",
+      "type": "passive",
+      "_id": "0BTrlx4ZdjOApMWl",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "malignant-chain-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.blightcondititem",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "label": "Blight",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "malignant-chain-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "label": "Paralysis",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736712374317,
+        "modifiedTime": 1736712460790,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/mana-burst.json
+++ b/packs/core-moves/mana-burst.json
@@ -4,7 +4,7 @@
   "_id": "lOAKrPYIPBjjJTaQ",
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "mana-burst",
     "traits": [
       "explode",
       "pulse",
@@ -30,43 +30,22 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null
+          "powerPoints": 7
         },
-        "variant": null,
         "types": [
           "fairy"
         ],
         "category": "special",
         "power": 85,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
         "description": "<p>Effect: On hit, all valid targets have a 10% chance of losing -1 DEF Stage for 5 Activations.</p>"
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 6200000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1719584791330,
-    "modifiedTime": 1719974181882,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/mana-cannon.json
+++ b/packs/core-moves/mana-cannon.json
@@ -4,7 +4,7 @@
   "_id": "fAOqThi2wPLSKPY2",
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "mana-cannon",
     "traits": [
       "blast-1",
       "pulse"
@@ -26,43 +26,76 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "fairy"
         ],
         "category": "special",
         "power": 105,
         "accuracy": 85,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
         "description": "<p>Effect: On hit, the user has a 10% chance of increasing their SPATK Stage by +1 for 5 Activations.</p>"
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 6300000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1719584951214,
-    "modifiedTime": 1720456239499,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Mana Cannon",
+      "type": "passive",
+      "_id": "rKLECqNlqKSDe5Jj",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "mana-cannon-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAa",
+            "predicate": [],
+            "chance": 10,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736717521543,
+        "modifiedTime": 1736717561000,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/mud-bomb.json
+++ b/packs/core-moves/mud-bomb.json
@@ -4,7 +4,6 @@
   "img": "systems/ptr2e/img/svg/ground_icon.svg",
   "system": {
     "slug": "mud-bomb",
-    "description": "",
     "traits": [
       "explode",
       "blast-3"
@@ -26,10 +25,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "special",
         "power": 65,
@@ -38,14 +34,14 @@
           "ground"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 30% chance of losing -1 ACC Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "11QeLN3JCGxmlkzb",
   "effects": []

--- a/packs/core-moves/sludge.json
+++ b/packs/core-moves/sludge.json
@@ -4,7 +4,6 @@
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
     "slug": "sludge",
-    "description": "",
     "traits": [
       "blast-1"
     ],
@@ -24,10 +23,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "special",
         "power": 65,
@@ -36,15 +32,69 @@
           "poison"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[poison] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "JyY5EGIMXjZ4p62a",
-  "effects": []
+  "effects": [
+    {
+      "name": "Sludge",
+      "type": "passive",
+      "_id": "t55kVM0wzpWGvjI2",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sludge-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.0",
+        "createdTime": 1736675928952,
+        "modifiedTime": 1736675959455,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/biting-cold.json
+++ b/packs/core-perks/biting-cold.json
@@ -8,7 +8,7 @@
       "previous": null
     },
     "actions": [],
-    "description": "<p>Passive: The user's Ice-Type Attacks have a 30% chance to inflict Frostbite.</p>",
+    "description": "<p>Passive: The user's Ice-Type Attacks have a 20% chance to inflict Frostbite.</p>",
     "traits": [],
     "prerequisites": [
       "trait:ice"
@@ -21,7 +21,8 @@
           "brittle-ice",
           "cryogenics",
           "chill-out",
-          "stat-iv-booster-1"
+          "stat-iv-booster-1",
+          "thermal-dynamics"
         ],
         "config": {
           "alpha": null,
@@ -40,9 +41,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
@@ -60,7 +58,7 @@
             "key": "ice-attack",
             "value": "Compendium.ptr2e.core-effects.Item.frostbiteconitem",
             "predicate": [],
-            "chance": 30,
+            "chance": 20,
             "affects": "target",
             "mode": 2,
             "priority": null,
@@ -95,10 +93,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.1.0",
+        "systemVersion": "0.10.0-alpha.5.0",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1736711266722,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }
   ],


### PR DESCRIPTION
Mostly move automations but a couple of small fixes in here too.
- Update Move: Sludge
- Create Move: Mud Bomb
- Update Equipment: DevonCorp Exo-Rig
- Update Perk: Biting Cold
- Update Move: Magma Storm
- Update Move: Malignant Chain
- Create Move: Mana Burst
- Update Move: Mana Cannon