### PR TITLE
Foundry Data Sync - Minor perk corrections and multiple perk and move automations

### DIFF
--- a/packs/core-abilities/amplifier.json
+++ b/packs/core-abilities/amplifier.json
@@ -23,7 +23,9 @@
       }
     ],
     "description": "<p>Effect: The user's [Sonic] attacks have 30% more Power and have their Range increased by 50%.</p>",
-    "traits": [],
+    "traits": [
+      "partial-automation"
+    ],
     "slug": "amplifier",
     "_migration": {
       "version": null,

--- a/packs/core-abilities/weak-armor.json
+++ b/packs/core-abilities/weak-armor.json
@@ -10,18 +10,17 @@
         ],
         "name": "Weak Armor",
         "slug": "weak-armor",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user is hit by a Physical-Category attack.</p>"
         },
         "range": {
           "target": "self",
           "unit": "m"
         },
-        "description": "<p>Trigger: The user is hit by a Physical-Category attack. </p><p>Effect: The user loses -1 DEF Stage and gains +1 SPD Stage for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user is hit by a Physical-Category attack.</p><p>Effect: The user loses -1 DEF Stage and gains +1 SPD Stage for 5 Activations.</p>",
+        "img": "systems/ptr2e/img/perk-icons/Combat.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a Physical-Category attack. </p><p>Effect: The user loses -1 DEF Stage and gains +1 SPD Stage for 5 Activations.</p>",
@@ -47,7 +46,7 @@
             "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
             "predicate": [],
             "chance": 100,
-            "affects": "self",
+            "affects": "defensive",
             "mode": 2,
             "priority": null,
             "ignored": false
@@ -58,7 +57,7 @@
             "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLM",
             "predicate": [],
             "chance": 100,
-            "affects": "self",
+            "affects": "defensive",
             "mode": 2,
             "priority": null,
             "ignored": false
@@ -92,10 +91,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.2.4.3",
+        "systemVersion": "0.10.0-alpha.5.1.2",
         "createdTime": 1729246091402,
-        "modifiedTime": 1729246157575,
-        "lastModifiedBy": "kwBsHDVcAxdQpMPC"
+        "modifiedTime": 1736881773684,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
       }
     }
   ]

--- a/packs/core-moves/agility.json
+++ b/packs/core-moves/agility.json
@@ -5,41 +5,94 @@
   "system": {
     "slug": "agility",
     "description": "<p>Effect: The user gains +2 SPD Stages for 5 Activations.</p>",
-    "traits": [],
+    "traits": [
+      "pp-updated"
+    ],
     "actions": [
       {
         "slug": "agility",
         "name": "Agility",
         "type": "attack",
-        "traits": [],
+        "traits": [
+          "pp-updated"
+        ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "psychic"
         ],
         "description": "<p>Effect: The user gains +2 SPD Stages for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "C",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "eZle1R3DPcxpNL97",
-  "effects": []
+  "effects": [
+    {
+      "name": "Agility",
+      "type": "passive",
+      "_id": "y8ACmbjofFMuy53S",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "agility-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLZ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736890383504,
+        "modifiedTime": 1736890404162,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/barrier.json
+++ b/packs/core-moves/barrier.json
@@ -5,41 +5,94 @@
   "system": {
     "slug": "barrier",
     "description": "<p>Effect: The user gains +2 DEF Stages for 5 Activations.</p>",
-    "traits": [],
+    "traits": [
+      "pp-updated"
+    ],
     "actions": [
       {
         "slug": "barrier",
         "name": "Barrier",
         "type": "attack",
-        "traits": [],
+        "traits": [
+          "pp-updated"
+        ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "psychic"
         ],
         "description": "<p>Effect: The user gains +2 DEF Stages for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "KSxhLJTzKi6cNI4p",
-  "effects": []
+  "effects": [
+    {
+      "name": "Barrier",
+      "type": "passive",
+      "_id": "ZEicDeXgxMwytnSd",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "barrier-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.DYJyYbH3EVwM4P90",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736889777642,
+        "modifiedTime": 1736889798874,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/helping-hand.json
+++ b/packs/core-moves/helping-hand.json
@@ -5,13 +5,17 @@
   "system": {
     "slug": "helping-hand",
     "description": "<p>Effect: The targets gains @Affliction[boosted] 2 and @Affliction[resolved] 2.</p>",
-    "traits": [],
+    "traits": [
+      "pp-updated"
+    ],
     "actions": [
       {
         "slug": "helping-hand",
         "name": "Helping Hand",
         "type": "attack",
-        "traits": [],
+        "traits": [
+          "pp-updated"
+        ],
         "range": {
           "target": "creature",
           "distance": 10,
@@ -19,27 +23,88 @@
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: The targets gains @Affliction[boosted] 2 and @Affliction[resolved] 2.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "losiXPVUcTy72boW",
-  "effects": []
+  "effects": [
+    {
+      "name": "Helping Hand",
+      "type": "passive",
+      "_id": "v84Wq2KgSd7tCv87",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "helping-hand-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.boostedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "helping-hand-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.resolvedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736887465748,
+        "modifiedTime": 1736887524483,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/hone-claws.json
+++ b/packs/core-moves/hone-claws.json
@@ -5,41 +5,105 @@
   "system": {
     "slug": "hone-claws",
     "description": "<p>Effect: The user's ATK Stage and ACC Stage increase by +1 each for 5 Activations.</p>",
-    "traits": [],
+    "traits": [
+      "pp-updated"
+    ],
     "actions": [
       {
         "slug": "hone-claws",
         "name": "Hone Claws",
         "type": "attack",
-        "traits": [],
+        "traits": [
+          "pp-updated"
+        ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "dark"
         ],
         "description": "<p>Effect: The user's ATK Stage and ACC Stage increase by +1 each for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "C",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "ACTyejrBHHBe0sJV",
-  "effects": []
+  "effects": [
+    {
+      "name": "Hone Claws",
+      "type": "passive",
+      "_id": "86MqRTUBSBxW0IXb",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "hone-claws-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.ZGwaMlzUwkSuCPyH",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "hone-claws-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.iv1l5qSwT9ykajV0",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736890258394,
+        "modifiedTime": 1736890300328,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/iron-defense.json
+++ b/packs/core-moves/iron-defense.json
@@ -4,42 +4,93 @@
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
     "slug": "iron-defense",
-    "description": "<p>Effect: The user increases their WC by 3 Stages (max WC 16) for 5 Activations and increases their DEF Stage by +2 for 5 Activations.</p>",
     "traits": [],
     "actions": [
       {
         "slug": "iron-defense",
         "name": "Iron Defense",
         "type": "attack",
-        "traits": [],
+        "traits": [
+          "pp-updated",
+          "partial-automation"
+        ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "steel"
         ],
         "description": "<p>Effect: The user increases their WC by 3 Stages (max WC 16) for 5 Activations and increases their DEF Stage by +2 for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "C",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "qSWTxI39iL7ivEVw",
-  "effects": []
+  "effects": [
+    {
+      "name": "Iron Defense",
+      "type": "passive",
+      "_id": "HOl2oVB3iOBTL4Qb",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "iron-defense-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.DYJyYbH3EVwM4P90",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736888535213,
+        "modifiedTime": 1736888558910,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/mean-look.json
+++ b/packs/core-moves/mean-look.json
@@ -4,11 +4,7 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "mean-look",
-    "description": "<p>Effect: All valid targets gain @Affliction[stuck] 5 and @Affliction[Taunted] 5.</p>",
-    "traits": [
-      "social",
-      "friendly"
-    ],
+    "traits": [],
     "actions": [
       {
         "slug": "mean-look",
@@ -16,7 +12,8 @@
         "type": "attack",
         "traits": [
           "social",
-          "friendly"
+          "friendly",
+          "pp-updated"
         ],
         "range": {
           "target": "cone",
@@ -25,27 +22,88 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 8,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 6
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
-        "description": "<p>Effect: All valid targets gain @Affliction[stuck] 5 and @Affliction[Taunted] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "description": "<p>Effect: All valid targets gain @Affliction[stuck] 5 and @Affliction[taunted] 5.</p>",
+        "img": "systems/ptr2e/img/svg/normal_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "TErn7z89DFNr28vJ",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mean Look",
+      "type": "passive",
+      "_id": "AHUPEh4whmBjXszd",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "mean-look-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.stuckconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "mean-look-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.tauntedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736890025350,
+        "modifiedTime": 1736890065326,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/metal-sound.json
+++ b/packs/core-moves/metal-sound.json
@@ -6,7 +6,8 @@
     "slug": "metal-sound",
     "description": "<p>Effect: On hit, all valid targets lose -2 SPDEF for 5 Activations.</p>",
     "traits": [
-      "sonic"
+      "sonic",
+      "pp-updated"
     ],
     "actions": [
       {
@@ -14,7 +15,8 @@
         "name": "Metal Sound",
         "type": "attack",
         "traits": [
-          "sonic"
+          "sonic",
+          "pp-updated"
         ],
         "range": {
           "target": "cone",
@@ -23,27 +25,78 @@
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "status",
-        "power": null,
         "accuracy": 85,
         "types": [
           "steel"
         ],
         "description": "<p>Effect: On hit, all valid targets lose -2 SPDEF for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "mYQseVatavuGbtWc",
-  "effects": []
+  "effects": [
+    {
+      "name": "Metal Sound",
+      "type": "passive",
+      "_id": "3i1Q06DMyhuMH8qF",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "metal-sound-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.PYz1Z32uiXoulkW2",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736890162009,
+        "modifiedTime": 1736890184683,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/minimize.json
+++ b/packs/core-moves/minimize.json
@@ -6,7 +6,8 @@
     "slug": "minimize",
     "description": "<p>Effect: The user gains @Affliction[shrink] condition and has its EVA increase by +2 Stages for 5 Activations.</p>",
     "traits": [
-      "shrink"
+      "shrink",
+      "pp-updated"
     ],
     "actions": [
       {
@@ -14,36 +15,97 @@
         "name": "Minimize",
         "type": "attack",
         "traits": [
-          "shrink"
+          "shrink",
+          "pp-updated"
         ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: The user gains @Affliction[shrink] condition and has its EVA increase by +2 Stages for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "B",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "7ugux2WH3qil0DtG",
-  "effects": []
+  "effects": [
+    {
+      "name": "Minimize",
+      "type": "passive",
+      "_id": "PYkEw8ucsC0s0iNW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "minimize-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.shrinkcondititem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "minimize-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.QdbBH4Zmewj1ZB9q",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736889920411,
+        "modifiedTime": 1736889963771,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/nasty-plot.json
+++ b/packs/core-moves/nasty-plot.json
@@ -5,31 +5,94 @@
   "system": {
     "slug": "nasty-plot",
     "description": "<p>Effect: The user's SPATK Stage is increased by +2 for 5 Activations.</p>",
-    "traits": [],
+    "traits": [
+      "pp-updated"
+    ],
     "actions": [
       {
         "slug": "nasty-plot",
         "name": "Nasty Plot",
         "type": "attack",
-        "traits": [],
+        "traits": [
+          "pp-updated"
+        ],
         "range": {
           "target": "self",
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5
+          "powerPoints": 3
         },
         "category": "status",
         "types": [
           "dark"
         ],
         "description": "<p>Effect: The user's SPATK Stage is increased by +2 for 5 Activations.</p>",
-        "img": "systems/ptr2e/img/svg/dark_icon.svg"
+        "img": "systems/ptr2e/img/svg/dark_icon.svg",
+        "predicate": []
       }
     ],
-    "grade": "C"
+    "grade": "C",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "OpvmLYUIPWCYcowY",
-  "effects": []
+  "effects": [
+    {
+      "name": "Nasty Plot",
+      "type": "passive",
+      "_id": "odcE0bseYTWhFoif",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "nasty-plot-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAZ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736887640753,
+        "modifiedTime": 1736887667330,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/sharpen.json
+++ b/packs/core-moves/sharpen.json
@@ -5,41 +5,105 @@
   "system": {
     "slug": "sharpen",
     "description": "<p>Effect: The user gains +1 ATK Stages for 5 Activations and @Affliction[sharpen] 5.</p>",
-    "traits": [],
+    "traits": [
+      "pp-updated"
+    ],
     "actions": [
       {
         "slug": "sharpen",
         "name": "Sharpen",
         "type": "attack",
-        "traits": [],
+        "traits": [
+          "pp-updated"
+        ],
         "range": {
           "target": "creature",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 2
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: The user gains +1 ATK Stages for 5 Activations and @Affliction[sharpen] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "D",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "ZbfFVvq6rf5tyiUI",
-  "effects": []
+  "effects": [
+    {
+      "name": "Sharpen",
+      "type": "passive",
+      "_id": "PpPHGUQSnVwgQJ1K",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sharpen-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.ZGwaMlzUwkSuCPyH",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "sharpen-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.sharpencondiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736888218983,
+        "modifiedTime": 1736888268127,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/swords-dance.json
+++ b/packs/core-moves/swords-dance.json
@@ -6,7 +6,8 @@
     "slug": "swords-dance",
     "description": "<p>Effect: The user raises their ATK Stages by +2 for 5 Activations.</p>",
     "traits": [
-      "dance"
+      "dance",
+      "pp-updated"
     ],
     "actions": [
       {
@@ -14,7 +15,8 @@
         "name": "Swords Dance",
         "type": "attack",
         "traits": [
-          "dance"
+          "dance",
+          "pp-updated"
         ],
         "range": {
           "target": "self",
@@ -22,23 +24,28 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5
+          "powerPoints": 3
         },
         "category": "status",
         "types": [
           "normal"
         ],
         "description": "<p>Effect: The user raises their ATK Stages by +2 for 5 Activations.</p>",
-        "img": "systems/ptr2e/img/svg/normal_icon.svg"
+        "img": "systems/ptr2e/img/svg/normal_icon.svg",
+        "predicate": []
       }
     ],
-    "grade": "C"
+    "grade": "C",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "DfeVcS4PIWcHqut8",
   "effects": [
     {
       "name": "Swords Dance",
-      "img": "icons/svg/down.svg",
+      "img": "systems/ptr2e/img/icons/physical_icon.png",
       "type": "affliction",
       "duration": {
         "turns": 5,
@@ -52,10 +59,12 @@
       "system": {
         "changes": [
           {
-            "type": "basic",
-            "key": "system.attributes.atk.Stage",
-            "value": 2,
+            "type": "roll-effect",
+            "key": "swords-dance-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.g1Gt9mJWimAqrqZ0",
             "predicate": [],
+            "chance": 100,
+            "affects": "target",
             "mode": 2,
             "priority": null,
             "ignored": false
@@ -70,7 +79,7 @@
         "stacks": 0,
         "priority": 50
       },
-      "description": "<p>Effect: The afflicted creature’s default SPATK Stages are reduced by 1.</p>",
+      "description": "<p>+2 Attack Stages</p>",
       "statuses": [],
       "_id": "m4TnGrODsVuLi0lM",
       "disabled": false,
@@ -82,12 +91,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.327",
+        "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.1.5.2",
+        "systemVersion": "0.10.0-alpha.5.1.2",
         "createdTime": 1718630215519,
-        "modifiedTime": 1718630215519,
-        "lastModifiedBy": "y4EIjJlrc2eCclW7"
+        "modifiedTime": 1736888398708,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
       }
     }
   ]

--- a/packs/core-perks/aura-haze.json
+++ b/packs/core-perks/aura-haze.json
@@ -19,19 +19,21 @@
         "description": "<p>Your skill at manipulating your own Aura allows you to create an indistinct haze about yourself. You gain +1 EVA stage for 5 Activations.</p>",
         "cost": {
           "activation": "simple",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "type": "generic",
+        "type": "attack",
         "traits": [],
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/perk-icons/Aura.svg",
         "range": {
-          "target": "enemy",
-          "unit": "m",
-          "distance": 0
+          "target": "self",
+          "unit": "m"
         },
-        "variant": null
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": []
       }
     ],
     "slug": "aura-haze",
@@ -63,14 +65,65 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "_id": "UmbmjzRANft3PAxG",
   "img": "systems/ptr2e/img/perk-icons/Aura.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Aura Haze",
+      "type": "passive",
+      "_id": "Uh6oIjyCAA77vnOT",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "aura-haze-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.OUBNweJOMjAEtAye",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736876041388,
+        "modifiedTime": 1736876155757,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ],
   "folder": "I7ocNlZvZjyhwUcw"
 }

--- a/packs/core-perks/drifter.json
+++ b/packs/core-perks/drifter.json
@@ -19,21 +19,15 @@
         "slug": "drifter",
         "description": "<p>You gain the [Hover] trait, and if you did not already possess a Flight movement, you gain a Flight Movement Allowance equal to that of your highest Primary Movement Score.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "drifter",
@@ -47,9 +41,9 @@
         "connected": [
           "dustoff",
           "wingblades",
-          "improved-flight-1-1",
-          "enchanting-smile",
           "improved-flight-1",
+          "enchanting-smile",
+          "improved-flight",
           "acrobat",
           "root-2"
         ],
@@ -70,11 +64,13 @@
       }
     ],
     "autoUnlock": [
-      "trait:hover"
+      {
+        "or": [
+          "trait:hover",
+          "trait:winged"
+        ]
+      }
     ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },

--- a/packs/core-perks/hivemark.json
+++ b/packs/core-perks/hivemark.json
@@ -16,21 +16,16 @@
         "img": "systems/ptr2e/img/svg/bug_icon.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
-        "hidden": true,
-        "variant": null
+        "hidden": true
       }
     ],
     "slug": "hivemark",
-    "description": "<p>Passive: Your Bug-Type Moves gain a +20% chance to inflict Infested 5.</p>",
+    "description": "<p>Passive: Your Bug-Type Moves gain a +20% chance to inflict @Affliction[infested] 5.</p>",
     "traits": [],
     "prerequisites": [
       "trait:bug"
@@ -41,7 +36,7 @@
         "connected": [
           "adhesive-digits",
           "silk-swing",
-          "improved-threaded-1"
+          "improved-threaded"
         ],
         "config": {
           "alpha": null,
@@ -60,9 +55,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },

--- a/packs/core-perks/improved-threaded.json
+++ b/packs/core-perks/improved-threaded.json
@@ -1,0 +1,142 @@
+{
+  "name": "Improved Threaded",
+  "type": "perk",
+  "folder": "zrVtKATNxzLNxTUe",
+  "system": {
+    "prerequisites": [
+      "#An Threaded Movement Allowance",
+      "#Running 25 + 5 x (# of Improved Threaded Perks already obtained)",
+      "#Acrobatics 25 + 5 x (# of Improved Threaded Perks already obtained)"
+    ],
+    "cost": 1,
+    "description": "<p>Improve your Threaded Movement Allowance by 2.</p>",
+    "actions": [
+      {
+        "name": "Improved Threaded",
+        "slug": "improved-threaded",
+        "description": "<p>Improve your Threaded Movement Allowance by 2.</p>",
+        "cost": {
+          "activation": "free"
+        },
+        "type": "passive",
+        "traits": [],
+        "img": "icons/svg/explosion.svg",
+        "range": {
+          "target": "enemy",
+          "unit": "m"
+        }
+      }
+    ],
+    "slug": "improved-threaded",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    },
+    "variant": "multi",
+    "mode": "individual",
+    "nodes": [
+      {
+        "connected": [
+          "hivemark",
+          "silk-swing",
+          "mankey-see-mankey-do",
+          "adhesive-digits"
+        ],
+        "config": {
+          "alpha": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "borderWidth": null,
+          "texture": "systems/ptr2e/img/svg/bug_icon.svg",
+          "tint": null,
+          "scale": null
+        },
+        "hidden": false,
+        "type": "normal",
+        "x": 90,
+        "y": 27,
+        "tier": null
+      },
+      {
+        "x": 85,
+        "y": 36,
+        "connected": [
+          "silk-swing",
+          "adhesive-digits",
+          "improved-overland-7"
+        ],
+        "config": {
+          "alpha": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "borderWidth": null,
+          "texture": null,
+          "tint": null,
+          "scale": null
+        },
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ],
+    "autoUnlock": [],
+    "global": true,
+    "webs": []
+  },
+  "_id": "OluRtmzPHj9OgOXc",
+  "img": "systems/ptr2e/img/svg/bug_icon.svg",
+  "effects": [
+    {
+      "name": "Improved Threaded",
+      "type": "passive",
+      "_id": "BBaeUT5zeChKTMLy",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.movement.threaded.value",
+            "value": 2,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736876858383,
+        "modifiedTime": 1736876884316,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
+}

--- a/packs/core-perks/the-meaning-of-haste.json
+++ b/packs/core-perks/the-meaning-of-haste.json
@@ -9,22 +9,23 @@
       {
         "name": "The Meaning of Haste",
         "slug": "the-meaning-of-haste",
-        "description": "All allied creatures gain +2 SPD stages for 5 Activations.",
+        "description": "<p>All allied creatures gain +2 SPD stages for 5 Activations.</p>",
         "traits": [],
-        "type": "generic",
+        "type": "attack",
         "range": {
           "target": "field",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null
+          "powerPoints": 6
         },
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "systems/ptr2e/img/perk-icons/Orders_Training.svg",
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "predicate": []
       }
     ],
     "slug": "the-meaning-of-haste",
@@ -66,11 +67,62 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "The Meaning of Haste",
+      "type": "passive",
+      "_id": "h6oOzXCzDtnujBxY",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "the-meaning-of-haste-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLZ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736877838885,
+        "modifiedTime": 1736877883752,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/trained-wielder.json
+++ b/packs/core-perks/trained-wielder.json
@@ -13,21 +13,15 @@
         "slug": "trained-wielder",
         "description": "<p>Gain a Wielded Item Slot.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "trained-wielder",
@@ -63,10 +57,9 @@
         "tier": null
       }
     ],
-    "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
+    "autoUnlock": [
+      "trait:wielder"
+    ],
     "global": true,
     "webs": []
   },

--- a/packs/core-perks/vigilant-guardian.json
+++ b/packs/core-perks/vigilant-guardian.json
@@ -36,14 +36,73 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "img": "systems/ptr2e/img/perk-icons/Combat.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Vigilant Guardian",
+      "type": "passive",
+      "_id": "Vqjep80xzxd86kem",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.CzvgRhfvDuRjrtA1",
+            "predicate": [],
+            "replaceSelf": true,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.2",
+        "createdTime": 1736878288284,
+        "modifiedTime": 1736878309861,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ],
   "_id": "K1CHM8mGL4RHVeUC",
   "folder": "c29hnIAtXgwB7FeY"
 }


### PR DESCRIPTION
From The Black Knight world on 14/01/25
- Update Perk: Aura Haze
- Update Perk: Trained Wielder
- Update Perk: Improved Threaded
- Update Perk: The Meaning of Haste
- Update Perk: Vigilant Guardian
- Update Perk: Hivemark
- Update Perk: Drifter
- Update Ability: Weak Armor
- Update Ability: Amplifier
- Update Move: Helping Hand
- Update Move: Nasty Plot
- Update Move: Sharpen
- Update Move: Swords Dance
- Update Move: Iron Defense
- Update Move: Barrier
- Update Move: Minimize
- Update Move: Mean Look
- Update Move: Metal Sound
- Update Move: Hone Claws
- Update Move: Agility