### PR TITLE
Foundry Data Sync - Species fixes + Rage and Leer rollback

### DIFF
--- a/packs/core-moves/leer.json
+++ b/packs/core-moves/leer.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "leer",
-    "description": "<p>Effect: All valid targets lose -1 DEF Stages for 5 Activations and gain @Affliction[fear] 2.</p>",
-    "traits": [
-      "social",
-      "friendly",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "leer",
@@ -27,26 +21,25 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "status",
-        "power": null,
         "accuracy": 100,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: All valid targets lose -1 DEF Stages for 5 Activations and gain @Affliction[fear] 2.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "slot": 1,
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "6xLPJIk5QClQKiGv",
   "effects": []

--- a/packs/core-moves/rage.json
+++ b/packs/core-moves/rage.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "rage",
-    "description": "",
-    "traits": [
-      "contact",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "rage",
@@ -33,11 +28,27 @@
         "types": [
           "normal"
         ],
-        "description": "<p>Effect: The user gains @Affliction[enraged] 2. While @Affliction[enraged], if the user is hit by a damaging attack, they gain +1 ATK Stage for 5 Activations.</p>"
+        "description": "<p>Effect: The user gains @Affliction[enraged] 2. While @Affliction[enraged], if the user is hit by a damaging attack, they gain +1 ATK Stage for 5 Activations.</p>",
+        "img": "icons/svg/explosion.svg",
+        "slot": 4,
+        "predicate": []
       }
     ],
-    "grade": "E"
+    "grade": "E",
+    "_migration": {
+      "version": null,
+      "previous": null
+    },
+    "traits": []
   },
   "_id": "6OK8vhZYljL4X7cd",
-  "effects": []
+  "effects": [],
+  "flags": {
+    "ptr2e": {
+      "grantedBy": {
+        "id": "c7XB9rHsJMCXrIsE",
+        "onDelete": "cascade"
+      }
+    }
+  }
 }

--- a/packs/core-species/braviary.json
+++ b/packs/core-species/braviary.json
@@ -6,7 +6,7 @@
     "number": 628,
     "size": {
       "category": "medium",
-      "type": "height",
+      "type": "quad",
       "height": 1.5,
       "weight": 41
     },
@@ -206,247 +206,103 @@
     "moves": {
       "levelUp": [
         {
-          "name": "wing-attack",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "leer",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "peck",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sky-attack",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "name": "superpower",
+          "gen": "scarlet-violet",
+          "level": 0
         },
         {
           "name": "hone-claws",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "leer",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "peck",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "sky-attack",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "wing-attack",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "fury-attack",
-          "level": 5,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 5
         },
         {
           "name": "tailwind",
-          "level": 18,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 18
         },
         {
           "name": "scary-face",
-          "level": 24,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 24
         },
         {
           "name": "aerial-ace",
-          "level": 30,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 30
         },
         {
           "name": "slash",
-          "level": 36,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 36
         },
         {
           "name": "whirlwind",
-          "level": 42,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 42
         },
         {
           "name": "crush-claw",
-          "level": 48,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 48
         },
         {
           "name": "sky-drop",
-          "level": 50,
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "defog",
-          "level": 64,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "thrash",
-          "level": 72,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "superpower",
-          "level": 0,
-          "gen": "scarlet-violet"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 50
         },
         {
           "name": "air-slash",
-          "level": 57,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 57
+        },
+        {
+          "name": "defog",
+          "gen": "scarlet-violet",
+          "level": 64
+        },
+        {
+          "name": "thrash",
+          "gen": "scarlet-violet",
+          "level": 72
         },
         {
           "name": "brave-bird",
-          "level": 80,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 80
         }
       ],
       "tutor": [
         {
-          "name": "snore",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "heat-wave",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "roost",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "zen-headbutt",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "laser-focus",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "dual-wingbeat",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "cut",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "fly",
+          "name": "acrobatics",
           "gen": "scarlet-violet"
-        },
-        {
-          "name": "body-slam",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "take-down",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "double-edge",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "hyper-beam",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "strength",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "toxic",
-          "gen": "ultra-sun-ultra-moon"
         },
         {
           "name": "agility",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "double-team",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "swift",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rest",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-slide",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "substitute",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "reversal",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "protect",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "endure",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "swagger",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "steel-wing",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "attract",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "return",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "frustration",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "metal-claw",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "hidden-power",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "rain-dance",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sunny-day",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-smash",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "facade",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "helping-hand",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "feather-dance",
           "gen": "scarlet-violet"
         },
         {
@@ -454,7 +310,15 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "rock-tomb",
+          "name": "assurance",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "attract",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "body-slam",
           "gen": "scarlet-violet"
         },
         {
@@ -462,51 +326,7 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "pluck",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "u-turn",
-          "gen": "scarlet-violet"
-        },
-        {
           "name": "close-combat",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "assurance",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "giga-impact",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "shadow-claw",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "iron-head",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "round",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "acrobatics",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "retaliate",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "work-up",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "hurricane",
           "gen": "scarlet-violet"
         },
         {
@@ -514,8 +334,188 @@
           "gen": "ultra-sun-ultra-moon"
         },
         {
+          "name": "cut",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "double-edge",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "double-team",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "dual-wingbeat",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "endure",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "facade",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "feather-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "fly",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "frustration",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "giga-impact",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "heat-wave",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "helping-hand",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "hidden-power",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "hurricane",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "hyper-beam",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "iron-head",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "laser-focus",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "metal-claw",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "pluck",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "protect",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rain-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rest",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "retaliate",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "return",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "reversal",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rock-slide",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rock-smash",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "rock-tomb",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "roost",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "shadow-claw",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "steel-wing",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "strength",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "substitute",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "swagger",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "swift",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "take-down",
+          "gen": "scarlet-violet"
+        },
+        {
           "name": "tera-blast",
           "gen": "scarlet-violet"
+        },
+        {
+          "name": "toxic",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "u-turn",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "work-up",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "zen-headbutt",
+          "gen": "ultra-sun-ultra-moon"
         }
       ]
     },
@@ -544,16 +544,25 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
       "uuid": "Compendium.ptr2e.core-species.Item.pyZamrkL16BWbkgG",
-      "methods": []
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "_migration": {
       "version": null,
       "previous": null
-    }
+    },
+    "genderRatio": -1
   },
   "_id": "YToJ8K4rws0x7cNa",
   "effects": []

--- a/packs/core-species/corvisquire.json
+++ b/packs/core-species/corvisquire.json
@@ -17,72 +17,64 @@
     "moves": {
       "levelUp": [
         {
+          "name": "hone-claws",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
           "name": "leer",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "peck",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "hone-claws",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "power-trip",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "fury-attack",
-          "level": 12,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 12
         },
         {
           "name": "pluck",
-          "level": 16,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 16
         },
         {
           "name": "taunt",
-          "level": 22,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 22
         },
         {
           "name": "scary-face",
-          "level": 28,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 28
         },
         {
           "name": "drill-peck",
-          "level": 34,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 34
         },
         {
           "name": "swagger",
-          "level": 40,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 40
         },
         {
           "name": "brave-bird",
-          "level": 46,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 46
         }
       ],
       "tutor": [
         {
-          "name": "dual-wingbeat",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "fly",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "take-down",
+          "name": "aerial-ace",
           "gen": "scarlet-violet"
         },
         {
@@ -90,55 +82,27 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "focus-energy",
+          "name": "air-cutter",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "air-slash",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "assurance",
           "gen": "sword-shield"
-        },
-        {
-          "name": "swift",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rest",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "substitute",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "thief",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "snore",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "reversal",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "spite",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "protect",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "endure",
-          "gen": "scarlet-violet"
         },
         {
           "name": "attract",
           "gen": "sword-shield"
         },
         {
-          "name": "sleep-talk",
-          "gen": "scarlet-violet"
+          "name": "dual-wingbeat",
+          "gen": "sword-shield"
         },
         {
-          "name": "sunny-day",
+          "name": "endure",
           "gen": "scarlet-violet"
         },
         {
@@ -146,55 +110,15 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "revenge",
-          "gen": "sword-shield"
-        },
-        {
           "name": "fake-tears",
           "gen": "scarlet-violet"
         },
         {
-          "name": "air-cutter",
+          "name": "fly",
           "gen": "scarlet-violet"
         },
         {
-          "name": "aerial-ace",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "tailwind",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "u-turn",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "payback",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "assurance",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "air-slash",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "nasty-plot",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "round",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "retaliate",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "work-up",
+          "name": "focus-energy",
           "gen": "sword-shield"
         },
         {
@@ -202,8 +126,84 @@
           "gen": "scarlet-violet"
         },
         {
+          "name": "nasty-plot",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "payback",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "protect",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rest",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "retaliate",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "revenge",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "reversal",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "snore",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "spite",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "substitute",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "swift",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "tailwind",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "take-down",
+          "gen": "scarlet-violet"
+        },
+        {
           "name": "tera-blast",
           "gen": "scarlet-violet"
+        },
+        {
+          "name": "thief",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "u-turn",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "work-up",
+          "gen": "sword-shield"
         }
       ]
     },
@@ -211,7 +211,7 @@
       "height": 0.8,
       "weight": 16,
       "category": "small",
-      "type": "height"
+      "type": "quad"
     },
     "captureRate": 120,
     "eggGroups": [
@@ -249,6 +249,10 @@
                 "item": null,
                 "level": null,
                 "knownMove": null
+              },
+              "perk": {
+                "x": 15,
+                "y": 15
               }
             }
           ],
@@ -257,16 +261,24 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.P5TjmXGB9w5dzcVb"
+      "uuid": "Compendium.ptr2e.core-species.Item.P5TjmXGB9w5dzcVb",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "number": 822,
     "traits": [
       "pokemon",
-      "winged",
-      "underdog"
+      "winged"
     ],
     "diet": [
       "omnivore"
@@ -431,9 +443,12 @@
       "badland",
       "swamp"
     ],
-    "slug": "corvisquire"
+    "slug": "corvisquire",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "sZs1m65t7GnCoYC6",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/fearow.json
+++ b/packs/core-species/fearow.json
@@ -6,7 +6,7 @@
     "number": 22,
     "size": {
       "category": "small",
-      "type": "height",
+      "type": "quad",
       "height": 1.2,
       "weight": 38
     },
@@ -30,7 +30,6 @@
     "traits": [
       "pokemon",
       "winged",
-      "underdog",
       "pack-mon",
       "fully-evolved"
     ],
@@ -191,6 +190,10 @@
         {
           "name": "bide",
           "gen": "yellow"
+        },
+        {
+          "name": "brave-bird",
+          "gen": "dev"
         },
         {
           "name": "captivate",
@@ -383,10 +386,6 @@
         {
           "name": "work-up",
           "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "brave-bird",
-          "gen": "dev"
         }
       ],
       "levelUp": [
@@ -507,16 +506,28 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
       "uuid": "Compendium.ptr2e.core-species.Item.jI9m0C2OUiBGLkX6",
-      "methods": []
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "badland"
     ],
-    "slug": "fearow"
+    "slug": "fearow",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Gq5LQT8lWAWHhjqZ",
   "effects": []

--- a/packs/core-species/mandibuzz.json
+++ b/packs/core-species/mandibuzz.json
@@ -6,7 +6,7 @@
     "number": 630,
     "size": {
       "category": "tiny",
-      "type": "height",
+      "type": "quad",
       "height": 1.2,
       "weight": 39.5
     },
@@ -204,297 +204,125 @@
       "spe": 80
     },
     "types": [
-      "dark",
-      "flying"
+      "flying",
+      "dark"
     ],
     "moves": {
       "levelUp": [
         {
-          "name": "gust",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "leer",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "toxic",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sky-attack",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "name": "bone-rush",
+          "gen": "scarlet-violet",
+          "level": 0
         },
         {
           "name": "flatter",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "gust",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "leer",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "pluck",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "sky-attack",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "toxic",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "fury-attack",
-          "level": 5,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 5
         },
         {
           "name": "tailwind",
-          "level": 18,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 18
         },
         {
           "name": "feint-attack",
-          "level": 23,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 23
         },
         {
           "name": "knock-off",
-          "level": 24,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 24
         },
         {
           "name": "punishment",
-          "level": 28,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 28
         },
         {
           "name": "iron-defense",
-          "level": 30,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 30
         },
         {
           "name": "whirlwind",
-          "level": 36,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 36
         },
         {
           "name": "air-slash",
-          "level": 42,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 42
         },
         {
           "name": "dark-pulse",
-          "level": 48,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "nasty-plot",
-          "level": 57,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "defog",
-          "level": 64,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "mirror-move",
-          "level": 70,
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "bone-rush",
-          "level": 0,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 48
         },
         {
           "name": "embargo",
-          "level": 50,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 50
+        },
+        {
+          "name": "nasty-plot",
+          "gen": "scarlet-violet",
+          "level": 57
+        },
+        {
+          "name": "defog",
+          "gen": "scarlet-violet",
+          "level": 64
+        },
+        {
+          "name": "mirror-move",
+          "gen": "ultra-sun-ultra-moon",
+          "level": 70
         },
         {
           "name": "attract",
-          "level": 72,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 72
         },
         {
           "name": "brave-bird",
-          "level": 80,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 80
         }
       ],
       "tutor": [
         {
-          "name": "mean-look",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "roost",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "snore",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "heat-wave",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "snatch",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "block",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "foul-play",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "lash-out",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "dual-wingbeat",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "cut",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "fly",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "take-down",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "double-edge",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "hyper-beam",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "double-team",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "swift",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rest",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "substitute",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "thief",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "spite",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "protect",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "scary-face",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sandstorm",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "endure",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "swagger",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "steel-wing",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "return",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "frustration",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "hidden-power",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "rain-dance",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sunny-day",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "psych-up",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "shadow-ball",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-smash",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "uproar",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "torment",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "facade",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "taunt",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "feather-dance",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "fake-tears",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "air-cutter",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-tomb",
+          "name": "acrobatics",
           "gen": "scarlet-violet"
         },
         {
@@ -502,7 +330,95 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "u-turn",
+          "name": "air-cutter",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "assurance",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "block",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "confide",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "cut",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "double-edge",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "double-team",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "dual-wingbeat",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "endure",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "facade",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "fake-tears",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "feather-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "fly",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "foul-play",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "frustration",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "giga-impact",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "heat-wave",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "hidden-power",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "hurricane",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "hyper-beam",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "incinerate",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "lash-out",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "mean-look",
           "gen": "scarlet-violet"
         },
         {
@@ -510,23 +426,19 @@
           "gen": "sword-shield"
         },
         {
-          "name": "assurance",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "giga-impact",
+          "name": "protect",
           "gen": "scarlet-violet"
         },
         {
-          "name": "round",
-          "gen": "sword-shield"
+          "name": "psych-up",
+          "gen": "scarlet-violet"
         },
         {
-          "name": "incinerate",
-          "gen": "omega-ruby-alpha-sapphire"
+          "name": "rain-dance",
+          "gen": "scarlet-violet"
         },
         {
-          "name": "acrobatics",
+          "name": "rest",
           "gen": "scarlet-violet"
         },
         {
@@ -534,23 +446,111 @@
           "gen": "sword-shield"
         },
         {
-          "name": "hurricane",
+          "name": "return",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "rock-smash",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "rock-tomb",
           "gen": "scarlet-violet"
+        },
+        {
+          "name": "roost",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "sandstorm",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "scary-face",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "shadow-ball",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
         },
         {
           "name": "snarl",
           "gen": "scarlet-violet"
         },
         {
-          "name": "confide",
+          "name": "snatch",
           "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "spite",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "steel-wing",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "substitute",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "swagger",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "swift",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "take-down",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "taunt",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "tera-blast",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "thief",
+          "gen": "scarlet-violet"
         },
         {
           "name": "throat-chop",
           "gen": "scarlet-violet"
         },
         {
-          "name": "tera-blast",
+          "name": "torment",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "u-turn",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "uproar",
           "gen": "scarlet-violet"
         }
       ]
@@ -584,13 +584,25 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.nblqEGUBR9j0toUz"
+      "uuid": "Compendium.ptr2e.core-species.Item.nblqEGUBR9j0toUz",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "26EjJQF3dPu7oRmS",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/rufflet.json
+++ b/packs/core-species/rufflet.json
@@ -6,7 +6,7 @@
     "number": 627,
     "size": {
       "category": "tiny",
-      "type": "height",
+      "type": "quad",
       "height": 0.5,
       "weight": 10.5
     },
@@ -30,7 +30,6 @@
     "traits": [
       "pokemon",
       "winged",
-      "underdog",
       "guster",
       "pack-mon"
     ],
@@ -288,139 +287,11 @@
       ],
       "tutor": [
         {
-          "name": "rock-smash",
+          "name": "acrobatics",
           "gen": "scarlet-violet"
-        },
-        {
-          "name": "roost",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "snore",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "heat-wave",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "superpower",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "dual-wingbeat",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "cut",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "fly",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "body-slam",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "take-down",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "double-edge",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "strength",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "toxic",
-          "gen": "ultra-sun-ultra-moon"
         },
         {
           "name": "agility",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "double-team",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "swift",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rest",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-slide",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "substitute",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "protect",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "endure",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "swagger",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "steel-wing",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "attract",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "return",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "frustration",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "hidden-power",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "rain-dance",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sunny-day",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "facade",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "helping-hand",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "feather-dance",
           "gen": "scarlet-violet"
         },
         {
@@ -428,7 +299,15 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "rock-tomb",
+          "name": "assurance",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "attract",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "body-slam",
           "gen": "scarlet-violet"
         },
         {
@@ -436,47 +315,7 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "pluck",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "u-turn",
-          "gen": "scarlet-violet"
-        },
-        {
           "name": "close-combat",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "assurance",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "shadow-claw",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "zen-headbutt",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "round",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "acrobatics",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "retaliate",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "work-up",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "hurricane",
           "gen": "scarlet-violet"
         },
         {
@@ -484,7 +323,167 @@
           "gen": "ultra-sun-ultra-moon"
         },
         {
+          "name": "cut",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "double-edge",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "double-team",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "dual-wingbeat",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "endure",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "facade",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "feather-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "fly",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "frustration",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "heat-wave",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "helping-hand",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "hidden-power",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "hurricane",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "pluck",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "protect",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rain-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rest",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "retaliate",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "return",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "rock-slide",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rock-smash",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rock-tomb",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "roost",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "shadow-claw",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "steel-wing",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "strength",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "substitute",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "superpower",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "swagger",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "swift",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "take-down",
+          "gen": "scarlet-violet"
+        },
+        {
           "name": "tera-blast",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "toxic",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "u-turn",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "work-up",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "zen-headbutt",
           "gen": "scarlet-violet"
         }
       ]
@@ -493,7 +492,6 @@
     "eggGroups": [
       "flying"
     ],
-    "genderRatio": 0,
     "habitats": [
       "badland",
       "swamp",
@@ -519,7 +517,11 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         },
         {
           "name": "hisuian-braviary",
@@ -543,13 +545,25 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.pyZamrkL16BWbkgG"
+      "uuid": "Compendium.ptr2e.core-species.Item.pyZamrkL16BWbkgG",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "pyZamrkL16BWbkgG",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/spearow.json
+++ b/packs/core-species/spearow.json
@@ -6,7 +6,7 @@
     "number": 21,
     "size": {
       "category": "tiny",
-      "type": "height",
+      "type": "quad",
       "height": 0.3,
       "weight": 2
     },
@@ -30,7 +30,6 @@
     "traits": [
       "pokemon",
       "winged",
-      "underdog",
       "pack-mon"
     ],
     "abilities": {
@@ -194,6 +193,10 @@
         {
           "name": "bide",
           "gen": "yellow"
+        },
+        {
+          "name": "brave-bird",
+          "gen": "dev"
         },
         {
           "name": "captivate",
@@ -398,10 +401,6 @@
         {
           "name": "work-up",
           "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "brave-bird",
-          "gen": "dev"
         }
       ],
       "levelUp": [
@@ -502,16 +501,28 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
       "uuid": "Compendium.ptr2e.core-species.Item.jI9m0C2OUiBGLkX6",
-      "methods": []
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "badland"
     ],
-    "slug": "spearow"
+    "slug": "spearow",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "jI9m0C2OUiBGLkX6",
   "effects": []

--- a/packs/core-species/vullaby.json
+++ b/packs/core-species/vullaby.json
@@ -6,7 +6,7 @@
     "number": 629,
     "size": {
       "category": "tiny",
-      "type": "height",
+      "type": "quad",
       "height": 0.5,
       "weight": 9
     },
@@ -30,7 +30,6 @@
     "traits": [
       "pokemon",
       "winged",
-      "underdog",
       "guster",
       "pack-mon"
     ],
@@ -200,8 +199,8 @@
       "spe": 60
     },
     "types": [
-      "dark",
-      "flying"
+      "flying",
+      "dark"
     ],
     "moves": {
       "levelUp": [
@@ -303,72 +302,28 @@
       ],
       "tutor": [
         {
-          "name": "toxic",
+          "name": "aerial-ace",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "air-cutter",
           "gen": "scarlet-violet"
         },
         {
-          "name": "scary-face",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "steel-wing",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "mean-look",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "fake-tears",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "roost",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "foul-play",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "snore",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "heat-wave",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "snatch",
-          "gen": "ultra-sun-ultra-moon"
+          "name": "assurance",
+          "gen": "sword-shield"
         },
         {
           "name": "block",
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "lash-out",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "dual-wingbeat",
-          "gen": "sword-shield"
+          "name": "confide",
+          "gen": "ultra-sun-ultra-moon"
         },
         {
           "name": "cut",
           "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "fly",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "take-down",
-          "gen": "scarlet-violet"
         },
         {
           "name": "double-edge",
@@ -379,39 +334,31 @@
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "swift",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rest",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "substitute",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "thief",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "spite",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "protect",
-          "gen": "scarlet-violet"
+          "name": "dual-wingbeat",
+          "gen": "sword-shield"
         },
         {
           "name": "endure",
           "gen": "scarlet-violet"
         },
         {
-          "name": "swagger",
+          "name": "facade",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "fake-tears",
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "return",
+          "name": "feather-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "fly",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "foul-play",
           "gen": "ultra-sun-ultra-moon"
         },
         {
@@ -419,67 +366,23 @@
           "gen": "ultra-sun-ultra-moon"
         },
         {
+          "name": "heat-wave",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
           "name": "hidden-power",
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "rain-dance",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sunny-day",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "psych-up",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "shadow-ball",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-smash",
+          "name": "incinerate",
           "gen": "omega-ruby-alpha-sapphire"
         },
         {
-          "name": "uproar",
-          "gen": "scarlet-violet"
+          "name": "lash-out",
+          "gen": "sword-shield"
         },
         {
-          "name": "torment",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "facade",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "taunt",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "feather-dance",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "air-cutter",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-tomb",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "aerial-ace",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "u-turn",
+          "name": "mean-look",
           "gen": "scarlet-violet"
         },
         {
@@ -487,35 +390,131 @@
           "gen": "sword-shield"
         },
         {
-          "name": "assurance",
-          "gen": "sword-shield"
+          "name": "protect",
+          "gen": "scarlet-violet"
         },
         {
-          "name": "round",
-          "gen": "sword-shield"
+          "name": "psych-up",
+          "gen": "scarlet-violet"
         },
         {
-          "name": "incinerate",
-          "gen": "omega-ruby-alpha-sapphire"
+          "name": "rain-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rest",
+          "gen": "scarlet-violet"
         },
         {
           "name": "retaliate",
           "gen": "sword-shield"
         },
         {
+          "name": "return",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "rock-smash",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "rock-tomb",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "roost",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "scary-face",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "shadow-ball",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
+        },
+        {
           "name": "snarl",
           "gen": "scarlet-violet"
         },
         {
-          "name": "confide",
+          "name": "snatch",
           "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "spite",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "steel-wing",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "substitute",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "swagger",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "swift",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "take-down",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "taunt",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "tera-blast",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "thief",
+          "gen": "scarlet-violet"
         },
         {
           "name": "throat-chop",
           "gen": "scarlet-violet"
         },
         {
-          "name": "tera-blast",
+          "name": "torment",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "toxic",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "u-turn",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "uproar",
           "gen": "scarlet-violet"
         }
       ]
@@ -549,13 +548,25 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.nblqEGUBR9j0toUz"
+      "uuid": "Compendium.ptr2e.core-species.Item.nblqEGUBR9j0toUz",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "nblqEGUBR9j0toUz",
-  "effects": [],
-  "folder": null
+  "effects": []
 }


### PR DESCRIPTION
Automation had been done incorrectly on Rage and Leer.
- Update Species: fearow
- Update Species: spearow
- Update Species: braviary
- Update Species: mandibuzz
- Update Species: vullaby
- Update Species: rufflet
- Update Species: corvisquire
- Update Move: Rage
- Update Move: Leer