### PR TITLE
Foundry Data Sync - Fox Fixes 19/01/25

### DIFF
--- a/packs/core-abilities/holiday-cheer.json
+++ b/packs/core-abilities/holiday-cheer.json
@@ -18,11 +18,11 @@
           "target": "self",
           "unit": "m"
         },
-        "description": "<p>Effect: The user has +1 default CRIT and EVA Stage in Snowy Weather. The user the user is treated as having the Ice Type for the effects of Snowy Weather.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user has +1 default CRIT and EVA Stage in Snowy Weather. The user is treated as having the Ice Type for the effects of Snowy Weather.</p>",
+        "img": "icons/magic/air/weather-clouds-snow.webp"
       }
     ],
-    "description": "<p>Effect: The user has +1 default CRIT and EVA Stage in Snowy Weather. The user the user is treated as having the Ice Type for the effects of Snowy Weather.</p>",
+    "description": "<p>Effect: The user has +1 default CRIT and EVA Stage in Snowy Weather. The user is treated as having the Ice Type for the effects of Snowy Weather.</p>",
     "traits": [
       "environ"
     ],

--- a/packs/core-effects/friend-guard-dr.json
+++ b/packs/core-effects/friend-guard-dr.json
@@ -1,0 +1,72 @@
+{
+  "name": "Friend Guard DR",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": {
+        "schema": 0.109,
+        "foundry": "12.331",
+        "system": "0.10.0-alpha.5.1.2"
+      }
+    },
+    "traits": []
+  },
+  "img": "icons/magic/defensive/illusion-evasion-echo-purple.webp",
+  "effects": [
+    {
+      "name": "Friend Guard DR",
+      "type": "passive",
+      "_id": "8kNkzqOu46oUQtGF",
+      "img": "icons/magic/defensive/illusion-evasion-echo-purple.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "attack-damage-percentile",
+            "value": -25,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.4",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "AUlSkFUziUM3nxww"
+}

--- a/packs/core-moves/high-jump-kick.json
+++ b/packs/core-moves/high-jump-kick.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
     "slug": "high-jump-kick",
-    "description": "",
-    "traits": [
-      "crash-1-2",
-      "dash",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "high-jump-kick",
@@ -19,7 +13,8 @@
           "crash-1-2",
           "dash",
           "contact",
-          "pp-updated"
+          "pp-updated",
+          "kick"
         ],
         "range": {
           "target": "creature",
@@ -28,10 +23,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "physical",
         "power": 130,
@@ -39,15 +31,16 @@
         "types": [
           "fighting"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "VgDCfzEkW4Gt6vA5",
   "effects": []

--- a/packs/core-moves/leer.json
+++ b/packs/core-moves/leer.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "leer",
-    "description": "<p>Effect: All valid targets lose -1 DEF Stages for 5 Activations and gain @Affliction[fear] 2.</p>",
-    "traits": [
-      "social",
-      "friendly",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "leer",
@@ -27,26 +21,25 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "status",
-        "power": null,
         "accuracy": 100,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: All valid targets lose -1 DEF Stages for 5 Activations and gain @Affliction[fear] 2.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "slot": 1,
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "6xLPJIk5QClQKiGv",
   "effects": []

--- a/packs/core-moves/neurotoxin.json
+++ b/packs/core-moves/neurotoxin.json
@@ -4,13 +4,7 @@
   "_id": "73h0Lk9HvCvqwwbc",
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "contact",
-      "grapple",
-      "jaw",
-      "horn"
-    ],
+    "slug": "neurotoxin",
     "actions": [
       {
         "name": "Neurotoxin",
@@ -30,43 +24,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "poison"
         ],
         "category": "physical",
         "power": 55,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[paralysis] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[paralysis] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721256964354,
-    "modifiedTime": 1721257134890,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Neurotoxin",
+      "type": "passive",
+      "_id": "YdCr7y1lAFtRvSff",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "neurotoxin-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.4",
+        "createdTime": 1737308487802,
+        "modifiedTime": 1737308512977,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/night-storm.json
+++ b/packs/core-moves/night-storm.json
@@ -4,11 +4,7 @@
   "_id": "jcfvalGWvnCcEhgj",
   "img": "systems/ptr2e/img/svg/dark_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "wind",
-      "blast-3"
-    ],
+    "slug": "night-storm",
     "actions": [
       {
         "name": "Night Storm",
@@ -26,43 +22,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null
+          "powerPoints": 7
         },
-        "variant": null,
         "types": [
           "dark"
         ],
         "category": "special",
         "power": 110,
         "accuracy": 70,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 10% chance of gaining @Affliction[blinded] 5.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 10% chance of gaining @Affliction[blinded] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 6700000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1718737581155,
-    "modifiedTime": 1719974607390,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Night Storm",
+      "type": "passive",
+      "_id": "jCI0fTLA6aKpvmkZ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "night-storm-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.blindedcondiitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.4",
+        "createdTime": 1737308576170,
+        "modifiedTime": 1737308598019,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/no-retreat.json
+++ b/packs/core-moves/no-retreat.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
     "slug": "no-retreat",
-    "description": "<p>Effect: The user gains @Affliction[stuck] 5 and @Affliction[boosted] 5.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "no-retreat",
@@ -17,32 +13,28 @@
           "pp-updated"
         ],
         "range": {
-          "target": "field",
-          "distance": 0,
+          "target": "self",
           "unit": "m"
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 2
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "fighting"
         ],
         "description": "<p>Effect: The user gains @Affliction[stuck] 5, @Affliction[boosted] 5, and @Affliction[resolved] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/fighting_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Yl9mMjXxnNloKmMS",
   "effects": []

--- a/packs/core-moves/noble-roar.json
+++ b/packs/core-moves/noble-roar.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "noble-roar",
-    "description": "<p>Effect: All valid targets lose -1 ATK and SPATK Stages for 5 Activations.</p>",
-    "traits": [
-      "sonic",
-      "friendly",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "noble-roar",
@@ -27,27 +21,90 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "status",
-        "power": null,
         "accuracy": 100,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: All valid targets lose -1 ATK and SPATK Stages for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "IphPhLWHEidcmFQX",
-  "effects": []
+  "effects": [
+    {
+      "name": "Noble Roar",
+      "type": "passive",
+      "_id": "cRGPa2FCiJY4Zp2Z",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "noble-roar-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.ikCAv5w4iNfHHqaE",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "noble-roar-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1JXumQz0QqthT9Iv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.4",
+        "createdTime": 1737308743384,
+        "modifiedTime": 1737308800689,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/noxious-acid.json
+++ b/packs/core-moves/noxious-acid.json
@@ -4,10 +4,7 @@
   "_id": "K68tBqtac9J769mO",
   "img": "systems/ptr2e/img/svg/bug_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "blast-2"
-    ],
+    "slug": "noxious-acid",
     "actions": [
       {
         "name": "Noxious Acid",
@@ -24,11 +21,8 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null
+          "powerPoints": 4
         },
-        "variant": null,
         "types": [
           "poison",
           "bug"
@@ -36,32 +30,70 @@
         "category": "special",
         "power": 65,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 30% chance of losing -1 ACC Stage for 5 Activations. This attack is considered to be both Bug and Poison Type.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 30% chance of losing -1 ACC Stage for 5 Activations. This attack is considered to be both Bug and Poison Type.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 12100000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1718729744618,
-    "modifiedTime": 1719974737668,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Noxious Acid",
+      "type": "passive",
+      "_id": "31inaYT1AXvHsT8M",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "noxious-acid-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.wA5oCsgHmZLcHHSn",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.4",
+        "createdTime": 1737308825429,
+        "modifiedTime": 1737308853280,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/noxious-torque.json
+++ b/packs/core-moves/noxious-torque.json
@@ -4,14 +4,6 @@
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
     "slug": "noxious-torque",
-    "description": "",
-    "traits": [
-      "dash",
-      "pass-4",
-      "crash-1-2",
-      "contact",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "noxious-torque",
@@ -31,10 +23,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "physical",
         "power": 100,
@@ -43,15 +32,71 @@
           "poison"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[poison] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "JUHacX6HRSzHQWRH",
-  "effects": []
+  "effects": [
+    {
+      "name": "Noxious Torque",
+      "type": "passive",
+      "_id": "m13Ry2QJmMKj65Z2",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "noxious-torque-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.4",
+        "createdTime": 1737308879892,
+        "modifiedTime": 1737308904124,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/oblivion-wing.json
+++ b/packs/core-moves/oblivion-wing.json
@@ -4,13 +4,6 @@
   "img": "systems/ptr2e/img/svg/flying_icon.svg",
   "system": {
     "slug": "oblivion-wing",
-    "description": "",
-    "traits": [
-      "legendary",
-      "drain-3-4",
-      "ray",
-      "aura"
-    ],
     "actions": [
       {
         "slug": "oblivion-wing",
@@ -30,26 +23,26 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "special",
         "power": 80,
         "accuracy": 100,
         "types": [
-          "flying"
+          "flying",
+          "dark"
         ],
         "description": "<p>Effect: This attack is considered both Flying and Dark Type.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/flying_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "dByLKnrdqTOoQg2O",
   "effects": []

--- a/packs/core-moves/oceanic-operetta.json
+++ b/packs/core-moves/oceanic-operetta.json
@@ -4,13 +4,6 @@
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
     "slug": "oceanic-operetta",
-    "description": "<p>Trigger: User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p><p>Effect: After resolving this attack, the user increases its default SPATK and SPDEF by +1.</p><p>Requirement: [Primarina] Z-Power-Crystal as an Accessory Item and Sparkling Aria on the user's Active List.</p>",
-    "traits": [
-      "zenith",
-      "move-locked",
-      "sonic",
-      "blast-4"
-    ],
     "actions": [
       {
         "slug": "oceanic-operetta",
@@ -29,9 +22,6 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null,
           "trigger": "<p>User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p>"
         },
         "category": "special",
@@ -41,15 +31,83 @@
           "water"
         ],
         "description": "<p>Trigger: User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p><p>Effect: After resolving this attack, the user increases its default SPATK and SPDEF by +1.</p><p>Requirement: [Primarina] Z-Power-Crystal as an Accessory Item and Sparkling Aria on the user's Active List.</p>",
-        "contestType": "",
-        "contestEffect": "",
         "free": true,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "QlvmbOkzMwys6B7v",
-  "effects": []
+  "effects": [
+    {
+      "name": "Oceanic Operetta",
+      "type": "passive",
+      "_id": "yP418r9jPXps8jrc",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "oceanic-operetta-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAa",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "oceanic-operetta-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.jEX7s3GbbAtzgyS3",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.4",
+        "createdTime": 1737312882393,
+        "modifiedTime": 1737312942508,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/octazooka.json
+++ b/packs/core-moves/octazooka.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
     "slug": "octazooka",
-    "description": "",
-    "traits": [
-      "missile"
-    ],
     "actions": [
       {
         "slug": "octazooka",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "special",
         "power": 95,
@@ -36,15 +29,71 @@
           "water"
         ],
         "description": "<p>Effect: On hit, the target has a 50% chance of losing -1 ACC Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "v0LgBc8UCwP24yfX",
-  "effects": []
+  "effects": [
+    {
+      "name": "Octazooka",
+      "type": "passive",
+      "_id": "vaNNWF11FZMgNFmc",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "octazooka-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.wA5oCsgHmZLcHHSn",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.4",
+        "createdTime": 1737312982917,
+        "modifiedTime": 1737313010434,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/overheat.json
+++ b/packs/core-moves/overheat.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/fire_icon.svg",
   "system": {
     "slug": "overheat",
-    "description": "",
-    "traits": [
-      "defrost"
-    ],
     "actions": [
       {
         "slug": "overheat",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "special",
         "power": 130,
@@ -36,15 +29,71 @@
           "fire"
         ],
         "description": "<p>Effect: On hit, the user loses -2 SPATK Stages for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "1YuSHdlx3r8g5RJ3",
-  "effects": []
+  "effects": [
+    {
+      "name": "Overheat",
+      "type": "passive",
+      "_id": "stTbXR9vGl3X2Vl7",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "overheat-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.EYmp1DeE1Lwzi0D1",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.4",
+        "createdTime": 1737313307256,
+        "modifiedTime": 1737313364179,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/pacify.json
+++ b/packs/core-moves/pacify.json
@@ -4,12 +4,7 @@
   "_id": "tBtVuXzzJMlfmA7n",
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "social",
-      "exhaust",
-      "pp-updated"
-    ],
+    "slug": "pacify",
     "actions": [
       {
         "name": "Pacify",
@@ -27,43 +22,77 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null
+          "powerPoints": 4
         },
-        "variant": null,
         "types": [
           "fairy"
         ],
         "category": "status",
-        "power": null,
         "accuracy": 80,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target loses -3 ATK Stages for 5 Activations.</p>"
+        "description": "<p>Effect: On hit, the target loses -3 ATK Stages for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 6900000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1719585883093,
-    "modifiedTime": 1719971994938,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Pacify",
+      "type": "passive",
+      "_id": "pqt4vVuK9QIsXc0r",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "pacify-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.uMWvv5ozhm5NRnjc",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.4",
+        "createdTime": 1737313437210,
+        "modifiedTime": 1737313456262,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/parasite-swarm.json
+++ b/packs/core-moves/parasite-swarm.json
@@ -4,17 +4,11 @@
   "_id": "N2yNROP0PHQ4Nstj",
   "img": "systems/ptr2e/img/svg/bug_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "5-strike",
-      "jaw",
-      "horn",
-      "pp-updated"
-    ],
+    "slug": "parasite-swarm",
     "actions": [
       {
         "name": "Parasite Swarm",
-        "slug": "parasite-Swarm",
+        "slug": "parasite-swarm",
         "type": "attack",
         "img": "icons/svg/explosion.svg",
         "traits": [
@@ -30,43 +24,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "bug"
         ],
         "category": "physical",
         "power": 20,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[leech] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[leech] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 12200000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1718729938664,
-    "modifiedTime": 1719974846401,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Parasite Swarm",
+      "type": "passive",
+      "_id": "M1VmZrFU401KnXG1",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "parasite-swarm-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.leechconditiitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737313667254,
+        "modifiedTime": 1737313703911,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/parting-shot.json
+++ b/packs/core-moves/parting-shot.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/dark_icon.svg",
   "system": {
     "slug": "parting-shot",
-    "description": "<p>Effect: On hit, the target's ATK and SPATK Stages are reduced by -1 for 5 Activations. The user may then freely move themselves up to half of the Movement Score of their choice away from the target. If the user is an owned Pokémon, they may then immediately be returned their Poké Ball and another Pokémon may immediately be sent out in their place.</p>",
-    "traits": [
-      "dash",
-      "sonic",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "parting-shot",
@@ -27,27 +21,90 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "status",
-        "power": null,
         "accuracy": 100,
         "types": [
           "dark"
         ],
         "description": "<p>Effect: On hit, the target's ATK and SPATK Stages are reduced by -1 for 5 Activations. The user may then freely move themselves up to half of the Movement Score of their choice away from the target. If the user is an owned Pokémon, they may then immediately be returned their Poké Ball and another Pokémon may immediately be sent out in their place.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "menGVw2OO4CdcTe2",
-  "effects": []
+  "effects": [
+    {
+      "name": "Parting Shot",
+      "type": "passive",
+      "_id": "flKaFsbf3ldTpvY2",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "parting-shot-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.ikCAv5w4iNfHHqaE",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "parting-shot-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1JXumQz0QqthT9Iv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737313890684,
+        "modifiedTime": 1737313946672,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/pastel-punch.json
+++ b/packs/core-moves/pastel-punch.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
   "system": {
     "slug": "pastel-punch",
-    "description": "",
-    "traits": [
-      "punch",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "pastel-punch",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 2
         },
         "category": "physical",
         "power": 70,
@@ -38,15 +30,71 @@
           "fairy"
         ],
         "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[drowsy] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "sexjuc9Ibj8AjAFw",
-  "effects": []
+  "effects": [
+    {
+      "name": "Pastel Punch",
+      "type": "passive",
+      "_id": "KEiMGHlxBQzrIQqS",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "pastel-punch-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.drowsycondititem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737314014934,
+        "modifiedTime": 1737314034496,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/pepper-powder.json
+++ b/packs/core-moves/pepper-powder.json
@@ -4,11 +4,7 @@
   "_id": "6iVjrQAsXZID7s9K",
   "img": "systems/ptr2e/img/svg/grass_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "powder",
-      "pp-updated"
-    ],
+    "slug": "pepper-powder",
     "actions": [
       {
         "name": "Pepper Powder",
@@ -26,43 +22,88 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null
+          "powerPoints": 4
         },
-        "variant": null,
         "types": [
           "grass"
         ],
         "category": "status",
-        "power": null,
         "accuracy": 70,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets lose -2 ATK and ACC Stages for 5 Activations.</p>"
+        "description": "<p>Effect: On hit, all valid targets lose -2 ATK and ACC Stages for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720809626173,
-    "modifiedTime": 1720810528494,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Pepper Powder",
+      "type": "passive",
+      "_id": "oXj9QUlgNR8kg2Cx",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "pepper-powder-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.Sp0TScnwSTu8Gusr",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "pepper-powder-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.RVIdzfbF4xwy2qLq",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737314100172,
+        "modifiedTime": 1737314218094,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/perish-song.json
+++ b/packs/core-moves/perish-song.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "perish-song",
-    "description": "<p>Effect: All valid targets gain @Affliction[perish] 5.</p>",
-    "traits": [
-      "sonic",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "perish-song",
@@ -25,27 +20,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 10,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 10
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: All valid targets gain @Affliction[perish] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "im3tx4lD8l78ruz4",
-  "effects": []
+  "effects": [
+    {
+      "name": "Perish Song",
+      "type": "passive",
+      "_id": "YUFZtysG2WwReJgr",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "perish-song-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.perishcondititem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737314286121,
+        "modifiedTime": 1737314318809,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/phantom-pain.json
+++ b/packs/core-moves/phantom-pain.json
@@ -4,8 +4,7 @@
   "_id": "qziSLv5nzIEo0OwN",
   "img": "systems/ptr2e/img/svg/ghost_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [],
+    "slug": "phantom-pain",
     "actions": [
       {
         "name": "Phantom Pain",
@@ -20,43 +19,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "ghost"
         ],
         "category": "special",
         "power": 50,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[splinter] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[splinter] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720462084617,
-    "modifiedTime": 1720462188482,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Phantom Pain",
+      "type": "passive",
+      "_id": "fTaY7oGnGifd0cKC",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "phantom-pain-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.splinterconditem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737314384831,
+        "modifiedTime": 1737314409023,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/piercing-drone.json
+++ b/packs/core-moves/piercing-drone.json
@@ -4,10 +4,7 @@
   "_id": "YZ1xJ13a5aYqvill",
   "img": "systems/ptr2e/img/svg/bug_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "sonic"
-    ],
+    "slug": "piercing-drone",
     "actions": [
       {
         "name": "Piercing Drone",
@@ -25,43 +22,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "bug"
         ],
         "category": "special",
         "power": 100,
         "accuracy": 85,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 10% chance of losing -1 SPATK Stage for 5 Activations.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 10% chance of losing -1 SPATK Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 12400000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1718728842633,
-    "modifiedTime": 1720456269697,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Piercing Drone",
+      "type": "passive",
+      "_id": "LWstcI2NkuCpIrYM",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "piercing-drone-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1JXumQz0QqthT9Iv",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737314535873,
+        "modifiedTime": 1737314558748,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/pixie-pummel.json
+++ b/packs/core-moves/pixie-pummel.json
@@ -5,13 +5,6 @@
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
   "system": {
     "slug": "pixie-pummel",
-    "traits": [
-      "contact",
-      "6-strike",
-      "dash",
-      "priority-1",
-      "pp-updated"
-    ],
     "actions": [
       {
         "name": "Pizxie Pummel",
@@ -33,42 +26,89 @@
         "cost": {
           "activation": "complex",
           "powerPoints": 4,
-          "delay": null,
           "priority": 2
         },
-        "variant": null,
         "types": [
           "fairy"
         ],
         "category": "physical",
         "power": 30,
         "accuracy": 85,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the user loses -1 DEF and SPDEF Stage for 5 Activations.</p>"
+        "description": "<p>Effect: On hit, the user loses -1 DEF and SPDEF Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 7300000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1719585983867,
-    "modifiedTime": 1719975227127,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Pixie Pummel",
+      "type": "passive",
+      "_id": "IeRlvUwcRRctDSxK",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "pixie-pummel-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "pixie-pummel-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737314881585,
+        "modifiedTime": 1737314931899,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/pixie-tail.json
+++ b/packs/core-moves/pixie-tail.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
   "system": {
     "slug": "pixie-tail",
-    "description": "",
-    "traits": [
-      "tail",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "pixie-tail",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "physical",
         "power": 100,
@@ -38,15 +30,71 @@
           "fairy"
         ],
         "description": "<p>Effect: On hit, the target has a 30% chance of losing -1 SPDEF Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Ychp463vORkNlFgs",
-  "effects": []
+  "effects": [
+    {
+      "name": "Pixie Tail",
+      "type": "passive",
+      "_id": "v9STYORrzyqSYKDG",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "pixie-tail-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737314728599,
+        "modifiedTime": 1737314825767,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/plasma-blaster.json
+++ b/packs/core-moves/plasma-blaster.json
@@ -4,13 +4,7 @@
   "_id": "snBuSorXGvmp7Dmt",
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "pulse",
-      "5-strike",
-      "ray",
-      "pp-updated"
-    ],
+    "slug": "plasma-blaster",
     "actions": [
       {
         "name": "Plasma Blaster",
@@ -30,43 +24,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "electric"
         ],
         "category": "special",
         "power": 35,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 40% chance of gaining @Affliction[burn] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 40% chance of gaining @Affliction[burn] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 7400000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1718742736048,
-    "modifiedTime": 1719975355594,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Plasma Blaster",
+      "type": "passive",
+      "_id": "MvGj00SKiYfFJoXi",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "plasma-blaster-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 40,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737314983598,
+        "modifiedTime": 1737315011360,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/plasma-pulse.json
+++ b/packs/core-moves/plasma-pulse.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "system": {
     "slug": "plasma-pulse",
-    "description": "",
-    "traits": [
-      "pulse"
-    ],
     "actions": [
       {
         "slug": "plasma-pulse",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 6
         },
         "category": "special",
         "power": 65,
@@ -36,15 +29,71 @@
           "electric"
         ],
         "description": "<p>Effect: This attack deals double damage to creatures that have @Affliction[paralysis]. On hit, all valid targets have a 10% chance to gain @Affliction[paralysis] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "mCAB8qA6BlMEPgg6",
-  "effects": []
+  "effects": [
+    {
+      "name": "Plasma Pulse",
+      "type": "passive",
+      "_id": "V0BxYNHJZyl4x1NC",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "plasma-pulse-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737315081292,
+        "modifiedTime": 1737315110108,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/power-chord.json
+++ b/packs/core-moves/power-chord.json
@@ -4,10 +4,7 @@
   "_id": "w5bSm61mqcAl7r9S",
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "sonic"
-    ],
+    "slug": "power-chord",
     "actions": [
       {
         "name": "Power Chord",
@@ -24,43 +21,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "steel"
         ],
         "category": "special",
         "power": 70,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: The user gains +1 SPATK Stage for 5 Activations.</p>"
+        "description": "<p>Effect: The user gains +1 SPATK Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721313542990,
-    "modifiedTime": 1721313629917,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Power Chord",
+      "type": "passive",
+      "_id": "rPpHsAHgHDA6mUuz",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "power-chord-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAa",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737315256060,
+        "modifiedTime": 1737315281385,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/psy-punch.json
+++ b/packs/core-moves/psy-punch.json
@@ -4,11 +4,7 @@
   "_id": "pgEIVBTL5eAx5f7G",
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "punch",
-      "contact"
-    ],
+    "slug": "psy-punch",
     "actions": [
       {
         "name": "Psy Punch",
@@ -26,43 +22,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "psychic"
         ],
         "category": "physical",
         "power": 75,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[confused] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[confused] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721263729913,
-    "modifiedTime": 1721263802226,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Psy Punch",
+      "type": "passive",
+      "_id": "hvwE3gFggO3T65PQ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "psy-punch-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737315364454,
+        "modifiedTime": 1737315381820,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/psychic-noise.json
+++ b/packs/core-moves/psychic-noise.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
   "system": {
     "slug": "psychic-noise",
-    "description": "",
-    "traits": [
-      "sonic"
-    ],
     "actions": [
       {
         "slug": "psychic-noise",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "special",
         "power": 75,
@@ -36,15 +29,71 @@
           "psychic"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 40% chance of gaining @Affliction[stunted] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "uFDEwGGaBvMpq7VY",
-  "effects": []
+  "effects": [
+    {
+      "name": "Psychic Noise",
+      "type": "passive",
+      "_id": "khxvRj8qON5tQgvO",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "psychic-noise-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.stuntedcondiitem",
+            "predicate": [],
+            "chance": 40,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737315609249,
+        "modifiedTime": 1737315636088,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/psycho-boost.json
+++ b/packs/core-moves/psycho-boost.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
   "system": {
     "slug": "psycho-boost",
-    "description": "",
-    "traits": [
-      "legendary",
-      "blast-2"
-    ],
     "actions": [
       {
         "slug": "psycho-boost",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 8,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 8
         },
         "category": "special",
         "power": 140,
@@ -38,15 +30,71 @@
           "psychic"
         ],
         "description": "<p>Effect: On hit, the user gain +2 SPATK Stages for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Ul0GKtqIw60Ksd88",
-  "effects": []
+  "effects": [
+    {
+      "name": "Psycho Boost",
+      "type": "passive",
+      "_id": "FIw1S8YiLMvaHApa",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "psycho-boost-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAZ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737315672020,
+        "modifiedTime": 1737315729972,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/psyshield-bash.json
+++ b/packs/core-moves/psyshield-bash.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
   "system": {
     "slug": "psyshield-bash",
-    "description": "",
-    "traits": [
-      "dash",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "psyshield-bash",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "physical",
         "power": 70,
@@ -38,15 +30,71 @@
           "psychic"
         ],
         "description": "<p>Effect: The user gains +1 DEF Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "4nPMp1hnGyrMyh2D",
-  "effects": []
+  "effects": [
+    {
+      "name": "Psyshield Bash",
+      "type": "passive",
+      "_id": "n4gL98EYF6BTAg34",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "psyshield-bash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.sMystTj3FBJ00AZp",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737315797219,
+        "modifiedTime": 1737315820125,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/psystrike.json
+++ b/packs/core-moves/psystrike.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
   "system": {
     "slug": "psystrike",
-    "description": "",
-    "traits": [
-      "push-6",
-      "legendary"
-    ],
     "actions": [
       {
         "slug": "psystrike",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 6
         },
         "category": "special",
         "power": 100,
@@ -38,14 +30,17 @@
           "psychic"
         ],
         "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/psychic_icon.svg",
+        "defensiveStat": "def",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Myq3zLTugQJaKrEY",
   "effects": []

--- a/packs/core-moves/puzzle-powder.json
+++ b/packs/core-moves/puzzle-powder.json
@@ -4,11 +4,7 @@
   "_id": "nq9qfIR9C4KZv0Pw",
   "img": "systems/ptr2e/img/svg/grass_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "powder",
-      "pp-updated"
-    ],
+    "slug": "puzzle-powder",
     "actions": [
       {
         "name": "Puzzle Powder",
@@ -26,43 +22,77 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "grass"
         ],
         "category": "status",
-        "power": null,
         "accuracy": 75,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets are @Affliction[confused] 5.</p>"
+        "description": "<p>Effect: On hit, all valid targets are @Affliction[confused] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720810594560,
-    "modifiedTime": 1720810655157,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Puzzle Powder",
+      "type": "passive",
+      "_id": "sKSWTNaYy6kbxZZJ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "puzzle-powder-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737315921639,
+        "modifiedTime": 1737315946588,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/pyro-ball.json
+++ b/packs/core-moves/pyro-ball.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/fire_icon.svg",
   "system": {
     "slug": "pyro-ball",
-    "description": "",
-    "traits": [
-      "defrost",
-      "kick"
-    ],
     "actions": [
       {
         "slug": "pyro-ball",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 6
         },
         "category": "physical",
         "power": 120,
@@ -38,15 +30,71 @@
           "fire"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[burn] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "1SzBS4pFVkqBZ0qj",
-  "effects": []
+  "effects": [
+    {
+      "name": "Pyro Ball",
+      "type": "passive",
+      "_id": "IQ7lYFgUXJRrIAuc",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "pyro-ball-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737315979888,
+        "modifiedTime": 1737316002292,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/pyro-rend.json
+++ b/packs/core-moves/pyro-rend.json
@@ -4,18 +4,13 @@
   "_id": "4ep5E76ZpTgH0XRs",
   "img": "systems/ptr2e/img/svg/fire_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "sharp",
-      "contact",
-      "crit-1"
-    ],
+    "slug": "pyro-rend",
     "actions": [
       {
         "name": "Pyro Rend",
         "slug": "pyro-rend",
         "type": "attack",
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/fire_icon.svg",
         "traits": [
           "sharp",
           "contact",
@@ -28,43 +23,25 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "fire"
         ],
         "category": "physical",
         "power": 80,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: This attack calculates damage against the target's SPDEF, rather than DEF.</p>"
+        "description": "<p>Effect: This attack calculates damage against the target's SPDEF, rather than DEF.</p>",
+        "defensiveStat": "spd",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 7900000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1719596241805,
-    "modifiedTime": 1719976014895,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/radiant-claw.json
+++ b/packs/core-moves/radiant-claw.json
@@ -4,18 +4,13 @@
   "_id": "ltoPWw8KlfJflb8r",
   "img": "systems/ptr2e/img/svg/dragon_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "sharp",
-      "dash",
-      "contact"
-    ],
+    "slug": "radiant-claw",
     "actions": [
       {
         "name": "Radiant Claw",
         "slug": "radiant-claw",
         "type": "attack",
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/dragon_icon.svg",
         "traits": [
           "sharp",
           "dash",
@@ -28,43 +23,25 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "dragon"
         ],
         "category": "physical",
         "power": 70,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: This attack calculates damage against the target's SPDEF, rather than DEF.</p>"
+        "description": "<p>Effect: This attack calculates damage against the target's SPDEF, rather than DEF.</p>",
+        "defensiveStat": "spd",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 8100000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1718740234079,
-    "modifiedTime": 1719976089727,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/rage-powder.json
+++ b/packs/core-moves/rage-powder.json
@@ -4,14 +4,6 @@
   "img": "systems/ptr2e/img/svg/bug_icon.svg",
   "system": {
     "slug": "rage-powder",
-    "description": "<p>Effect: All valid targets are @Affliction[taunted] 5 and @Affliction[enraged] 5.</p>",
-    "traits": [
-      "defensive",
-      "friendly",
-      "powder",
-      "priority-2",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "rage-powder",
@@ -31,27 +23,93 @@
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 8,
-          "delay": null,
-          "priority": 2,
-          "trigger": null
+          "powerPoints": 5,
+          "priority": 2
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "bug"
         ],
         "description": "<p>Effect: All valid targets are @Affliction[taunted] 5 and @Affliction[enraged] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/bug_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "OGgb9QPYzm7HTeS7",
-  "effects": []
+  "effects": [
+    {
+      "name": "Rage Powder",
+      "type": "affliction",
+      "_id": "52v32TQ6xsKLxcYc",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "rage-powder-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.tauntedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "rage-powder-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.enragedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737316114940,
+        "modifiedTime": 1737316163567,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/roar.json
+++ b/packs/core-moves/roar.json
@@ -4,14 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "roar",
-    "description": "<p>Effect: All valid targets gain @Affliction[fear] 5.</p>",
-    "traits": [
-      "social",
-      "sonic",
-      "friendly",
-      "delay-3",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "roar",
@@ -32,26 +24,78 @@
         "cost": {
           "activation": "complex",
           "powerPoints": 4,
-          "delay": 3,
-          "priority": null,
-          "trigger": null
+          "delay": 3
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: All valid targets gain @Affliction[fear] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "JkdiBWMUql7JsHN6",
-  "effects": []
+  "effects": [
+    {
+      "name": "Roar",
+      "type": "passive",
+      "_id": "YNMRTN0wfK9lK4wB",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "roar-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.fearconditioitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737316367068,
+        "modifiedTime": 1737316389078,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/rock-climb.json
+++ b/packs/core-moves/rock-climb.json
@@ -4,13 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "rock-climb",
-    "description": "",
-    "traits": [
-      "dash",
-      "contact",
-      "field",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "rock-climb",
@@ -29,10 +22,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "physical",
         "power": 90,
@@ -41,15 +31,71 @@
           "normal"
         ],
         "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[confused] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "SJLdQyoY9zBtoCTR",
-  "effects": []
+  "effects": [
+    {
+      "name": "Rock Climb",
+      "type": "passive",
+      "_id": "gLwqB4iOfEMLe3jQ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "rock-climb-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737316421897,
+        "modifiedTime": 1737316450576,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/rock-polish.json
+++ b/packs/core-moves/rock-polish.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/rock_icon.svg",
   "system": {
     "slug": "rock-polish",
-    "description": "<p>Effect: The user's SPD Stage increases by +1 for 5 Activations.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "rock-polish",
@@ -18,32 +14,82 @@
         ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 1
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "rock"
         ],
         "description": "<p>Effect: The user's SPD Stage increases by +1 for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "gl9grdDol5tujgPd",
-  "effects": []
+  "effects": [
+    {
+      "name": "Rock Polish",
+      "type": "passive",
+      "_id": "4EubqNwMyHz3kxf2",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "rock-polish-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLM",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737316469527,
+        "modifiedTime": 1737316494667,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/rocky-rebuff.json
+++ b/packs/core-moves/rocky-rebuff.json
@@ -4,11 +4,7 @@
   "_id": "hBXyr28hEfRL3VQC",
   "img": "systems/ptr2e/img/svg/rock_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "social",
-      "pp-updated"
-    ],
+    "slug": "rocky-rebuff",
     "actions": [
       {
         "name": "Rocky Rebuff",
@@ -26,43 +22,88 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
-        "variant": null,
         "types": [
           "untyped"
         ],
         "category": "status",
-        "power": null,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: All valid targets lose -1 ATK Stages for 5 Activations, and user gains +1 DEF Stage for 5 Activations.</p>"
+        "description": "<p>Effect: All valid targets lose -1 ATK Stages for 5 Activations, and user gains +1 DEF Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721269490476,
-    "modifiedTime": 1721269589459,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Rocky Rebuff",
+      "type": "passive",
+      "_id": "9jwYtOzdmVkE2A8O",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "rocky-rebuff-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.ikCAv5w4iNfHHqaE",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "rocky-rebuff-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.sMystTj3FBJ00AZp",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737316546935,
+        "modifiedTime": 1737316592786,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/rot-cloud.json
+++ b/packs/core-moves/rot-cloud.json
@@ -4,10 +4,7 @@
   "_id": "Hm7TcVFbJ7VxDo4O",
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "blast-3"
-    ],
+    "slug": "rot-cloud",
     "actions": [
       {
         "name": "Rot Cloud",
@@ -24,43 +21,89 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 8,
-          "delay": null,
-          "priority": null
+          "powerPoints": 8
         },
-        "variant": null,
         "types": [
           "poison"
         ],
         "category": "special",
         "power": 95,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 10% chance of gaining @Affliction[poison] 5 and a 10% chance of gaining @Affliction[splinter] 5.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 10% chance of gaining @Affliction[poison] 5 and a 10% chance of gaining @Affliction[splinter] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721258573940,
-    "modifiedTime": 1721259008066,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Rot Cloud",
+      "type": "passive",
+      "_id": "VFvBGu8nptFenaB2",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "rot-cloud-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "rot-cloud-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.splinterconditem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737316636242,
+        "modifiedTime": 1737316675473,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/ruby-beam.json
+++ b/packs/core-moves/ruby-beam.json
@@ -4,10 +4,7 @@
   "_id": "6yO14dd1qO7r9EFC",
   "img": "systems/ptr2e/img/svg/rock_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "ray"
-    ],
+    "slug": "ruby-beam",
     "actions": [
       {
         "name": "Ruby Beam",
@@ -24,43 +21,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "rock"
         ],
         "category": "special",
         "power": 80,
         "accuracy": 95,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[burn]  5.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[burn]  5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721269729006,
-    "modifiedTime": 1721269898261,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Ruby Beam",
+      "type": "passive",
+      "_id": "BJ4WXQyJ2asFlbSe",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "ruby-beam-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737316715666,
+        "modifiedTime": 1737316733675,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/rust-breath.json
+++ b/packs/core-moves/rust-breath.json
@@ -4,8 +4,7 @@
   "_id": "QWMbQoEQBDutGn3c",
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [],
+    "slug": "rust-breath",
     "actions": [
       {
         "name": "Rust Breath",
@@ -20,43 +19,89 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "steel"
         ],
         "category": "special",
         "power": 60,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[poison] 5 and a 30% chance of losing -1 SPDEF Stage for 5 Activations.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[poison] 5 and a 30% chance of losing -1 SPDEF Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721313645524,
-    "modifiedTime": 1721313832740,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Rust Breath",
+      "type": "passive",
+      "_id": "B2tPotiSt3Q5UPlt",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "rust-breath-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "rust-breath-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737316772987,
+        "modifiedTime": 1737316823398,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/salt-crash.json
+++ b/packs/core-moves/salt-crash.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
     "slug": "salt-crash",
-    "description": "",
-    "traits": [
-      "crushing",
-      "dash"
-    ],
     "actions": [
       {
         "slug": "salt-crash",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "physical",
         "power": 70,
@@ -38,15 +30,71 @@
           "fighting"
         ],
         "description": "<p>Effect: On hit, the user gains +1 DEF Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "TTb6FIfjUbCkwcbE",
-  "effects": []
+  "effects": [
+    {
+      "name": "Salt Crash",
+      "type": "passive",
+      "_id": "C3UOBQsnU2rgO7wO",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "salt-crash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.sMystTj3FBJ00AZp",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737316860083,
+        "modifiedTime": 1737316901143,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/sapphire-beam.json
+++ b/packs/core-moves/sapphire-beam.json
@@ -4,10 +4,7 @@
   "_id": "94IUhgoRIBpG2Ci8",
   "img": "systems/ptr2e/img/svg/rock_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "ray"
-    ],
+    "slug": "sapphire-beam",
     "actions": [
       {
         "name": "Sapphire Beam",
@@ -24,43 +21,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "rock"
         ],
         "category": "special",
         "power": 80,
         "accuracy": 95,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[frostbite] 5.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[frostbite] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721269922395,
-    "modifiedTime": 1721269958835,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Sapphire Beam",
+      "type": "passive",
+      "_id": "SEpB3Jqe5Fzk48PD",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sapphire-beam-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.frostbiteconitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737316960979,
+        "modifiedTime": 1737316984461,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/sappy-seed.json
+++ b/packs/core-moves/sappy-seed.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/grass_icon.svg",
   "system": {
     "slug": "sappy-seed",
-    "description": "",
-    "traits": [
-      "mascot"
-    ],
     "actions": [
       {
         "slug": "sappy-seed",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "physical",
         "power": 80,
@@ -36,15 +29,71 @@
           "grass"
         ],
         "description": "<p>Effect: On hit, the target gains @Affliction[leech] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "hOjkEDXu6NO7Af1y",
-  "effects": []
+  "effects": [
+    {
+      "name": "Sappy Seed",
+      "type": "passive",
+      "_id": "9Cer9HpMSQTweOTY",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sappy-seed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.leechconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317014151,
+        "modifiedTime": 1737317042188,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/scald.json
+++ b/packs/core-moves/scald.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
     "slug": "scald",
-    "description": "",
-    "traits": [
-      "defrost"
-    ],
     "actions": [
       {
         "slug": "scald",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "special",
         "power": 80,
@@ -36,15 +29,112 @@
           "water"
         ],
         "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[burn] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "AJkZffOTAegPVug6",
-  "effects": []
+  "effects": [
+    {
+      "name": "scald-attack",
+      "type": "passive",
+      "_id": "iHJyJy0CwwkJ1WBl",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317094669,
+        "modifiedTime": 1737317094669,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    },
+    {
+      "name": "Scald",
+      "type": "passive",
+      "_id": "LOrTzocd7aEwZc27",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "scald-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317102734,
+        "modifiedTime": 1737317125369,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/schadenfreude.json
+++ b/packs/core-moves/schadenfreude.json
@@ -4,11 +4,7 @@
   "_id": "SoCoMVFFppjfZXj2",
   "img": "systems/ptr2e/img/svg/dark_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "social",
-      "pp-updated"
-    ],
+    "slug": "schadenfreude",
     "actions": [
       {
         "name": "Schadenfreude",
@@ -17,7 +13,8 @@
         "img": "icons/svg/explosion.svg",
         "traits": [
           "social",
-          "pp-updated"
+          "pp-updated",
+          "schadenfreude-attack"
         ],
         "range": {
           "target": "cone",
@@ -26,43 +23,88 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "dark"
         ],
         "category": "status",
-        "power": null,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: All valid targets lose -1 SPDEF Stages for 5 Activations, and the user increases their SPATK by +1 Stage for 5 Activations.</p>"
+        "description": "<p>Effect: All valid targets lose -1 SPDEF Stages for 5 Activations, and the user increases their SPATK by +1 Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 9000000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1718738158953,
-    "modifiedTime": 1719976365950,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Schadenfreude",
+      "type": "passive",
+      "_id": "zlxYLLTW1nvuEFXg",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "schadenfreude-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "schadenfreude-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAa",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317194679,
+        "modifiedTime": 1737317274040,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/sea-shanty.json
+++ b/packs/core-moves/sea-shanty.json
@@ -4,12 +4,7 @@
   "_id": "EFO2ENjeCTdR4l51",
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "sonic",
-      "social",
-      "friendly"
-    ],
+    "slug": "sea-shanty",
     "actions": [
       {
         "name": "Sea Shanty",
@@ -28,43 +23,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null
+          "powerPoints": 6
         },
-        "variant": null,
         "types": [
           "water"
         ],
         "category": "special",
         "power": 70,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 20% chance of gaining @Affliction[taunted] 5.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 20% chance of gaining @Affliction[taunted] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721319183840,
-    "modifiedTime": 1721319404061,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Sea Shanty",
+      "type": "passive",
+      "_id": "WoApFrbaVfOy3Oo2",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sea-shanty-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.tauntedcondiitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317326253,
+        "modifiedTime": 1737317356381,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/secret-sword.json
+++ b/packs/core-moves/secret-sword.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
     "slug": "secret-sword",
-    "description": "",
-    "traits": [
-      "pass-4",
-      "sharp",
-      "legendary"
-    ],
     "actions": [
       {
         "slug": "secret-sword",
@@ -28,10 +22,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "special",
         "power": 85,
@@ -40,14 +31,17 @@
           "fighting"
         ],
         "description": "<p>Effect: This Attack's damage is calculated using the target's DEF.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/fighting_icon.svg",
+        "defensiveStat": "def",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "odtntQAPOhX5PLEG",
   "effects": []

--- a/packs/core-moves/sediment-smother.json
+++ b/packs/core-moves/sediment-smother.json
@@ -4,8 +4,7 @@
   "_id": "UQgPZl6MhCinecLA",
   "img": "systems/ptr2e/img/svg/rock_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [],
+    "slug": "sediment-smother",
     "actions": [
       {
         "name": "Sediment Smother",
@@ -20,43 +19,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "rock"
         ],
         "category": "physical",
         "power": 80,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[paralysis] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[paralysis] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721269981433,
-    "modifiedTime": 1721270038899,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Sediment Smother",
+      "type": "passive",
+      "_id": "wOtg1AQfMA2K2k26",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sediment-smother-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317456876,
+        "modifiedTime": 1737317496826,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/seed-flare.json
+++ b/packs/core-moves/seed-flare.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/grass_icon.svg",
   "system": {
     "slug": "seed-flare",
-    "description": "",
-    "traits": [
-      "legendary"
-    ],
     "actions": [
       {
         "slug": "seed-flare",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "special",
         "power": 120,
@@ -36,15 +29,71 @@
           "grass"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 30% chance of losing -2 SPDEF Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "qZVY1nJAhW7xt9OY",
-  "effects": []
+  "effects": [
+    {
+      "name": "Seed Flare",
+      "type": "passive",
+      "_id": "QAFEOyQe4VngEJis",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "seed-flare-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.PYz1Z32uiXoulkW2",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317531208,
+        "modifiedTime": 1737317550423,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/seismic-fist.json
+++ b/packs/core-moves/seismic-fist.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/ground_icon.svg",
   "system": {
     "slug": "seismic-fist",
-    "description": "",
-    "traits": [
-      "punch",
-      "earthbound"
-    ],
     "actions": [
       {
         "slug": "seismic-fist",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 2
         },
         "category": "physical",
         "power": 50,
@@ -38,15 +30,71 @@
           "ground"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 20% chance to lose -1 DEF for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "uYan2yXFlkGlHgQH",
-  "effects": []
+  "effects": [
+    {
+      "name": "Seismic Fist",
+      "type": "passive",
+      "_id": "UvLldXcoPwt75PUa",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "seismic-fist-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317597018,
+        "modifiedTime": 1737317624421,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shadow-bolt.json
+++ b/packs/core-moves/shadow-bolt.json
@@ -4,8 +4,6 @@
   "img": "systems/ptr2e/img/svg/shadow_icon.svg",
   "system": {
     "slug": "shadow-bolt",
-    "description": "",
-    "traits": [],
     "actions": [
       {
         "slug": "shadow-bolt",
@@ -21,10 +19,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "special",
         "power": 90,
@@ -33,15 +28,71 @@
           "shadow"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[paralysis] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "9QeNvziOB80xdTut",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shadow Bolt",
+      "type": "passive",
+      "_id": "bxmUjw9g3N4TQ4uu",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shadow-bolt-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317680157,
+        "modifiedTime": 1737317699884,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shadow-bone.json
+++ b/packs/core-moves/shadow-bone.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/ghost_icon.svg",
   "system": {
     "slug": "shadow-bone",
-    "description": "",
-    "traits": [
-      "bone"
-    ],
     "actions": [
       {
         "slug": "shadow-bone",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "physical",
         "power": 85,
@@ -36,15 +29,71 @@
           "ghost"
         ],
         "description": "<p>Effect: On hit, the target has a 20% chance of losing -1 DEF Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "sqRazM3Swvf3cfUk",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shadow Bone",
+      "type": "passive",
+      "_id": "bEujp6U55xyLlhsa",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shadow-bone-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317729659,
+        "modifiedTime": 1737317752712,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shadow-boost.json
+++ b/packs/core-moves/shadow-boost.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/shadow_icon.svg",
   "system": {
     "slug": "shadow-boost",
-    "description": "<p>Effect: The user's DEF and SPDEF Stages are reduced by -1, and their ATK and SPATK Stages are increased by +3 for 5 Activations.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "shadow-boost",
@@ -18,32 +14,115 @@
         ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "shadow"
         ],
         "description": "<p>Effect: The user's DEF and SPDEF Stages are reduced by -1, and their ATK and SPATK Stages are increased by +3 for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "8XIuyqZaczFmCebp",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shadow Boost",
+      "type": "passive",
+      "_id": "ale99aDG1PQ6Jv50",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shadow-boost-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "shadow-boost-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "shadow-boost-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.tH75RuGeGEDpXSah",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "shadow-boost-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAz",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317785606,
+        "modifiedTime": 1737317922811,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shadow-crush.json
+++ b/packs/core-moves/shadow-crush.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/shadow_icon.svg",
   "system": {
     "slug": "shadow-crush",
-    "description": "",
-    "traits": [
-      "contact"
-    ],
     "actions": [
       {
         "slug": "shadow-crush",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "physical",
         "power": 85,
@@ -36,15 +29,71 @@
           "shadow"
         ],
         "description": "<p>Effect: On hit, the target has a 80% chance of losing -1 DEF Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "18ZKiSXENwifLgHV",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shadow Crush",
+      "type": "passive",
+      "_id": "2JIFBYJgfLfAxnle",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shadow-crush-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 80,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737317959832,
+        "modifiedTime": 1737317982675,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shadow-down.json
+++ b/packs/core-moves/shadow-down.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/shadow_icon.svg",
   "system": {
     "slug": "shadow-down",
-    "description": "<p>Effect: On hit, all valid targets lose -2 DEF Stage for 5 Activations.</p>",
-    "traits": [
-      "friendly",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "shadow-down",
@@ -25,26 +20,24 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 9,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 9
         },
         "category": "status",
-        "power": null,
         "accuracy": 85,
         "types": [
           "shadow"
         ],
         "description": "<p>Effect: On hit, all valid targets lose -2 DEF Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "R4t5pLgeDvmZ3fd6",
   "effects": []

--- a/packs/core-moves/shadow-fire.json
+++ b/packs/core-moves/shadow-fire.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/shadow_icon.svg",
   "system": {
     "slug": "shadow-fire",
-    "description": "",
-    "traits": [
-      "pulse"
-    ],
     "actions": [
       {
         "slug": "shadow-fire",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "special",
         "power": 90,
@@ -36,15 +29,71 @@
           "shadow"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[burn] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "O57gfX8AHRF03KUM",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shadow Fire",
+      "type": "passive",
+      "_id": "xqKmdUdT1dnG4U0t",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shadow-fire-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737318063895,
+        "modifiedTime": 1737318080178,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shadow-panic.json
+++ b/packs/core-moves/shadow-panic.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/shadow_icon.svg",
   "system": {
     "slug": "shadow-panic",
-    "description": "<p>Effect: On hit, all valid targets become @Affliction[confused] 5.</p>",
-    "traits": [
-      "sonic",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "shadow-panic",
@@ -25,26 +20,24 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 1
         },
         "category": "status",
-        "power": null,
         "accuracy": 60,
         "types": [
           "shadow"
         ],
         "description": "<p>Effect: On hit, all valid targets become @Affliction[confused] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "PsxctPOZBM3u4RWF",
   "effects": []

--- a/packs/core-moves/shattered-psyche.json
+++ b/packs/core-moves/shattered-psyche.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
   "system": {
     "slug": "shattered-psyche",
-    "description": "<p>Trigger: User's partner uses Z-Pose! and triggers the appropriate Z-Crystal.</p><p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[confused] 5. Upon resolving this attack, the user freely uses Psychic Terrain.</p><p>Requirement: [Psychic] Z-Crystal as an Accessory Item and a Psychic-Type attack on the user's Active List.</p>",
-    "traits": [
-      "zenith",
-      "push-5"
-    ],
     "actions": [
       {
         "slug": "shattered-psyche",
@@ -25,9 +20,6 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null,
           "trigger": "<p>User's partner uses Z-Pose! and triggers the appropriate Z-Crystal.</p>"
         },
         "category": "physical",
@@ -37,15 +29,72 @@
           "psychic"
         ],
         "description": "<p>Trigger: User's partner uses Z-Pose! and triggers the appropriate Z-Crystal.</p><p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[confused] 5. Upon resolving this attack, the user freely uses Psychic Terrain.</p><p>Requirement: [Psychic] Z-Crystal as an Accessory Item and a Psychic-Type attack on the user's Active List.</p>",
-        "contestType": "",
-        "contestEffect": "",
         "free": true,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "6O8J8tV8HLrdH1tP",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shattered Psyche",
+      "type": "passive",
+      "_id": "ZExrQBgUSU1FSoDC",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shattered-psyche-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737318216398,
+        "modifiedTime": 1737318236837,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shell-shock.json
+++ b/packs/core-moves/shell-shock.json
@@ -4,12 +4,7 @@
   "_id": "pittprd1e3TajcRB",
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "explode",
-      "sonic",
-      "blast-2"
-    ],
+    "slug": "shell-shock",
     "actions": [
       {
         "name": "Shell Shock",
@@ -28,43 +23,89 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null
+          "powerPoints": 6
         },
-        "variant": null,
         "types": [
           "steel"
         ],
         "category": "special",
         "power": 90,
         "accuracy": 85,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[confused] 5 and @Affliction[hindered] 5.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[confused] 5 and @Affliction[hindered] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721314058382,
-    "modifiedTime": 1721314147449,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Shell Shock",
+      "type": "passive",
+      "_id": "eVHCcfMsUQf3JQRU",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shell-shock-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "shell-shock-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.hinderedconditem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737318262339,
+        "modifiedTime": 1737318329886,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shell-side-arm.json
+++ b/packs/core-moves/shell-side-arm.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
     "slug": "shell-side-arm",
-    "description": "",
-    "traits": [
-      "missile"
-    ],
     "actions": [
       {
         "slug": "shell-side-arm",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "special",
         "power": 90,
@@ -36,15 +29,71 @@
           "poison"
         ],
         "description": "<p>Effect: The user may use this attack as a 1m Physical Category attack without the [Missile] trait. On hit, the target has a 20% chance of gaining @Affliction[poison] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Tk1gco0MnXrf3Cdr",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shell Side Arm",
+      "type": "passive",
+      "_id": "BULNDD3L1wE8kysa",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shell-side-arm-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737318361283,
+        "modifiedTime": 1737318437759,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shell-smash.json
+++ b/packs/core-moves/shell-smash.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "shell-smash",
-    "description": "<p>Effect: The user's DEF and SPDEF Stages are reduced by -1 and their ATK, SPATK and SPD Stage are increased by +2 for 5 Activations.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "shell-smash",
@@ -18,32 +14,126 @@
         ],
         "range": {
           "target": "creature",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: The user's DEF and SPDEF Stages are reduced by -1 and their ATK, SPATK and SPD Stage are increased by +2 for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "DDRTQENRv77pGG22",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shell Smash",
+      "type": "passive",
+      "_id": "FMAVtswNnrvisZkC",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shell-smash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "shell-smash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "shell-smash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.g1Gt9mJWimAqrqZ0",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "shell-smash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAZ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "shell-smash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLZ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737320220456,
+        "modifiedTime": 1737320390033,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shelter.json
+++ b/packs/core-moves/shelter.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
     "slug": "shelter",
-    "description": "<p>Effect: The user gains +1 DEF, SPDEF, and EVA Stages and loses -1 SPD Stage for 5 Activations.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "shelter",
@@ -18,31 +14,27 @@
         ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "steel"
         ],
         "description": "<p>Effect: The user gains +1 DEF, SPDEF, and EVA Stages and loses -1 SPD Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "6LwZk7iiCDVe82VK",
   "effects": []

--- a/packs/core-moves/shift-gear.json
+++ b/packs/core-moves/shift-gear.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
     "slug": "shift-gear",
-    "description": "<p>Effect: The user raises their ATK Stage by +1 and their SPD Stage by +2 for 5 Activations.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "shift-gear",
@@ -18,31 +14,27 @@
         ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "steel"
         ],
         "description": "<p>Effect: The user raises their ATK Stage by +1 and their SPD Stage by +2 for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "cip9DUR5L95c1JpS",
   "effects": []

--- a/packs/core-moves/shiver.json
+++ b/packs/core-moves/shiver.json
@@ -4,10 +4,7 @@
   "_id": "6x7UgbfG7pwicnVJ",
   "img": "systems/ptr2e/img/svg/ice_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "pp-updated"
-    ],
+    "slug": "shiver",
     "actions": [
       {
         "name": "Shiver",
@@ -24,43 +21,77 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "ice"
         ],
         "category": "status",
-        "power": null,
         "accuracy": 85,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: All valid targets lose -2 SPD Stages for 5 Activations.</p>"
+        "description": "<p>Effect: All valid targets lose -2 SPD Stages for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720812653050,
-    "modifiedTime": 1720812737174,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Shiver",
+      "type": "passive",
+      "_id": "LWbl5AP1p3eH1Zc5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shiver-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.9FlxAAlUW2PrKOd0",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737320663578,
+        "modifiedTime": 1737320685059,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shocking-cascade.json
+++ b/packs/core-moves/shocking-cascade.json
@@ -4,13 +4,7 @@
   "_id": "YDEotKbnmF7UPix9",
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "5-strike",
-      "pulse",
-      "recoil-1-4",
-      "pp-updated"
-    ],
+    "slug": "shocking-cascade",
     "actions": [
       {
         "name": "Shocking Cascade",
@@ -30,43 +24,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null
+          "powerPoints": 7
         },
-        "variant": null,
         "types": [
           "electric"
         ],
         "category": "special",
         "power": 40,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[paralysis] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[paralysis] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 9400000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1718743964545,
-    "modifiedTime": 1719977611222,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Shocking Cascade",
+      "type": "passive",
+      "_id": "3memYPahdlAwue2k",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shocking-cascade-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737320717066,
+        "modifiedTime": 1737320741951,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shrapnel-shot.json
+++ b/packs/core-moves/shrapnel-shot.json
@@ -4,10 +4,7 @@
   "_id": "LbqvBrCjr8OhQC0d",
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "missile"
-    ],
+    "slug": "shrapnel-shot",
     "actions": [
       {
         "name": "Shrapnel Shot",
@@ -24,43 +21,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
-        "variant": null,
         "types": [
           "steel"
         ],
         "category": "physical",
         "power": 45,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[splinter] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[splinter] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721314177990,
-    "modifiedTime": 1721314241125,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Shrapnel Shot",
+      "type": "passive",
+      "_id": "7ajWCEpAra6h2Nqn",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shrapnel-shot-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.splinterconditem",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737320764073,
+        "modifiedTime": 1737320791528,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/sigma-wind.json
+++ b/packs/core-moves/sigma-wind.json
@@ -4,12 +4,7 @@
   "_id": "BnaI29Q8WakCGGh9",
   "img": "systems/ptr2e/img/svg/flying_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "sky",
-      "wind",
-      "legendary"
-    ],
+    "slug": "sigma-wind",
     "actions": [
       {
         "name": "Sigma Wind",
@@ -28,43 +23,89 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null
+          "powerPoints": 6
         },
-        "variant": null,
         "types": [
           "flying"
         ],
         "category": "special",
         "power": 90,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target gains @Affliction[grounded] 5 and has a 20% chance of gaining @Affliction[paralysis] 5.</p>"
+        "description": "<p>Effect: On hit, the target gains @Affliction[grounded] 5 and has a 20% chance of gaining @Affliction[paralysis] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 9500000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1719598129939,
-    "modifiedTime": 1719977826694,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Sigma Wind",
+      "type": "passive",
+      "_id": "4bUVQpcdr5ZwdJCc",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sigma-wind-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.groundedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "sigma-wind-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737320828274,
+        "modifiedTime": 1737320877710,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/silver-wind.json
+++ b/packs/core-moves/silver-wind.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/bug_icon.svg",
   "system": {
     "slug": "silver-wind",
-    "description": "",
-    "traits": [
-      "wind",
-      "powder"
-    ],
     "actions": [
       {
         "slug": "silver-wind",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "special",
         "power": 60,
@@ -38,15 +30,71 @@
           "bug"
         ],
         "description": "<p>Effect: After this attack resolves, the user has a 10% chance of gaining ATK, DEF, SPATK, SPDEF and SPD Stage by 1 for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Tiyl0SKP24f05kAu",
-  "effects": []
+  "effects": [
+    {
+      "name": "Silver Wind",
+      "type": "passive",
+      "_id": "4Wxd8PZkcCoMkgmt",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "silver-wind-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.rMNLqloV5nLmCLrZ",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737320914817,
+        "modifiedTime": 1737320938483,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/skitter-smack.json
+++ b/packs/core-moves/skitter-smack.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/bug_icon.svg",
   "system": {
     "slug": "skitter-smack",
-    "description": "",
-    "traits": [
-      "pass-2",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "skitter-smack",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "physical",
         "power": 70,
@@ -38,15 +30,71 @@
           "bug"
         ],
         "description": "<p>Effect: On hit, the target loses -1 SPATK Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "gxhNlns100h709Oq",
-  "effects": []
+  "effects": [
+    {
+      "name": "Skitter Smack",
+      "type": "passive",
+      "_id": "wE9CPy0urKcwS83I",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "skitter-smack-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1JXumQz0QqthT9Iv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737320980232,
+        "modifiedTime": 1737321001650,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/sky-fall.json
+++ b/packs/core-moves/sky-fall.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/flying_icon.svg",
   "system": {
     "slug": "sky-fall",
-    "description": "",
-    "traits": [
-      "dash",
-      "pass-3"
-    ],
     "actions": [
       {
         "slug": "sky-fall",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "physical",
         "power": 85,
@@ -38,15 +30,71 @@
           "flying"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[paralysis] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "e1PMYoHlbRDJtC3v",
-  "effects": []
+  "effects": [
+    {
+      "name": "Sky Fall",
+      "type": "passive",
+      "_id": "HLW68Ehw1E9sVGlr",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sky-fall-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737321069687,
+        "modifiedTime": 1737321095577,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/sludge-bomb.json
+++ b/packs/core-moves/sludge-bomb.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
     "slug": "sludge-bomb",
-    "description": "",
-    "traits": [
-      "explode",
-      "missile",
-      "blast-2"
-    ],
     "actions": [
       {
         "slug": "sludge-bomb",
@@ -28,10 +22,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 6
         },
         "category": "special",
         "power": 90,
@@ -40,14 +31,16 @@
           "poison"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[poison] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "3NZj02Fbw14aWuTa",
   "effects": []

--- a/packs/core-moves/sludge-wave.json
+++ b/packs/core-moves/sludge-wave.json
@@ -4,8 +4,6 @@
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
     "slug": "sludge-wave",
-    "description": "",
-    "traits": [],
     "actions": [
       {
         "slug": "sludge-wave",
@@ -21,10 +19,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "special",
         "power": 95,
@@ -33,15 +28,71 @@
           "poison"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 10% chance of gaining @Affliction[poison] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "S6Es8M8WvI34bCDi",
-  "effects": []
+  "effects": [
+    {
+      "name": "Sludge Wave",
+      "type": "passive",
+      "_id": "bjATUHB2W1tMGJnS",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sludge-wave-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737321227323,
+        "modifiedTime": 1737321282097,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/slumber-fang.json
+++ b/packs/core-moves/slumber-fang.json
@@ -4,11 +4,7 @@
   "_id": "GmJYEzL7zbGEuieR",
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "jaw",
-      "contact"
-    ],
+    "slug": "slumber-fang",
     "actions": [
       {
         "name": "Slumber Fang",
@@ -26,43 +22,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "poison"
         ],
         "category": "physical",
         "power": 60,
         "accuracy": 85,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target gains @Affliction[drowsy] 5.</p>"
+        "description": "<p>Effect: On hit, the target gains @Affliction[drowsy] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721259027588,
-    "modifiedTime": 1721259759481,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Slumber Fang",
+      "type": "passive",
+      "_id": "vCz5n1TRDmoYKmKl",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "slumber-fang-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.drowsycondititem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737321305820,
+        "modifiedTime": 1737321343569,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/spectral-tail.json
+++ b/packs/core-moves/spectral-tail.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/ghost_icon.svg",
   "system": {
     "slug": "spectral-tail",
-    "description": "",
-    "traits": [
-      "tail"
-    ],
     "actions": [
       {
         "slug": "spectral-tail",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 2
         },
         "category": "physical",
         "power": 60,
@@ -36,15 +29,71 @@
           "ghost"
         ],
         "description": "<p>Effect: On hit, all legal targets have a 20% chance of gaining @Affliction[frostbite] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "ofDL7eMpRZMnBcdi",
-  "effects": []
+  "effects": [
+    {
+      "name": "Spectral Tail",
+      "type": "passive",
+      "_id": "EkiqhvRlsSaA1TXp",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "spectral-tail-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.frostbiteconitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737321746144,
+        "modifiedTime": 1737321773428,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/spicy-extract.json
+++ b/packs/core-moves/spicy-extract.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/grass_icon.svg",
   "system": {
     "slug": "spicy-extract",
-    "description": "<p>Effect: On hit, the target gains +2 ATK and loses -2 DEF Stages for 5 Activations.</p>",
-    "traits": [
-      "danger-close",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "spicy-extract",
@@ -25,27 +20,89 @@
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 2
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "grass"
         ],
         "description": "<p>Effect: On hit, the target gains +2 ATK and loses -2 DEF Stages for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "laOufrtJHyb7s0Np",
-  "effects": []
+  "effects": [
+    {
+      "name": "Spicy Extract",
+      "type": "passive",
+      "_id": "9fo4Pzjglzqqoihx",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "spicy-extract-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.g1Gt9mJWimAqrqZ0",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "spicy-extract-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.B79G2s6TauIlmsno",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737321837457,
+        "modifiedTime": 1737321885760,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/spin-out.json
+++ b/packs/core-moves/spin-out.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
     "slug": "spin-out",
-    "description": "",
-    "traits": [
-      "dash",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "spin-out",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "physical",
         "power": 100,
@@ -38,15 +30,71 @@
           "steel"
         ],
         "description": "<p>Effect: On hit, the user loses -2 SPD Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "9pHsEHiFkJJ3i6bM",
-  "effects": []
+  "effects": [
+    {
+      "name": "Spin Out",
+      "type": "passive",
+      "_id": "oXL4kN5uQTkjF0Ru",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "spin-out-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.9FlxAAlUW2PrKOd0",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737321955666,
+        "modifiedTime": 1737321975342,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/spirit-break.json
+++ b/packs/core-moves/spirit-break.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
   "system": {
     "slug": "spirit-break",
-    "description": "",
-    "traits": [
-      "pass-2",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "spirit-break",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "physical",
         "power": 75,
@@ -38,14 +30,16 @@
           "fairy"
         ],
         "description": "<p>Effect: On hit, the target loses -1 ATK Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "rMUF5zVFhV8JoypN",
   "effects": []

--- a/packs/core-moves/splishy-splash.json
+++ b/packs/core-moves/splishy-splash.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
     "slug": "splishy-splash",
-    "description": "",
-    "traits": [
-      "mascot"
-    ],
     "actions": [
       {
         "slug": "splishy-splash",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "special",
         "power": 90,
@@ -36,15 +29,71 @@
           "water"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[paralysis] 5. The user may freely relocate themself to any open square within the affected Range.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "kCn9Pi9GvRwDxNO8",
-  "effects": []
+  "effects": [
+    {
+      "name": "Splishy Splash",
+      "type": "passive",
+      "_id": "29IMhlswDnXTePTP",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "splishy-splash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737322090354,
+        "modifiedTime": 1737322118118,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/spotlight.json
+++ b/packs/core-moves/spotlight.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "spotlight",
-    "description": "<p>Effect: The target becomes @Affliction[marked] 5.</p>",
-    "traits": [
-      "social",
-      "priority-2",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "spotlight",
@@ -28,26 +22,78 @@
         "cost": {
           "activation": "simple",
           "powerPoints": 4,
-          "delay": null,
-          "priority": 2,
-          "trigger": null
+          "priority": 2
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: The target becomes @Affliction[marked] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "JxOXqFuEj85tbDOg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Spotlight",
+      "type": "passive",
+      "_id": "kHtziGK9yGzQjwIj",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "spotlight-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.markedcondititem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737322184450,
+        "modifiedTime": 1737322204260,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/spring-tail.json
+++ b/packs/core-moves/spring-tail.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/grass_icon.svg",
   "system": {
     "slug": "spring-tail",
-    "description": "",
-    "traits": [
-      "tail",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "spring-tail",
@@ -25,11 +20,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "activation": "complex"
         },
         "category": "physical",
         "power": 50,
@@ -38,15 +29,71 @@
           "grass"
         ],
         "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[leech] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "KXVjXgXE63kQbw8r",
-  "effects": []
+  "effects": [
+    {
+      "name": "Spring Tail",
+      "type": "passive",
+      "_id": "ct7uSr0FMAgJ0VWr",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "spring-tail-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.leechconditiitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737322224527,
+        "modifiedTime": 1737322249737,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/star-beam.json
+++ b/packs/core-moves/star-beam.json
@@ -4,10 +4,7 @@
   "_id": "uwkwLU9GN0DNeRHK",
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "ray"
-    ],
+    "slug": "star-beam",
     "actions": [
       {
         "name": "Star Beam",
@@ -24,11 +21,8 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null
+          "powerPoints": 6
         },
-        "variant": null,
         "types": [
           "psychic",
           "fairy"
@@ -36,32 +30,70 @@
         "category": "special",
         "power": 130,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On resolution, the user loses -2 SPATK Stages for 5 Activations.</p>"
+        "description": "<p>Effect: On resolution, the user loses -2 SPATK Stages for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721264045448,
-    "modifiedTime": 1721264145737,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Star Beam",
+      "type": "passive",
+      "_id": "E7MONnGcMpav7mvn",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "star-beam-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.EYmp1DeE1Lwzi0D1",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737322299267,
+        "modifiedTime": 1737322321888,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/steel-roller.json
+++ b/packs/core-moves/steel-roller.json
@@ -4,14 +4,6 @@
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
     "slug": "steel-roller",
-    "description": "",
-    "traits": [
-      "environ",
-      "crushing",
-      "contact",
-      "field",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "steel-roller",
@@ -22,7 +14,8 @@
           "crushing",
           "contact",
           "field",
-          "pp-updated"
+          "pp-updated",
+          "curl"
         ],
         "range": {
           "target": "wide-line",
@@ -32,8 +25,6 @@
         "cost": {
           "activation": "complex",
           "powerPoints": 8,
-          "delay": null,
-          "priority": null,
           "trigger": "A [Terrain] is present."
         },
         "category": "physical",
@@ -43,14 +34,16 @@
           "steel"
         ],
         "description": "<p>Effect: This attack ends all [Terrain] effects on use. If there is no active [Terrain] effect, this attack fails. The user may freely move to any open space in this attacks range.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "f1owTUALsuAOxqFj",
   "effects": []

--- a/packs/core-moves/steel-wing.json
+++ b/packs/core-moves/steel-wing.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
     "slug": "steel-wing",
-    "description": "",
-    "traits": [
-      "sharp",
-      "pass-2",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "steel-wing",
@@ -28,10 +22,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 2
         },
         "category": "physical",
         "power": 70,
@@ -40,15 +31,71 @@
           "steel"
         ],
         "description": "<p>Effect: On hit, the user has a 10% chance of raising their DEF Stage by +1 for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "GaZA17geF0W38wzi",
-  "effects": []
+  "effects": [
+    {
+      "name": "Steel Wing",
+      "type": "passive",
+      "_id": "Ufd8SoBQTSCGueHP",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "steel-wing-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.sMystTj3FBJ00AZp",
+            "predicate": [],
+            "chance": 10,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737322385375,
+        "modifiedTime": 1737322409367,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/stoked-sparksurfer.json
+++ b/packs/core-moves/stoked-sparksurfer.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "system": {
     "slug": "stoked-sparksurfer",
-    "description": "<p>Trigger: User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p><p>Effect: The user may freely move up to double their Flight Score when declaring this attack. On hit, all legal targets gain @Affliction[paralysis] 5.</p><p>Requirement: [Pikachu] Z-Power-Crystal as an Accessory Item and Thunderbolt on the user's Active List.</p>",
-    "traits": [
-      "zenith",
-      "dash",
-      "pass-5"
-    ],
     "actions": [
       {
         "slug": "stoked-sparksurfer",
@@ -27,9 +21,6 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null,
           "trigger": "<p>User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p>"
         },
         "category": "special",
@@ -39,15 +30,72 @@
           "electric"
         ],
         "description": "<p>Trigger: User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p><p>Effect: The user may freely move up to double their Flight Score when declaring this attack. On hit, all legal targets gain @Affliction[paralysis] 5.</p><p>Requirement: [Pikachu] Z-Power-Crystal as an Accessory Item and Thunderbolt on the user's Active List.</p>",
-        "contestType": "",
-        "contestEffect": "",
         "free": true,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "wlHWup7MYL88PcGg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Stoked Sparksurfer",
+      "type": "passive",
+      "_id": "wH3UeRRfjmXpijQJ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "stoked-sparksurfer-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737322494015,
+        "modifiedTime": 1737322518136,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/strange-steam.json
+++ b/packs/core-moves/strange-steam.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
   "system": {
     "slug": "strange-steam",
-    "description": "",
-    "traits": [
-      "friendly"
-    ],
     "actions": [
       {
         "slug": "strange-steam",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "special",
         "power": 90,
@@ -36,15 +29,71 @@
           "fairy"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[confused] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "bE19iPQuIODss8Mr",
-  "effects": []
+  "effects": [
+    {
+      "name": "Strange Steam",
+      "type": "passive",
+      "_id": "6Tovxp29qasXgEoE",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "strange-steam-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737322579367,
+        "modifiedTime": 1737322608157,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/stun-spore.json
+++ b/packs/core-moves/stun-spore.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/grass_icon.svg",
   "system": {
     "slug": "stun-spore",
-    "description": "<p>Effect: On hit, all valid targets gain @Affliction[paralysis] 5.</p>",
-    "traits": [
-      "powder",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "stun-spore",
@@ -25,26 +20,24 @@
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 2
         },
         "category": "status",
-        "power": null,
         "accuracy": 75,
         "types": [
           "grass"
         ],
         "description": "<p>Effect: On hit, all valid targets gain @Affliction[paralysis] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "zA2Aie3gUYFwdRwh",
   "effects": []

--- a/packs/core-moves/subduction.json
+++ b/packs/core-moves/subduction.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/ground_icon.svg",
   "system": {
     "slug": "subduction",
-    "description": "",
-    "traits": [
-      "blast-3"
-    ],
     "actions": [
       {
         "slug": "subduction",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "physical",
         "power": 140,
@@ -36,15 +29,82 @@
           "ground"
         ],
         "description": "<p>Effect: On hit, all valid targets lose -2 SPD Stages. The user gains @Affliction[confused] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "zPd9TgBoFp8GkYjw",
-  "effects": []
+  "effects": [
+    {
+      "name": "Subduction",
+      "type": "passive",
+      "_id": "dKGwpp3xkqwZQ5Um",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "subduction-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.9FlxAAlUW2PrKOd0",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "subduction-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737322714514,
+        "modifiedTime": 1737322763898,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/supercharge.json
+++ b/packs/core-moves/supercharge.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "system": {
     "slug": "supercharge",
-    "description": "<p>Effect: The user gains +1 ATK and SPD Stage for 5 Activations.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "supercharge",
@@ -18,32 +14,93 @@
         ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "electric"
         ],
         "description": "<p>Effect: The user gains +1 ATK and SPD Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "G09NVwJorYKAsbzQ",
-  "effects": []
+  "effects": [
+    {
+      "name": "Supercharge",
+      "type": "passive",
+      "_id": "PPSKFBU9urlpONNE",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "supercharge-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.ZGwaMlzUwkSuCPyH",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "supercharge-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLM",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737322918210,
+        "modifiedTime": 1737322964430,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/swagger.json
+++ b/packs/core-moves/swagger.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "swagger",
-    "description": "<p>Effect: On hit, the target's ATK Stages increase by +2 for 5 Activations and they become @Affliction[confused] 5.</p>",
-    "traits": [
-      "social",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "swagger",
@@ -25,27 +20,90 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 2
         },
         "category": "status",
-        "power": null,
         "accuracy": 85,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: On hit, the target's ATK Stages increase by +2 for 5 Activations and they become @Affliction[confused] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "wYGAvakAQaDex43K",
-  "effects": []
+  "effects": [
+    {
+      "name": "Swagger",
+      "type": "passive",
+      "_id": "ZQBZF1FCvkgU4iZW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "swagger-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.g1Gt9mJWimAqrqZ0",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "swagger-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737323078462,
+        "modifiedTime": 1737323121638,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/sweet-kiss.json
+++ b/packs/core-moves/sweet-kiss.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
   "system": {
     "slug": "sweet-kiss",
-    "description": "<p>Effect: On hit, the target becomes @Affliction[confused] 5.</p>",
-    "traits": [
-      "social",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "sweet-kiss",
@@ -25,27 +20,79 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 2
         },
         "category": "status",
-        "power": null,
         "accuracy": 75,
         "types": [
           "fairy"
         ],
         "description": "<p>Effect: On hit, the target becomes @Affliction[confused] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "B0vBMTGdIVQJAuaJ",
-  "effects": []
+  "effects": [
+    {
+      "name": "Sweet Kiss",
+      "type": "passive",
+      "_id": "SFC7ZDZqcUKA2ZE9",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sweet-kiss-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737323269435,
+        "modifiedTime": 1737323293193,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/syrup-bomb.json
+++ b/packs/core-moves/syrup-bomb.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/grass_icon.svg",
   "system": {
     "slug": "syrup-bomb",
-    "description": "",
-    "traits": [
-      "explode",
-      "blast-3"
-    ],
     "actions": [
       {
         "slug": "syrup-bomb",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "special",
         "power": 65,
@@ -38,15 +30,82 @@
           "grass"
         ],
         "description": "<p>Effect: On hit, all valid targets lose -1 SPD Stage for 5 Activations, and have a 30% of gaining @Affliction[slowed] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "zxxsNfaNg56Mhg5m",
-  "effects": []
+  "effects": [
+    {
+      "name": "Syrup Bomb",
+      "type": "passive",
+      "_id": "NdFT3NlmzplekjjJ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "syrup-bomb-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.HLAV9dhz632Rfp1K",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "syrup-bomb-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.slowedcondititem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737323497295,
+        "modifiedTime": 1737323565702,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/tail-glow.json
+++ b/packs/core-moves/tail-glow.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/bug_icon.svg",
   "system": {
     "slug": "tail-glow",
-    "description": "<p>Effect: The user increases their SPATK Stage by +3 for 5 Activations.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "tail-glow",
@@ -18,32 +14,82 @@
         ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "bug"
         ],
         "description": "<p>Effect: The user increases their SPATK Stage by +3 for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "heI4g1QzapfT9PCV",
-  "effects": []
+  "effects": [
+    {
+      "name": "Tail Glow",
+      "type": "passive",
+      "_id": "fxs9utWE5yx2bm0R",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "tail-glow-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAz",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737323679836,
+        "modifiedTime": 1737323703278,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/talon-raze.json
+++ b/packs/core-moves/talon-raze.json
@@ -4,14 +4,7 @@
   "_id": "yUPs9aZmnrM9gDSY",
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "legendary",
-      "sharp",
-      "contact",
-      "3-strike",
-      "pp-updated"
-    ],
+    "slug": "talon-raze",
     "actions": [
       {
         "name": "Talon Raze",
@@ -32,43 +25,24 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "fighting"
         ],
         "category": "physical",
         "power": 50,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On resolution, the user loses -1 ATK and SPD Stages for 5 Activations.</p>"
+        "description": "<p>Effect: On resolution, the user loses -1 ATK and SPD Stages for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 10200000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1719588567924,
-    "modifiedTime": 1719978244534,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/tear-gas.json
+++ b/packs/core-moves/tear-gas.json
@@ -4,12 +4,7 @@
   "_id": "pz019CwE0UEsAeAq",
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "basic",
-      "blast-1",
-      "pp-updated"
-    ],
+    "slug": "tear-gas",
     "actions": [
       {
         "name": "Tear Gas",
@@ -28,23 +23,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null
+          "powerPoints": 1
         },
-        "variant": null,
         "types": [
           "poison"
         ],
         "category": "special",
         "power": 40,
         "accuracy": 90,
-        "description": "<p>Effect: On hit, all valid targets have a 20% chance of losing -1 ACC Stage for 5 Activations.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 20% chance of losing -1 ACC Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Tear Gas",
+      "type": "passive",
+      "_id": "lzEM04wyJrDzG2B5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "tear-gas-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.wA5oCsgHmZLcHHSn",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737323903555,
+        "modifiedTime": 1737323929204,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/teeter-dance.json
+++ b/packs/core-moves/teeter-dance.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
     "slug": "teeter-dance",
-    "description": "<p>Effect: On hit, all valid targets become @Affliction[confused] 5.</p>",
-    "traits": [
-      "dance",
-      "social",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "teeter-dance",
@@ -27,27 +21,79 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "status",
-        "power": null,
         "accuracy": 100,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: On hit, all valid targets become @Affliction[confused] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Dqyt40R06sneLRdt",
-  "effects": []
+  "effects": [
+    {
+      "name": "Teeter Dance",
+      "type": "passive",
+      "_id": "EPYKrsDvfuG2DPbN",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "teeter-dance-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737323985468,
+        "modifiedTime": 1737324005807,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/tenebrous-typhoon.json
+++ b/packs/core-moves/tenebrous-typhoon.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/shadow_icon.svg",
   "system": {
     "slug": "tenebrous-typhoon",
-    "description": "<p>Trigger: User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p><p>Effect: On hit, all valid targets lose -1 EVA Stage for 5 Activations.</p><p>Requirement: Requirement: [Lugia] Z-Power-Crystal as an Accessory Item and Shadow Blast on the user's Active List.</p>",
-    "traits": [
-      "zenith",
-      "move-locked",
-      "crit-2"
-    ],
     "actions": [
       {
         "slug": "tenebrous-typhoon",
@@ -27,9 +21,6 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null,
           "trigger": "<p>User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p>"
         },
         "category": "special",
@@ -39,15 +30,72 @@
           "shadow"
         ],
         "description": "<p>Trigger: User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p><p>Effect: On hit, all valid targets lose -1 EVA Stage for 5 Activations.</p><p>Requirement: Requirement: [Lugia] Z-Power-Crystal as an Accessory Item and Shadow Blast on the user's Active List.</p>",
-        "contestType": "",
-        "contestEffect": "",
         "free": true,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "gGREhduorVawK1Sy",
-  "effects": []
+  "effects": [
+    {
+      "name": "Tenebrous Typhoon",
+      "type": "passive",
+      "_id": "l53ORYTSR0iWzphU",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "tenebrous-typhoon-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.hIE6W3Y5E9CyHiTy",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737324085525,
+        "modifiedTime": 1737324117989,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/tesla-prod.json
+++ b/packs/core-moves/tesla-prod.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "system": {
     "slug": "tesla-prod",
-    "description": "",
-    "traits": [
-      "2-strike",
-      "contact",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "tesla-prod",
@@ -27,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 1
         },
         "category": "physical",
         "power": 35,
@@ -39,15 +30,71 @@
           "electric"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[paralysis] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "0YbbHZV3600MTBHw",
-  "effects": []
+  "effects": [
+    {
+      "name": "Tesla Prod",
+      "type": "passive",
+      "_id": "pCN9sDCAfxDGZXrn",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "tesla-prod-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737324160181,
+        "modifiedTime": 1737324202758,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/thousand-cuts.json
+++ b/packs/core-moves/thousand-cuts.json
@@ -4,13 +4,6 @@
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
     "slug": "thousand-cuts",
-    "description": "",
-    "traits": [
-      "10-strike",
-      "sharp",
-      "contact",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "thousand-cuts",
@@ -29,10 +22,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "physical",
         "power": 15,
@@ -41,15 +31,71 @@
           "poison"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[poison] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "IlILvPalY9JdHvcQ",
-  "effects": []
+  "effects": [
+    {
+      "name": "Thousand Cuts",
+      "type": "passive",
+      "_id": "40i4FZhbM6A9BEz6",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "thousand-cuts-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737324319314,
+        "modifiedTime": 1737324344660,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/thunder-crash.json
+++ b/packs/core-moves/thunder-crash.json
@@ -4,12 +4,7 @@
   "_id": "eMaFTRVbnK6BFVhh",
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "pass-5",
-      "delay-1",
-      "contact"
-    ],
+    "slug": "thunder-crash",
     "actions": [
       {
         "name": "Thunder Crash",
@@ -29,42 +24,78 @@
         "cost": {
           "activation": "complex",
           "powerPoints": 4,
-          "delay": 1,
-          "priority": null
+          "delay": 1
         },
-        "variant": null,
         "types": [
           "electric"
         ],
         "category": "physical",
         "power": 130,
         "accuracy": 85,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On resolution, the user loses -2 ATK Stages for 5 Activations.</p>"
+        "description": "<p>Effect: On resolution, the user loses -2 ATK Stages for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 10400000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1718743677752,
-    "modifiedTime": 1720456352677,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Thunder Crash",
+      "type": "passive",
+      "_id": "4vfzFa22CXFdFaCy",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "thunder-crash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.Sp0TScnwSTu8Gusr",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737324424166,
+        "modifiedTime": 1737324448500,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/thunder-tail.json
+++ b/packs/core-moves/thunder-tail.json
@@ -4,11 +4,7 @@
   "_id": "FRFtOtq5NKcAR441",
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "tail",
-      "contact"
-    ],
+    "slug": "thunder-tail",
     "actions": [
       {
         "name": "Thunder Tail",
@@ -26,43 +22,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null
+          "powerPoints": 6
         },
-        "variant": null,
         "types": [
           "electric"
         ],
         "category": "physical",
         "power": 90,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 30% chance of losing -1 ACC Stage for 5 Activations.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 30% chance of losing -1 ACC Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 10600000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1718744111350,
-    "modifiedTime": 1719978559618,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Thunder Tail",
+      "type": "passive",
+      "_id": "rZ5anWQAopeZ5ZxC",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "thunder-tail-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.wA5oCsgHmZLcHHSn",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737324484748,
+        "modifiedTime": 1737324508107,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/thunderbolt.json
+++ b/packs/core-moves/thunderbolt.json
@@ -4,8 +4,6 @@
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "system": {
     "slug": "thunderbolt",
-    "description": "",
-    "traits": [],
     "actions": [
       {
         "slug": "thunderbolt",
@@ -21,10 +19,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "special",
         "power": 90,
@@ -33,15 +28,71 @@
           "electric"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[paralysis] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "7WSf5Om7cSiqh7nR",
-  "effects": []
+  "effects": [
+    {
+      "name": "Thunderbolt",
+      "type": "passive",
+      "_id": "hRFw9sICJrHvjdQR",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "thunderbolt-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737324572555,
+        "modifiedTime": 1737324589027,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/thunderous-kick.json
+++ b/packs/core-moves/thunderous-kick.json
@@ -4,14 +4,6 @@
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
     "slug": "thunderous-kick",
-    "description": "",
-    "traits": [
-      "legendary",
-      "dash",
-      "push-3",
-      "kick",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "thunderous-kick",
@@ -32,10 +24,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "physical",
         "power": 90,
@@ -45,15 +34,71 @@
           "electric"
         ],
         "description": "<p>Effect: On hit, the target loses -1 DEF Stage for 5 Activations. This attack is both Fighting- and Electric-Type.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "fXfHy8KhkSm1MMi4",
-  "effects": []
+  "effects": [
+    {
+      "name": "Thunderous Kick",
+      "type": "passive",
+      "_id": "kNHbR7yOoCUwBFyl",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "thunderous-kick-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737324622708,
+        "modifiedTime": 1737324648468,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/torch-song.json
+++ b/packs/core-moves/torch-song.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/fire_icon.svg",
   "system": {
     "slug": "torch-song",
-    "description": "",
-    "traits": [
-      "sonic"
-    ],
     "actions": [
       {
         "slug": "torch-song",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "special",
         "power": 80,
@@ -36,14 +29,16 @@
           "fire"
         ],
         "description": "<p>Effect: On hit, the user gains +1 SPATK Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "1kx0OT8MPP8Qcq2R",
   "effects": []

--- a/packs/core-moves/toxic-thread.json
+++ b/packs/core-moves/toxic-thread.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
     "slug": "toxic-thread",
-    "description": "<p>Effect: On hit, all valid targets lose -1 SPD Stage for 5 Activations and gain @Affliction[poison] 5.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "toxic-thread",
@@ -23,27 +19,90 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "status",
-        "power": null,
         "accuracy": 100,
         "types": [
           "poison"
         ],
         "description": "<p>Effect: On hit, all valid targets lose -1 SPD Stage for 5 Activations and gain @Affliction[poison] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "IKH5IDr2RsrNp9Vh",
-  "effects": []
+  "effects": [
+    {
+      "name": "Toxic Thread",
+      "type": "passive",
+      "_id": "Ge95VBvQFGld9T3B",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "toxic-thread-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.HLAV9dhz632Rfp1K",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "toxic-thread-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737324797187,
+        "modifiedTime": 1737324891440,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/toxicrash.json
+++ b/packs/core-moves/toxicrash.json
@@ -4,13 +4,7 @@
   "_id": "OR1xXtygDIWtG3c4",
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "contact",
-      "dash",
-      "pass-1",
-      "recoil-1-3"
-    ],
+    "slug": "toxicrash",
     "actions": [
       {
         "name": "Toxicrash",
@@ -30,43 +24,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null
+          "powerPoints": 7
         },
-        "variant": null,
         "types": [
           "poison"
         ],
         "category": "physical",
         "power": 120,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[poison] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[poison] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721259605190,
-    "modifiedTime": 1721259923410,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Toxicrash",
+      "type": "passive",
+      "_id": "7rzYaiR0z4bzt9t5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "toxicrash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737324956489,
+        "modifiedTime": 1737324979268,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/tractor-beam.json
+++ b/packs/core-moves/tractor-beam.json
@@ -4,10 +4,7 @@
   "_id": "iuF0phDA7IUForGE",
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "pp-updated"
-    ],
+    "slug": "tractor-beam",
     "actions": [
       {
         "name": "Tractor Beam",
@@ -24,43 +21,77 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null
+          "powerPoints": 7
         },
-        "variant": null,
         "types": [
           "steel"
         ],
         "category": "status",
-        "power": null,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: The target is @Affliction[lifted] 5.</p>"
+        "description": "<p>Effect: The target is @Affliction[lifted] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721314375384,
-    "modifiedTime": 1721314485132,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Tractor Beam",
+      "type": "passive",
+      "_id": "4gVAGRiF4pPpd6TU",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "tractor-beam-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.liftedcondititem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737325015826,
+        "modifiedTime": 1737325051639,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/tremor.json
+++ b/packs/core-moves/tremor.json
@@ -4,12 +4,7 @@
   "_id": "nxP4qVlVXnGSUbbX",
   "img": "systems/ptr2e/img/svg/ground_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "3-strike",
-      "earthbound",
-      "pp-updated"
-    ],
+    "slug": "tremor",
     "actions": [
       {
         "name": "Tremor",
@@ -28,43 +23,24 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null
+          "powerPoints": 1
         },
-        "variant": null,
         "types": [
           "untyped"
         ],
         "category": "physical",
         "power": 20,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 40% chance to lose -1 SPD Stage for 5 Activations.</p>"
+        "description": "<p>Effect: On hit, the target has a 40% chance to lose -1 SPD Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720800556737,
-    "modifiedTime": 1720800610604,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/trop-kick.json
+++ b/packs/core-moves/trop-kick.json
@@ -4,13 +4,6 @@
   "img": "systems/ptr2e/img/svg/grass_icon.svg",
   "system": {
     "slug": "trop-kick",
-    "description": "",
-    "traits": [
-      "dash",
-      "kick",
-      "push-1",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "trop-kick",
@@ -30,10 +23,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "physical",
         "power": 70,
@@ -42,15 +32,71 @@
           "grass"
         ],
         "description": "<p>Effect: On hit, the target loses -1 ATK Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "2I5U1h1VUufQ1P8Z",
-  "effects": []
+  "effects": [
+    {
+      "name": "Trop Kick",
+      "type": "passive",
+      "_id": "lKUujTVjvmeinnLT",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "trop-kick-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.ikCAv5w4iNfHHqaE",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737326164389,
+        "modifiedTime": 1737326185485,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/tsunami.json
+++ b/packs/core-moves/tsunami.json
@@ -4,10 +4,7 @@
   "_id": "2XaWuI8GW96AWkoR",
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "delay-2"
-    ],
+    "slug": "tsunami",
     "actions": [
       {
         "name": "Tsunami",
@@ -24,43 +21,100 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
-        "variant": null,
         "types": [
           "water"
         ],
         "category": "special",
         "power": 130,
         "accuracy": 70,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On resolution, the user loses -1 SPATK, SPDEF, and SPD Stages for 5 Activations.</p>"
+        "description": "<p>Effect: On resolution, the user loses -1 SPATK, SPDEF, and SPD Stages for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721319532650,
-    "modifiedTime": 1721319658257,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Tsunami",
+      "type": "passive",
+      "_id": "RAizk0E9lHKFcDwC",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "tsunami-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1JXumQz0QqthT9Iv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "tsunami-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "tsunami-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.HLAV9dhz632Rfp1K",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737326221719,
+        "modifiedTime": 1737326307549,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/turnabout.json
+++ b/packs/core-moves/turnabout.json
@@ -4,12 +4,7 @@
   "_id": "P2J1CVUTH03AzzTm",
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "aura",
-      "contact",
-      "pp-updated"
-    ],
+    "slug": "turnabout",
     "actions": [
       {
         "name": "Turnabout",
@@ -27,9 +22,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
         "types": [
           "normal"
@@ -38,13 +31,70 @@
         "power": 75,
         "accuracy": 90,
         "description": "<p>Effect: After this attack resolves, the user has a 10% chance of gaining ATK, DEF, SPATK, SPDEF and SPD Stage by 1 for 5 Activations.</p>",
-        "img": "systems/ptr2e/img/svg/normal_icon.svg"
+        "img": "systems/ptr2e/img/svg/normal_icon.svg",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "folder": ""
+  "effects": [
+    {
+      "name": "Turnabout",
+      "type": "passive",
+      "_id": "LixO8UO5lvWeDxK8",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "turnabout-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.rMNLqloV5nLmCLrZ",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737326360313,
+        "modifiedTime": 1737326382423,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/twineedle.json
+++ b/packs/core-moves/twineedle.json
@@ -4,13 +4,6 @@
   "img": "systems/ptr2e/img/svg/bug_icon.svg",
   "system": {
     "slug": "twineedle",
-    "description": "",
-    "traits": [
-      "2-strike",
-      "sharp",
-      "horn",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "twineedle",
@@ -29,10 +22,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 1
         },
         "category": "physical",
         "power": 25,
@@ -41,15 +31,71 @@
           "bug"
         ],
         "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[poison] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "rLMUMSSHkXGIqGab",
-  "effects": []
+  "effects": [
+    {
+      "name": "Twineedle",
+      "type": "passive",
+      "_id": "O9wgqQ9WFQJLEMdU",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "twineedle-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737326411109,
+        "modifiedTime": 1737326433842,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/v-create.json
+++ b/packs/core-moves/v-create.json
@@ -4,14 +4,6 @@
   "img": "systems/ptr2e/img/svg/fire_icon.svg",
   "system": {
     "slug": "v-create",
-    "description": "",
-    "traits": [
-      "dash",
-      "pass-6",
-      "legendary",
-      "defrost",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "v-create",
@@ -32,10 +24,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 9,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 9
         },
         "category": "physical",
         "power": 180,
@@ -44,15 +33,82 @@
           "fire"
         ],
         "description": "<p>Effect: The user loses -1 DEF and SPDEF Stages for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "53gsrIy5JCv0pJjV",
-  "effects": []
+  "effects": [
+    {
+      "name": "V-Create",
+      "type": "passive",
+      "_id": "0jG7V3QnGs7fMuuq",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "v-create-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "v-create-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737326537730,
+        "modifiedTime": 1737326616056,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/venom-drench.json
+++ b/packs/core-moves/venom-drench.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
     "slug": "venom-drench",
-    "description": "<p>Effect: Can only be used on a target with the @Affliction[poison] or @Affliction[blight] condition. The target's ATK, SPATK, and SPD Stages are reduced by -1 for 5 Activations.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "venom-drench",
@@ -23,27 +19,101 @@
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "status",
-        "power": null,
         "accuracy": 100,
         "types": [
           "poison"
         ],
         "description": "<p>Effect: Can only be used on a target with the @Affliction[poison] or @Affliction[blight] condition. The target's ATK, SPATK, and SPD Stages are reduced by -1 for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "AaE2M8OcbZpAGl1d",
-  "effects": []
+  "effects": [
+    {
+      "name": "Venom Drench",
+      "type": "passive",
+      "_id": "p9fUvtYy1VSA4ghz",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "venom-drench-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.ikCAv5w4iNfHHqaE",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "venom-drench-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1JXumQz0QqthT9Iv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "venom-drench-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.HLAV9dhz632Rfp1K",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737326687526,
+        "modifiedTime": 1737326751881,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/victory-dance.json
+++ b/packs/core-moves/victory-dance.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
     "slug": "victory-dance",
-    "description": "<p>Effect: The user gains +1 ATK, DEF, and SPD Stage for 5 Activations.</p>",
-    "traits": [
-      "dance",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "victory-dance",
@@ -20,32 +15,104 @@
         ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "fighting"
         ],
         "description": "<p>Effect: The user gains +1 ATK, DEF, and SPD Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "m0dvTLHCvut2nNPr",
-  "effects": []
+  "effects": [
+    {
+      "name": "Victory Dance",
+      "type": "passive",
+      "_id": "qDVAk5pT2ZVQo5Z4",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "victory-dance-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.ZGwaMlzUwkSuCPyH",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "victory-dance-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.sMystTj3FBJ00AZp",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "victory-dance-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLM",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737326798115,
+        "modifiedTime": 1737326866619,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/vile-nail.json
+++ b/packs/core-moves/vile-nail.json
@@ -4,13 +4,7 @@
   "_id": "M1KdLCchJqZknhKe",
   "img": "systems/ptr2e/img/svg/dark_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "crit-1",
-      "contact",
-      "horn",
-      "sharp"
-    ],
+    "slug": "vile-nail",
     "actions": [
       {
         "name": "Vile Nail",
@@ -30,43 +24,24 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "untyped"
         ],
         "category": "physical",
         "power": 60,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[poison] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[poison] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 13100000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1718735128644,
-    "modifiedTime": 1719979000418,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/virulent-vibe.json
+++ b/packs/core-moves/virulent-vibe.json
@@ -4,11 +4,7 @@
   "_id": "cBJvbvEEcNvdvMtZ",
   "img": "systems/ptr2e/img/svg/dark_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "aura",
-      "basic"
-    ],
+    "slug": "virulent-vibe",
     "actions": [
       {
         "name": "Virulent Vibe",
@@ -26,43 +22,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null
+          "powerPoints": 1
         },
-        "variant": null,
         "types": [
           "dark"
         ],
         "category": "special",
         "power": 35,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 10% chance of gaining @Affliction[fear] 5.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 10% chance of gaining @Affliction[fear] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 11100000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1718738305421,
-    "modifiedTime": 1719971994938,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Virulent Vibe",
+      "type": "passive",
+      "_id": "U0FgzURvRFloVavr",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "virulent-vibe-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.fearconditioitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737326948090,
+        "modifiedTime": 1737326966341,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/volt-tackle.json
+++ b/packs/core-moves/volt-tackle.json
@@ -4,13 +4,6 @@
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "system": {
     "slug": "volt-tackle",
-    "description": "",
-    "traits": [
-      "recoil-1-3",
-      "dash",
-      "push-2",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "volt-tackle",
@@ -30,10 +23,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 7
         },
         "category": "physical",
         "power": 120,
@@ -42,15 +32,71 @@
           "electric"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[paralysis] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "WLj5EwH05mdgKRez",
-  "effects": []
+  "effects": [
+    {
+      "name": "Volt Tackle",
+      "type": "passive",
+      "_id": "raAmoiwUqIAIc3la",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "volt-tackle-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737327030596,
+        "modifiedTime": 1737327052183,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/water-hammer.json
+++ b/packs/core-moves/water-hammer.json
@@ -4,11 +4,7 @@
   "_id": "jrzE3Z91OwBphf21",
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "crushing",
-      "contact"
-    ],
+    "slug": "water-hammer",
     "actions": [
       {
         "name": "Water Hammer",
@@ -26,43 +22,24 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
-        "variant": null,
         "types": [
           "water"
         ],
         "category": "physical",
         "power": 100,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the user loses -1 SPD Stage for 5 Activations.</p>"
+        "description": "<p>Effect: On hit, the user loses -1 SPD Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721319943047,
-    "modifiedTime": 1721320002166,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/web-ball.json
+++ b/packs/core-moves/web-ball.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/bug_icon.svg",
   "system": {
     "slug": "web-ball",
-    "description": "",
-    "traits": [
-      "missile"
-    ],
     "actions": [
       {
         "slug": "web-ball",
@@ -24,10 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 3
         },
         "category": "special",
         "power": 65,
@@ -36,15 +29,71 @@
           "bug"
         ],
         "description": "<p>Effect: On hit, the target loses -1 SPD Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "ub3a5v6pgoKDDI7x",
-  "effects": []
+  "effects": [
+    {
+      "name": "Web Ball",
+      "type": "passive",
+      "_id": "Rzx2ZTy85aEQ2hFv",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "web-ball-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.HLAV9dhz632Rfp1K",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737330498855,
+        "modifiedTime": 1737330521235,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/whiplash.json
+++ b/packs/core-moves/whiplash.json
@@ -4,8 +4,7 @@
   "_id": "pxM6ahlywPGdgKRd",
   "img": "systems/ptr2e/img/svg/grass_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [],
+    "slug": "whiplash",
     "actions": [
       {
         "name": "Whiplash",
@@ -20,43 +19,78 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "grass"
         ],
         "category": "physical",
         "power": 65,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[confused] 5.</p>"
+        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[confused] 5.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720797645046,
-    "modifiedTime": 1720797722100,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Whiplash",
+      "type": "passive",
+      "_id": "e3eLV22nDNJ0Suy1",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "whiplash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737330554885,
+        "modifiedTime": 1737330578176,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/whirling-rondé.json
+++ b/packs/core-moves/whirling-rondé.json
@@ -4,12 +4,7 @@
   "_id": "7rks31mDtXuY2MKb",
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "contact",
-      "dance",
-      "priority-1"
-    ],
+    "slug": "whirling-rondé",
     "actions": [
       {
         "name": "Whirling Rondé",
@@ -29,42 +24,78 @@
         "cost": {
           "activation": "complex",
           "powerPoints": 4,
-          "delay": null,
           "priority": 1
         },
-        "variant": null,
         "types": [
           "fairy"
         ],
         "category": "physical",
         "power": 55,
         "accuracy": 95,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets lose -1 SPATK Stage for 5 Activations.</p>"
+        "description": "<p>Effect: On hit, all valid targets lose -1 SPATK Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 11400000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1719587074437,
-    "modifiedTime": 1719979262907,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Whirling Rondé",
+      "type": "passive",
+      "_id": "lxHYaVudRk7bB2Gh",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "whirling-rondé",
+            "value": "Compendium.ptr2e.core-effects.Item.1JXumQz0QqthT9Iv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737331578526,
+        "modifiedTime": 1737331603670,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/wicked-torque.json
+++ b/packs/core-moves/wicked-torque.json
@@ -4,14 +4,6 @@
   "img": "systems/ptr2e/img/svg/dark_icon.svg",
   "system": {
     "slug": "wicked-torque",
-    "description": "",
-    "traits": [
-      "dash",
-      "pass-4",
-      "crash-1-2",
-      "contact",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "wicked-torque",
@@ -31,10 +23,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 5
         },
         "category": "physical",
         "power": 100,
@@ -43,15 +32,71 @@
           "dark"
         ],
         "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[drowsy] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "TWYwns2IOLQKn0tF",
-  "effects": []
+  "effects": [
+    {
+      "name": "Wicked Torque",
+      "type": "passive",
+      "_id": "7e7VGE8StJXkQ9VT",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "wicked-torque-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.drowsycondititem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737331631911,
+        "modifiedTime": 1737331660732,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/wild-shriek.json
+++ b/packs/core-moves/wild-shriek.json
@@ -4,12 +4,7 @@
   "_id": "tA3PiasZuKZIlvrW",
   "img": "systems/ptr2e/img/svg/grass_icon.svg",
   "system": {
-    "slug": null,
-    "traits": [
-      "sonic",
-      "delay-2",
-      "pp-updated"
-    ],
+    "slug": "wild-shriek",
     "actions": [
       {
         "name": "Wild Shriek",
@@ -28,43 +23,87 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null
+          "powerPoints": 7
         },
-        "variant": null,
         "types": [
           "grass"
         ],
         "category": "status",
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: All valid targets lose -2 SPDEF Stages for 5 Activations, and user gains +1 SPATK Stage for 5 Activations.</p>"
+        "description": "<p>Effect: All valid targets lose -2 SPDEF Stages for 5 Activations, and user gains +1 SPATK Stage for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "description": "",
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720810674304,
-    "modifiedTime": 1720810762766,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Wild Shriek",
+      "type": "passive",
+      "_id": "dqSaTP66bB3aEnPW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "wild-shriek-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.PYz1Z32uiXoulkW2",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "wild-shriek-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAa",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737332044592,
+        "modifiedTime": 1737332102506,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/mightyena-tactic.json
+++ b/packs/core-perks/mightyena-tactic.json
@@ -11,20 +11,15 @@
         "slug": "mightyena-tactic",
         "description": "<p>Gain +20 Power when attacking targets that have a net negative SPD stage.</p>",
         "traits": [],
-        "type": "generic",
+        "type": "passive",
         "range": {
           "target": "creature",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "simple",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "systems/ptr2e/img/perk-icons/Hunting.svg"
       }
     ],
     "slug": "mightyena-tactic",
@@ -39,7 +34,11 @@
     "nodes": [
       {
         "connected": [
-          "hamstring"
+          "hamstring",
+          "skirmish",
+          "quick-and-the-dead",
+          "run-down",
+          "improved-overland-9"
         ],
         "config": {
           "alpha": null,
@@ -58,9 +57,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },

--- a/packs/core-perks/resentment.json
+++ b/packs/core-perks/resentment.json
@@ -7,7 +7,7 @@
   "system": {
     "actions": [],
     "slug": "resentment",
-    "description": "<p>When your Shields are broken, you may spend 4PP to gain 2 ticks of Shields as a Free Action at [Interrupt 2].</p>",
+    "description": "<p>When your Shields are broken, you may spend 4PP to gain 2 ticks of Shields as a Complex Action at [Interrupt 2].</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 2,
@@ -37,9 +37,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },

--- a/packs/core-perks/venomous-stinger.json
+++ b/packs/core-perks/venomous-stinger.json
@@ -13,10 +13,33 @@
     "autoUnlock": [],
     "cost": 2,
     "webs": [
-      "Compendium.ptr2e.core-species.Item.BmuDohMAWcHopUmk"
+      "Compendium.ptr2e.core-species.Item.BmuDohMAWcHopUmk",
+      "Compendium.ptr2e.core-species.Item.qQqamSREK3YVGJih",
+      "Compendium.ptr2e.core-species.Item.7w0E5Uf9VC07c7OG",
+      "Compendium.ptr2e.core-species.Item.dNt6z45d0K3reNSu"
     ],
-    "global": false,
-    "nodes": []
+    "nodes": [
+      {
+        "x": 12,
+        "y": 15,
+        "connected": [
+          "evolution-weedle"
+        ],
+        "config": {
+          "alpha": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "borderWidth": null,
+          "texture": null,
+          "tint": null,
+          "scale": null
+        },
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ],
+    "slug": "venomous-stinger"
   },
   "img": "systems/ptr2e/img/perk-icons/Breeder.svg",
   "effects": [
@@ -75,6 +98,5 @@
     }
   ],
   "folder": "e9XnhZdjIE7hroYs",
-  "flags": {},
   "_id": "eZJbjxIaTYUydNy5"
 }

--- a/packs/core-species/beldum.json
+++ b/packs/core-species/beldum.json
@@ -29,10 +29,10 @@
     "traits": [
       "pokemon",
       "hover",
-      "underdog",
       "telepath",
       "telekinetic-2",
-      "magnetic"
+      "magnetic",
+      "em-sense-10"
     ],
     "abilities": {
       "starting": [
@@ -139,7 +139,7 @@
         "rvs": 0,
         "favourite": false,
         "hidden": false,
-        "group": "occult"
+        "group": null
       },
       {
         "slug": "running",
@@ -198,10 +198,6 @@
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "zen-headbutt",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
           "name": "iron-head",
           "gen": "ultra-sun-ultra-moon"
         },
@@ -212,6 +208,10 @@
         {
           "name": "tera-blast",
           "gen": "scarlet-violet"
+        },
+        {
+          "name": "zen-headbutt",
+          "gen": "ultra-sun-ultra-moon"
         }
       ],
       "levelUp": [
@@ -262,6 +262,10 @@
                 "item": null,
                 "level": null,
                 "knownMove": null
+              },
+              "perk": {
+                "x": 15,
+                "y": 15
               }
             }
           ],
@@ -270,17 +274,30 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.9EXS4qZZ1OH0aJrn"
+      "uuid": "Compendium.ptr2e.core-species.Item.9EXS4qZZ1OH0aJrn",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "industrial",
       "badland"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    },
+    "genderRatio": -1
   },
   "_id": "9EXS4qZZ1OH0aJrn",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/darmanitan-galarian.json
+++ b/packs/core-species/darmanitan-galarian.json
@@ -1,0 +1,697 @@
+{
+  "name": "darmanitan-galarian",
+  "type": "species",
+  "img": "systems/ptr2e/img/icons/species_icon.webp",
+  "system": {
+    "number": 555,
+    "form": "galarian",
+    "size": {
+      "category": "medium",
+      "type": "quad",
+      "height": 1.7,
+      "weight": 120
+    },
+    "diet": [
+      "herbivore"
+    ],
+    "movement": {
+      "primary": [
+        {
+          "type": "overland",
+          "value": 12
+        }
+      ],
+      "secondary": [
+        {
+          "type": "swim",
+          "value": 6
+        }
+      ]
+    },
+    "traits": [
+      "pokemon",
+      "chiller",
+      "freezer",
+      "semi-bipedal",
+      "underdog",
+      "fully-evolved"
+    ],
+    "abilities": {
+      "starting": [
+        {
+          "slug": "zen-mode"
+        }
+      ],
+      "basic": [
+        {
+          "slug": "cryogenic"
+        },
+        {
+          "slug": "vital-spirit"
+        }
+      ],
+      "advanced": [
+        {
+          "slug": "iron-fist"
+        },
+        {
+          "slug": "ice-body"
+        }
+      ],
+      "master": [
+        {
+          "slug": "mold-breaker"
+        },
+        {
+          "slug": "holiday-cheer"
+        }
+      ]
+    },
+    "skills": [
+      {
+        "slug": "acrobatics",
+        "value": 55,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "climb",
+        "value": 50,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "conversation",
+        "value": 50,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "intimidate",
+        "value": 40,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "lift",
+        "value": 55,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "listen",
+        "value": 40,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "natural-world",
+        "value": 25,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "negotiation",
+        "value": 35,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "running",
+        "value": 45,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "spot",
+        "value": 45,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "stealth",
+        "value": 35,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "survival",
+        "value": 35,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
+        "slug": "swim",
+        "value": 35,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      }
+    ],
+    "slug": "darmanitan",
+    "stats": {
+      "hp": 105,
+      "atk": 140,
+      "def": 55,
+      "spa": 30,
+      "spd": 55,
+      "spe": 95
+    },
+    "types": [
+      "ice"
+    ],
+    "moves": {
+      "levelUp": [
+        {
+          "name": "icicle-crash",
+          "gen": "sword-shield",
+          "level": 0
+        },
+        {
+          "name": "bite",
+          "gen": "sword-shield",
+          "level": 1
+        },
+        {
+          "name": "powder-snow",
+          "gen": "sword-shield",
+          "level": 1
+        },
+        {
+          "name": "tackle",
+          "gen": "sword-shield",
+          "level": 1
+        },
+        {
+          "name": "taunt",
+          "gen": "sword-shield",
+          "level": 1
+        },
+        {
+          "name": "avalanche",
+          "gen": "sword-shield",
+          "level": 12
+        },
+        {
+          "name": "work-up",
+          "gen": "sword-shield",
+          "level": 16
+        },
+        {
+          "name": "ice-fang",
+          "gen": "sword-shield",
+          "level": 20
+        },
+        {
+          "name": "headbutt",
+          "gen": "sword-shield",
+          "level": 24
+        },
+        {
+          "name": "ice-punch",
+          "gen": "sword-shield",
+          "level": 28
+        },
+        {
+          "name": "uproar",
+          "gen": "sword-shield",
+          "level": 32
+        },
+        {
+          "name": "belly-drum",
+          "gen": "sword-shield",
+          "level": 38
+        },
+        {
+          "name": "blizzard",
+          "gen": "sword-shield",
+          "level": 44
+        },
+        {
+          "name": "thrash",
+          "gen": "sword-shield",
+          "level": 50
+        },
+        {
+          "name": "superpower",
+          "gen": "sword-shield",
+          "level": 56
+        }
+      ],
+      "tutor": [
+        {
+          "name": "attract",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "avalanche",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "blizzard",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "body-press",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "body-slam",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "brick-break",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "bulk-up",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "bulldoze",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "burning-jealousy",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "dig",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "earthquake",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "encore",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "endure",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "facade",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "fire-blast",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "fire-fang",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "fire-punch",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "fire-spin",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "flamethrower",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "flare-blitz",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "focus-blast",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "focus-energy",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "giga-impact",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "grass-knot",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "gyro-ball",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "heat-wave",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "hyper-beam",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "ice-beam",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "ice-fang",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "ice-punch",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "iron-defense",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "iron-head",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "lash-out",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "mega-kick",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "mega-punch",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "overheat",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "payback",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "protect",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "psychic",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "rest",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "reversal",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "rock-slide",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "rock-tomb",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "snore",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "solar-beam",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "stone-edge",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "substitute",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "superpower",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "taunt",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "thief",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "u-turn",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "uproar",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "will-o-wisp",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "work-up",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "zen-headbutt",
+          "gen": "sword-shield"
+        }
+      ]
+    },
+    "captureRate": 60,
+    "eggGroups": [
+      "ground"
+    ],
+    "genderRatio": 4,
+    "habitats": [],
+    "evolutions": {
+      "name": "darumaka-galarian",
+      "details": null,
+      "evolutions": [
+        {
+          "name": "darmanitan-galarian",
+          "uuid": "Compendium.ptr2e.core-species.Item.gYXT4R9q1Fk21SZ5",
+          "methods": [
+            {
+              "type": "level",
+              "level": 35,
+              "operand": "or"
+            },
+            {
+              "type": "item",
+              "item": "ice-stone",
+              "operand": "or",
+              "held": false
+            }
+          ],
+          "details": {
+            "gender": null,
+            "item": null,
+            "level": null,
+            "knownMove": null
+          },
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
+        }
+      ],
+      "uuid": "Compendium.ptr2e.core-species.Item.OxiRikjnbwrn4hqS",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "gYXT4R9q1Fk21SZ5",
+  "effects": [
+    {
+      "name": "Zen Mode",
+      "type": "form",
+      "_id": "2WYmMQXTrM8Mfjk3",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:zen-mode:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Zen Mode Forme",
+            "predicate": [],
+            "alwaysActive": false,
+            "count": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "state": false
+          },
+          {
+            "type": "basic",
+            "predicate": [
+              "forme:zen-mode:active"
+            ],
+            "key": "system.type.types",
+            "value": "fire",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "predicate": [
+              "forme:zen-mode:active"
+            ],
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.fmuCUbeLJbHsVIMM",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "basic",
+            "predicate": [
+              "forme:zen-mode:active"
+            ],
+            "key": "system.details.size.height",
+            "value": 0.4,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "predicate": [
+              "forme:zen-mode:active"
+            ],
+            "key": "system.details.size.weight",
+            "value": 27.1,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "stats-alteration",
+            "predicate": [
+              "forme:zen-mode:active"
+            ],
+            "key": "",
+            "value": 0,
+            "hp": null,
+            "atk": 20,
+            "def": null,
+            "spa": null,
+            "spd": null,
+            "spe": 40,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "suppress-ability",
+            "predicate": [
+              "forme:zen-mode:active"
+            ],
+            "key": "sheer-force",
+            "value": 0,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1735660426098,
+        "modifiedTime": 1737331885760,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
+}

--- a/packs/core-species/dusclops.json
+++ b/packs/core-species/dusclops.json
@@ -32,10 +32,8 @@
       "darkvision-15",
       "invisibility",
       "phasing",
-      "black-hole",
       "bipedal",
-      "aura",
-      "underdog"
+      "aura"
     ],
     "abilities": {
       "starting": [
@@ -97,6 +95,14 @@
         "group": null
       },
       {
+        "slug": "ghost",
+        "value": 45,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
         "slug": "intimidate",
         "value": 45,
         "rvs": 0,
@@ -145,24 +151,16 @@
         "group": null
       },
       {
-        "slug": "ghost",
-        "value": 45,
+        "slug": "running",
+        "value": 30,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
-        "group": "occult"
+        "group": null
       },
       {
         "slug": "spiritual",
         "value": 50,
-        "rvs": 0,
-        "favourite": false,
-        "hidden": false,
-        "group": "occult"
-      },
-      {
-        "slug": "running",
-        "value": 30,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -208,287 +206,31 @@
     "moves": {
       "tutor": [
         {
-          "name": "haze",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "pain-split",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "memento",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "mega-punch",
-          "gen": "firered-leafgreen"
-        },
-        {
-          "name": "mega-kick",
-          "gen": "firered-leafgreen"
-        },
-        {
-          "name": "headbutt",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "body-slam",
-          "gen": "xd"
-        },
-        {
-          "name": "double-edge",
-          "gen": "xd"
-        },
-        {
-          "name": "counter",
-          "gen": "firered-leafgreen"
-        },
-        {
-          "name": "seismic-toss",
-          "gen": "xd"
-        },
-        {
-          "name": "mimic",
-          "gen": "xd"
-        },
-        {
-          "name": "metronome",
-          "gen": "firered-leafgreen"
-        },
-        {
-          "name": "dream-eater",
-          "gen": "xd"
-        },
-        {
-          "name": "rock-slide",
-          "gen": "firered-leafgreen"
-        },
-        {
-          "name": "substitute",
-          "gen": "xd"
-        },
-        {
-          "name": "nightmare",
-          "gen": "xd"
-        },
-        {
-          "name": "snore",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "spite",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "mud-slap",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "icy-wind",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "endure",
-          "gen": "emerald"
-        },
-        {
-          "name": "swagger",
-          "gen": "xd"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "dynamic-punch",
-          "gen": "emerald"
-        },
-        {
-          "name": "psych-up",
-          "gen": "emerald"
-        },
-        {
-          "name": "focus-punch",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "trick",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "skill-swap",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "snatch",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "sucker-punch",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "dark-pulse",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "ominous-wind",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "wonder-room",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "telekinesis",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
           "name": "ally-switch",
           "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "skitter-smack",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "poltergeist",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "ice-beam",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "blizzard",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "hyper-beam",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "strength",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "earthquake",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "toxic",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "psychic",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "double-team",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "leech-life",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "flash",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "rest",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "thief",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "protect",
-          "gen": "scarlet-violet"
         },
         {
           "name": "attract",
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
-          "name": "return",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "frustration",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "hidden-power",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "rain-dance",
+          "name": "blizzard",
           "gen": "scarlet-violet"
         },
         {
-          "name": "sunny-day",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-smash",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "torment",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "facade",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "taunt",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "helping-hand",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "revenge",
-          "gen": "sword-shield"
+          "name": "body-slam",
+          "gen": "xd"
         },
         {
           "name": "brick-break",
           "gen": "scarlet-violet"
         },
         {
-          "name": "imprison",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "rock-tomb",
+          "name": "bulldoze",
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
           "name": "calm-mind",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "natural-gift",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "embargo",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "giga-impact",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "trick-room",
           "gen": "scarlet-violet"
         },
         {
@@ -500,139 +242,395 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "round",
-          "gen": "sword-shield"
+          "name": "confide",
+          "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "bulldoze",
+          "name": "counter",
+          "gen": "firered-leafgreen"
+        },
+        {
+          "name": "dark-pulse",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "double-edge",
+          "gen": "xd"
+        },
+        {
+          "name": "double-team",
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
-          "name": "phantom-force",
+          "name": "dream-eater",
+          "gen": "xd"
+        },
+        {
+          "name": "dynamic-punch",
+          "gen": "emerald"
+        },
+        {
+          "name": "earthquake",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "embargo",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "endure",
+          "gen": "emerald"
+        },
+        {
+          "name": "facade",
           "gen": "scarlet-violet"
         },
         {
-          "name": "confide",
+          "name": "flash",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "focus-punch",
           "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "frustration",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "giga-impact",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "haze",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "headbutt",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "helping-hand",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "hidden-power",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "hyper-beam",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "ice-beam",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "icy-wind",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "imprison",
+          "gen": "scarlet-violet"
         },
         {
           "name": "infestation",
           "gen": "ultra-sun-ultra-moon"
         },
         {
+          "name": "leech-life",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "mega-kick",
+          "gen": "firered-leafgreen"
+        },
+        {
+          "name": "mega-punch",
+          "gen": "firered-leafgreen"
+        },
+        {
+          "name": "memento",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "metronome",
+          "gen": "firered-leafgreen"
+        },
+        {
+          "name": "mimic",
+          "gen": "xd"
+        },
+        {
+          "name": "mud-slap",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "natural-gift",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "nightmare",
+          "gen": "xd"
+        },
+        {
+          "name": "ominous-wind",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "pain-split",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "phantom-force",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "poltergeist",
+          "gen": "sword-shield"
+        },
+        {
           "name": "power-up-punch",
           "gen": "omega-ruby-alpha-sapphire"
         },
         {
+          "name": "protect",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "psych-up",
+          "gen": "emerald"
+        },
+        {
+          "name": "psychic",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rain-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rest",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "return",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "revenge",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "rock-slide",
+          "gen": "firered-leafgreen"
+        },
+        {
+          "name": "rock-smash",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "rock-tomb",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "seismic-toss",
+          "gen": "xd"
+        },
+        {
+          "name": "skill-swap",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "skitter-smack",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "snatch",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "spite",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "strength",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "substitute",
+          "gen": "xd"
+        },
+        {
+          "name": "sucker-punch",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "swagger",
+          "gen": "xd"
+        },
+        {
+          "name": "taunt",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "telekinesis",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
           "name": "tera-blast",
           "gen": "scarlet-violet"
+        },
+        {
+          "name": "thief",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "torment",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "toxic",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "trick",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "trick-room",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "wonder-room",
+          "gen": "ultra-sun-ultra-moon"
         }
       ],
       "levelUp": [
         {
-          "name": "fire-punch",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "ice-punch",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "thunder-punch",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "bind",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "leer",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "disable",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "name": "shadow-punch",
+          "gen": "scarlet-violet",
+          "level": 0
         },
         {
           "name": "astonish",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "bind",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "disable",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "fire-punch",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "gravity",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "ice-punch",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "leer",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "shadow-sneak",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "thunder-punch",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "confuse-ray",
-          "level": 12,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 12
         },
         {
           "name": "foresight",
-          "level": 14,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 14
         },
         {
           "name": "night-shade",
-          "level": 16,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 16
         },
         {
           "name": "payback",
-          "level": 20,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 20
         },
         {
           "name": "pursuit",
-          "level": 22,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 22
         },
         {
           "name": "will-o-wisp",
-          "level": 24,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 24
         },
         {
           "name": "mean-look",
-          "level": 28,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 28
         },
         {
           "name": "hex",
-          "level": 32,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 32
         },
         {
           "name": "curse",
-          "level": 36,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 36
         },
         {
           "name": "shadow-ball",
-          "level": 42,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 42
         },
         {
           "name": "future-sight",
-          "level": 48,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "shadow-punch",
-          "level": 0,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 48
         }
       ]
     },
@@ -684,21 +682,37 @@
                 "level": null,
                 "knownMove": null
               },
-              "evolutions": []
+              "evolutions": [],
+              "perk": {
+                "x": 15,
+                "y": 15
+              }
             }
-          ]
+          ],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.NRLM4OLKyc5fyeQ6"
+      "uuid": "Compendium.ptr2e.core-species.Item.NRLM4OLKyc5fyeQ6",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "forest",
       "woodland",
       "badland",
       "ruin"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "AHcoRwAZ2zheJlfe",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/dusknoir.json
+++ b/packs/core-species/dusknoir.json
@@ -32,7 +32,6 @@
       "darkvision-15",
       "invisibility",
       "phasing",
-      "black-hole",
       "medium",
       "hover",
       "aura"
@@ -97,6 +96,14 @@
         "group": null
       },
       {
+        "slug": "ghost",
+        "value": 60,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
         "slug": "intimidate",
         "value": 60,
         "rvs": 0,
@@ -145,24 +152,16 @@
         "group": null
       },
       {
-        "slug": "ghost",
-        "value": 60,
+        "slug": "running",
+        "value": 45,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
-        "group": "occult"
+        "group": null
       },
       {
         "slug": "spiritual",
         "value": 70,
-        "rvs": 0,
-        "favourite": false,
-        "hidden": false,
-        "group": "occult"
-      },
-      {
-        "slug": "running",
-        "value": 45,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -208,275 +207,31 @@
     "moves": {
       "tutor": [
         {
-          "name": "haze",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "pain-split",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "memento",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "headbutt",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "snore",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "spite",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "mud-slap",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "icy-wind",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "focus-punch",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "trick",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "skill-swap",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "snatch",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "sucker-punch",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "dark-pulse",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "ominous-wind",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "wonder-room",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "telekinesis",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
           "name": "ally-switch",
           "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "laser-focus",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "skitter-smack",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "poltergeist",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "mega-punch",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "mega-kick",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "body-slam",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "ice-beam",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "blizzard",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "hyper-beam",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "strength",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "earthquake",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "toxic",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "psychic",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "double-team",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "metronome",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "swift",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "dream-eater",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "leech-life",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "flash",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "rest",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-slide",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "substitute",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "thief",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "protect",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "endure",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "swagger",
-          "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
           "name": "attract",
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
-          "name": "return",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "frustration",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "hidden-power",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "rain-dance",
+          "name": "blizzard",
           "gen": "scarlet-violet"
         },
         {
-          "name": "sunny-day",
+          "name": "body-slam",
           "gen": "scarlet-violet"
-        },
-        {
-          "name": "psych-up",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-smash",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "torment",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "facade",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "taunt",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "helping-hand",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "revenge",
-          "gen": "sword-shield"
         },
         {
           "name": "brick-break",
           "gen": "scarlet-violet"
         },
         {
-          "name": "imprison",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "rock-tomb",
-          "gen": "scarlet-violet"
+          "name": "bulldoze",
+          "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
           "name": "calm-mind",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "natural-gift",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "embargo",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "focus-blast",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "giga-impact",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "trick-room",
           "gen": "scarlet-violet"
         },
         {
@@ -488,157 +243,401 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "round",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "bulldoze",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "phantom-force",
-          "gen": "scarlet-violet"
-        },
-        {
           "name": "confide",
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "infestation",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "power-up-punch",
-          "gen": "omega-ruby-alpha-sapphire"
+          "name": "dark-pulse",
+          "gen": "black-2-white-2"
         },
         {
           "name": "darkest-lariat",
           "gen": "sword-shield"
         },
         {
-          "name": "tera-blast",
+          "name": "double-team",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "dream-eater",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "earthquake",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "embargo",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "endure",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "facade",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "flash",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "focus-blast",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "focus-punch",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "frustration",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "giga-impact",
           "gen": "scarlet-violet"
         },
         {
           "name": "hard-press",
           "gen": "scarlet-violet"
+        },
+        {
+          "name": "haze",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "headbutt",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "helping-hand",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "hidden-power",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "hyper-beam",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "ice-beam",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "icy-wind",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "imprison",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "infestation",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "laser-focus",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "leech-life",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "mega-kick",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "mega-punch",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "memento",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "metronome",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "mud-slap",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "natural-gift",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "ominous-wind",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "pain-split",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "phantom-force",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "poltergeist",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "power-up-punch",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "protect",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "psych-up",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "psychic",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rain-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rest",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "return",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "revenge",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "rock-slide",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rock-smash",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "rock-tomb",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "skill-swap",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "skitter-smack",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "snatch",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "spite",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "strength",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "substitute",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sucker-punch",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "swagger",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "swift",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "taunt",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "telekinesis",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "tera-blast",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "thief",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "torment",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "toxic",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "trick",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "trick-room",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "wonder-room",
+          "gen": "ultra-sun-ultra-moon"
         }
       ],
       "levelUp": [
         {
           "name": "reaper-fist",
-          "level": 0,
-          "gen": "dev"
-        },
-        {
-          "name": "fire-punch",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "ice-punch",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "thunder-punch",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "bind",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "leer",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "disable",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "dev",
+          "level": 0
         },
         {
           "name": "astonish",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
-          "name": "shadow-punch",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "name": "bind",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "disable",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "fire-punch",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "gravity",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "ice-punch",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "leer",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "shadow-punch",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "shadow-sneak",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "thunder-punch",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "confuse-ray",
-          "level": 12,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 12
         },
         {
           "name": "foresight",
-          "level": 14,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 14
         },
         {
           "name": "night-shade",
-          "level": 16,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 16
         },
         {
           "name": "payback",
-          "level": 20,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 20
         },
         {
           "name": "pursuit",
-          "level": 22,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 22
         },
         {
           "name": "will-o-wisp",
-          "level": 24,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 24
         },
         {
           "name": "mean-look",
-          "level": 28,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 28
         },
         {
           "name": "hex",
-          "level": 32,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 32
         },
         {
           "name": "curse",
-          "level": 36,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 36
         },
         {
           "name": "shadow-ball",
-          "level": 42,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 42
         },
         {
           "name": "future-sight",
-          "level": 48,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 48
         },
         {
           "name": "destiny-bond",
-          "level": 54,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 54
         }
       ]
     },
@@ -684,7 +683,11 @@
                 "level": null,
                 "knownMove": null
               },
-              "evolutions": []
+              "evolutions": [],
+              "perk": {
+                "x": 15,
+                "y": 15
+              }
             }
           ],
           "details": {
@@ -692,19 +695,31 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.NRLM4OLKyc5fyeQ6"
+      "uuid": "Compendium.ptr2e.core-species.Item.NRLM4OLKyc5fyeQ6",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "forest",
       "woodland",
       "badland",
       "ruin"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "N0qK5vxpzw3opgHT",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/klang.json
+++ b/packs/core-species/klang.json
@@ -55,7 +55,7 @@
           "slug": "multi-headed"
         },
         {
-          "slug": "heavy-metal"
+          "slug": "clear-body"
         }
       ],
       "master": [
@@ -461,15 +461,31 @@
                 "level": null,
                 "knownMove": null
               },
-              "evolutions": []
+              "evolutions": [],
+              "perk": {
+                "x": 15,
+                "y": 15
+              }
             }
-          ]
+          ],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.TbebZS305DlE03eW"
+      "uuid": "Compendium.ptr2e.core-species.Item.TbebZS305DlE03eW",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "fOGWSu1iPXZosliW",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/klink.json
+++ b/packs/core-species/klink.json
@@ -55,7 +55,7 @@
           "slug": "multi-headed"
         },
         {
-          "slug": "heavy-metal"
+          "slug": "clear-body"
         }
       ],
       "master": [
@@ -457,15 +457,31 @@
                 "level": null,
                 "knownMove": null
               },
-              "evolutions": []
+              "evolutions": [],
+              "perk": {
+                "x": 15,
+                "y": 15
+              }
             }
-          ]
+          ],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.TbebZS305DlE03eW"
+      "uuid": "Compendium.ptr2e.core-species.Item.TbebZS305DlE03eW",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "TbebZS305DlE03eW",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/klinklang.json
+++ b/packs/core-species/klinklang.json
@@ -55,7 +55,7 @@
           "slug": "multi-headed"
         },
         {
-          "slug": "heavy-metal"
+          "slug": "clear-body"
         }
       ],
       "master": [
@@ -482,7 +482,11 @@
                 "level": null,
                 "knownMove": null
               },
-              "evolutions": []
+              "evolutions": [],
+              "perk": {
+                "x": 15,
+                "y": 15
+              }
             }
           ],
           "details": {
@@ -490,13 +494,25 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.TbebZS305DlE03eW"
+      "uuid": "Compendium.ptr2e.core-species.Item.TbebZS305DlE03eW",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "3UMuIyKBG6VEaWyl",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/metagross.json
+++ b/packs/core-species/metagross.json
@@ -672,6 +672,10 @@
                 "item": null,
                 "level": null,
                 "knownMove": null
+              },
+              "perk": {
+                "x": 15,
+                "y": 15
               }
             }
           ],
@@ -680,17 +684,30 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.9EXS4qZZ1OH0aJrn"
+      "uuid": "Compendium.ptr2e.core-species.Item.9EXS4qZZ1OH0aJrn",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "industrial",
       "badland"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    },
+    "genderRatio": -1
   },
   "_id": "snjGvdgpWVBFEdFr",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/metang.json
+++ b/packs/core-species/metang.json
@@ -29,10 +29,10 @@
     "traits": [
       "pokemon",
       "hover",
-      "underdog",
       "telepath",
       "magnetic",
-      "telekinetic-4"
+      "telekinetic-4",
+      "em-sense-15"
     ],
     "abilities": {
       "starting": [
@@ -139,7 +139,7 @@
         "rvs": 0,
         "favourite": false,
         "hidden": false,
-        "group": "occult"
+        "group": null
       },
       {
         "slug": "running",
@@ -190,280 +190,20 @@
     "moves": {
       "tutor": [
         {
-          "name": "ice-punch",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "thunder-punch",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "headbutt",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "body-slam",
-          "gen": "xd"
-        },
-        {
-          "name": "double-edge",
-          "gen": "xd"
-        },
-        {
-          "name": "mimic",
-          "gen": "xd"
-        },
-        {
-          "name": "defense-curl",
-          "gen": "emerald"
-        },
-        {
-          "name": "self-destruct",
-          "gen": "xd"
-        },
-        {
-          "name": "swift",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "explosion",
-          "gen": "firered-leafgreen"
-        },
-        {
-          "name": "rock-slide",
-          "gen": "firered-leafgreen"
-        },
-        {
-          "name": "substitute",
-          "gen": "xd"
-        },
-        {
-          "name": "snore",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "mud-slap",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "icy-wind",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "endure",
-          "gen": "emerald"
-        },
-        {
-          "name": "rollout",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "swagger",
-          "gen": "xd"
-        },
-        {
-          "name": "fury-cutter",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "dynamic-punch",
-          "gen": "emerald"
-        },
-        {
-          "name": "psych-up",
-          "gen": "emerald"
-        },
-        {
-          "name": "trick",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "signal-beam",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "gravity",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "iron-head",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "stealth-rock",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "telekinesis",
-          "gen": "ultra-sun-ultra-moon"
+          "name": "aerial-ace",
+          "gen": "scarlet-violet"
         },
         {
           "name": "ally-switch",
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "steel-beam",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "expanding-force",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "steel-roller",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "meteor-beam",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "cut",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "strength",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "earthquake",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "toxic",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "double-team",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "light-screen",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "reflect",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "flash",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "rest",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "protect",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sludge-bomb",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sandstorm",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "return",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "frustration",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "hidden-power",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "rain-dance",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sunny-day",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "shadow-ball",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "future-sight",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-smash",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "facade",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "focus-punch",
-          "gen": "scarlet-violet"
+          "name": "body-slam",
+          "gen": "xd"
         },
         {
           "name": "brick-break",
           "gen": "scarlet-violet"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "rock-tomb",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "cosmic-power",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "aerial-ace",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "gyro-ball",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "natural-gift",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "rock-polish",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "giga-impact",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "psycho-cut",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "grass-knot",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "psyshock",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "heavy-slam",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "round",
-          "gen": "sword-shield"
         },
         {
           "name": "bulldoze",
@@ -474,15 +214,83 @@
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "power-up-punch",
-          "gen": "omega-ruby-alpha-sapphire"
+          "name": "cosmic-power",
+          "gen": "sword-shield"
         },
         {
-          "name": "tera-blast",
+          "name": "cut",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "defense-curl",
+          "gen": "emerald"
+        },
+        {
+          "name": "double-edge",
+          "gen": "xd"
+        },
+        {
+          "name": "double-team",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "dynamic-punch",
+          "gen": "emerald"
+        },
+        {
+          "name": "earthquake",
           "gen": "scarlet-violet"
         },
         {
-          "name": "trailblaze",
+          "name": "endure",
+          "gen": "emerald"
+        },
+        {
+          "name": "expanding-force",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "explosion",
+          "gen": "firered-leafgreen"
+        },
+        {
+          "name": "facade",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "flash",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "focus-punch",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "frustration",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "fury-cutter",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "future-sight",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "giga-impact",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "grass-knot",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "gravity",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "gyro-ball",
           "gen": "scarlet-violet"
         },
         {
@@ -490,95 +298,287 @@
           "gen": "scarlet-violet"
         },
         {
+          "name": "headbutt",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "heavy-slam",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "hidden-power",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "ice-punch",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "icy-wind",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "iron-head",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "light-screen",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "meteor-beam",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "mimic",
+          "gen": "xd"
+        },
+        {
+          "name": "mud-slap",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "natural-gift",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "power-up-punch",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "protect",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "psych-up",
+          "gen": "emerald"
+        },
+        {
           "name": "psychic-noise",
           "gen": "scarlet-violet"
+        },
+        {
+          "name": "psycho-cut",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "psyshock",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rain-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "reflect",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rest",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "return",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "rock-polish",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "rock-slide",
+          "gen": "firered-leafgreen"
+        },
+        {
+          "name": "rock-smash",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "rock-tomb",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rollout",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "sandstorm",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "self-destruct",
+          "gen": "xd"
+        },
+        {
+          "name": "shadow-ball",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "signal-beam",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "sludge-bomb",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "stealth-rock",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "steel-beam",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "steel-roller",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "strength",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "substitute",
+          "gen": "xd"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "swagger",
+          "gen": "xd"
+        },
+        {
+          "name": "swift",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "telekinesis",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "tera-blast",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "thunder-punch",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "toxic",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "trailblaze",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "trick",
+          "gen": "ultra-sun-ultra-moon"
         }
       ],
       "levelUp": [
         {
-          "name": "tackle",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "bullet-punch",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "hone-claws",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "zen-headbutt",
-          "level": 6,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "magnet-rise",
-          "level": 12,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "take-down",
-          "level": 26,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "miracle-eye",
-          "level": 29,
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "hyper-beam",
-          "level": 74,
-          "gen": "scarlet-violet"
-        },
-        {
           "name": "confusion",
-          "level": 0,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "flash-cannon",
-          "level": 18,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "pursuit",
-          "level": 23,
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "psychic",
-          "level": 34,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "scary-face",
-          "level": 42,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "meteor-mash",
-          "level": 50,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "iron-defense",
-          "level": 58,
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "agility",
-          "level": 66,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 0
         },
         {
           "name": "metal-claw",
-          "level": 0,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 0
+        },
+        {
+          "name": "bullet-punch",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "hone-claws",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "tackle",
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "zen-headbutt",
+          "gen": "scarlet-violet",
+          "level": 6
+        },
+        {
+          "name": "magnet-rise",
+          "gen": "scarlet-violet",
+          "level": 12
+        },
+        {
+          "name": "flash-cannon",
+          "gen": "scarlet-violet",
+          "level": 18
+        },
+        {
+          "name": "pursuit",
+          "gen": "ultra-sun-ultra-moon",
+          "level": 23
+        },
+        {
+          "name": "take-down",
+          "gen": "scarlet-violet",
+          "level": 26
+        },
+        {
+          "name": "miracle-eye",
+          "gen": "ultra-sun-ultra-moon",
+          "level": 29
+        },
+        {
+          "name": "psychic",
+          "gen": "scarlet-violet",
+          "level": 34
+        },
+        {
+          "name": "scary-face",
+          "gen": "scarlet-violet",
+          "level": 42
+        },
+        {
+          "name": "meteor-mash",
+          "gen": "scarlet-violet",
+          "level": 50
+        },
+        {
+          "name": "iron-defense",
+          "gen": "scarlet-violet",
+          "level": 58
+        },
+        {
+          "name": "agility",
+          "gen": "scarlet-violet",
+          "level": 66
+        },
+        {
+          "name": "hyper-beam",
+          "gen": "scarlet-violet",
+          "level": 74
         }
       ]
     },
@@ -617,6 +617,10 @@
                 "item": null,
                 "level": null,
                 "knownMove": null
+              },
+              "perk": {
+                "x": 15,
+                "y": 15
               }
             }
           ],
@@ -625,17 +629,30 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.9EXS4qZZ1OH0aJrn"
+      "uuid": "Compendium.ptr2e.core-species.Item.9EXS4qZZ1OH0aJrn",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "industrial",
       "badland"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    },
+    "genderRatio": -1
   },
   "_id": "zD676fttCy7AwPLG",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/onix.json
+++ b/packs/core-species/onix.json
@@ -31,7 +31,8 @@
       "serpentine",
       "breathless",
       "tremorsense-15",
-      "underdog"
+      "direction-sense",
+      "em-sense-15"
     ],
     "abilities": {
       "starting": [
@@ -585,11 +586,19 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
       "uuid": "Compendium.ptr2e.core-species.Item.EkhJeHPiORiRxysb",
-      "methods": []
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "_migration": {
       "version": null,

--- a/packs/core-species/relicanth.json
+++ b/packs/core-species/relicanth.json
@@ -510,13 +510,22 @@
     "evolutions": {
       "name": "relicanth",
       "details": null,
-      "evolutions": []
+      "evolutions": [],
+      "uuid": null,
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "abyss"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "8UOxV0dUEyAgwBw9",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/steelix.json
+++ b/packs/core-species/steelix.json
@@ -31,7 +31,9 @@
       "serpentine",
       "breathless",
       "tremorsense-15",
-      "fully-evolved"
+      "fully-evolved",
+      "direction-sense",
+      "em-sense-15"
     ],
     "abilities": {
       "starting": [
@@ -618,11 +620,19 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
       "uuid": "Compendium.ptr2e.core-species.Item.EkhJeHPiORiRxysb",
-      "methods": []
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "_migration": {
       "version": null,
@@ -886,74 +896,6 @@
         "createdTime": 1733849401562,
         "modifiedTime": 1733856065105,
         "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
-    },
-    {
-      "name": "Breathless",
-      "type": "passive",
-      "system": {
-        "changes": [
-          {
-            "type": "roll-option",
-            "domain": "immunities",
-            "value": "trait:powder",
-            "key": "",
-            "mode": 2,
-            "priority": null,
-            "predicate": [],
-            "ignored": false,
-            "suboptions": [],
-            "state": true
-          },
-          {
-            "type": "roll-option",
-            "domain": "immunities",
-            "value": "trait:gas",
-            "key": "",
-            "mode": 2,
-            "priority": null,
-            "predicate": [],
-            "ignored": false,
-            "suboptions": [],
-            "state": true
-          }
-        ],
-        "traits": [
-          "breathless"
-        ],
-        "slug": null,
-        "removeAfterCombat": true,
-        "removeOnRecall": false,
-        "stacks": 0
-      },
-      "_id": null,
-      "img": null,
-      "disabled": false,
-      "duration": {
-        "startTime": null,
-        "seconds": null,
-        "combat": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
-      },
-      "description": "",
-      "origin": null,
-      "tint": "#ffffff",
-      "transfer": true,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "coreVersion": "12.331",
-        "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
-        "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
-        "compendiumSource": null,
-        "duplicateSource": null
       }
     }
   ]


### PR DESCRIPTION
Over 120 move automations, plus some species, perk and ability fixes.
- Update Species: onix
- Update Species: steelix
- Update Move: Neurotoxin
- Update Move: Night Storm
- Update Move: No Retreat
- Update Move: Noble Roar
- Update Move: Noxious Acid
- Update Move: Noxious Torque
- Update Move: Oblivion Wing
- Update Perk: Venomous Stinger
- Update Move: Steel Roller
- Update Effect: Friend Guard DR
- Update Species: dusclops
- Update Species: dusknoir
- Update Move: Oceanic Operetta
- Update Move: Octazooka
- Update Move: Overheat
- Update Move: Pacify
- Update Move: Parasite Swarm
- Update Move: Parting Shot
- Update Move: Pastel Punch
- Update Move: Pepper Powder
- Update Move: Perish Song
- Update Move: Phantom Pain
- Update Move: Piercing Drone
- Update Move: Leer
- Update Move: Pixie Tail
- Update Move: Pixie Pummel
- Update Move: Plasma Blaster
- Update Move: Plasma Pulse
- Update Move: Power Chord
- Update Move: Psy Punch
- Update Move: Psychic Noise
- Update Move: Psycho Boost
- Update Move: Psyshield Bash
- Update Move: Psystrike
- Update Move: Puzzle Powder
- Update Move: Pyro Ball
- Update Move: Pyro Rend
- Update Move: Radiant Claw
- Update Move: Rage Powder
- Update Move: Roar
- Update Move: Rock Climb
- Update Move: Rock Polish
- Update Move: Rocky Rebuff
- Update Move: Rot Cloud
- Update Move: Ruby Beam
- Update Move: Rust Breath
- Update Move: Salt Crash
- Update Move: Sapphire Beam
- Update Move: Sappy Seed
- Update Move: Scald
- Update Perk: Mightyena Tactic
- Update Move: Schadenfreude
- Update Move: Sea Shanty
- Update Move: Secret Sword
- Update Move: Sediment Smother
- Update Move: Seed Flare
- Update Move: Seismic Fist
- Update Move: Shadow Bolt
- Update Move: Shadow Bone
- Update Move: Shadow Boost
- Update Move: Shadow Crush
- Create Move: Shadow Down
- Update Move: Shadow Fire
- Create Move: Shadow Panic
- Update Move: Shattered Psyche
- Update Move: Shell Shock
- Update Move: Shell Side Arm
- Update Move: Shell Smash
- Create Move: Shelter
- Create Move: Shift Gear
- Update Move: Shiver
- Update Move: Shocking Cascade
- Update Move: Shrapnel Shot
- Update Move: Sigma Wind
- Update Move: Silver Wind
- Update Move: Skitter Smack
- Update Move: Sky Fall
- Create Move: Sludge Bomb
- Update Move: Sludge Wave
- Update Move: Slumber Fang
- Update Move: Spectral Tail
- Update Move: Spicy Extract
- Update Move: Spin Out
- Create Move: Spirit Break
- Update Move: Splishy Splash
- Update Move: Spotlight
- Update Move: Spring Tail
- Update Move: Star Beam
- Update Move: Steel Wing
- Update Move: Stoked Sparksurfer
- Update Move: Strange Steam
- Create Move: Stun Spore
- Update Move: Subduction
- Update Move: Supercharge
- Update Move: Swagger
- Update Move: Sweet Kiss
- Update Move: Syrup Bomb
- Update Move: Tail Glow
- Create Move: Talon Raze
- Update Move: Tear Gas
- Update Move: Teeter Dance
- Update Move: Tenebrous Typhoon
- Update Move: Tesla Prod
- Update Move: Thousand Cuts
- Update Move: Thunder Crash
- Update Move: Thunder Tail
- Update Move: Thunderbolt
- Update Move: Thunderous Kick
- Create Move: Torch Song
- Update Move: Toxic Thread
- Update Move: Toxicrash
- Update Move: Tractor Beam
- Create Move: Tremor
- Update Move: Trop Kick
- Update Move: Tsunami
- Update Move: Turnabout
- Update Move: Twineedle
- Update Move: V-create
- Update Move: Venom Drench
- Update Move: Victory Dance
- Create Move: Vile Nail
- Update Move: Virulent Vibe
- Update Move: Volt Tackle
- Create Move: Water Hammer
- Update Move: Web Ball
- Update Move: Whiplash
- Create Species: relicanth
- Update Move: High Jump Kick
- Update Species: beldum
- Update Species: metang
- Create Species: metagross
- Update Ability: Holiday Cheer
- Update Species: klink
- Update Species: klang
- Update Species: klinklang
- Update Perk: Resentment
- Update Move: Whirling Rondé
- Update Move: Wicked Torque
- Update Species: darmanitan-galarian
- Update Move: Wild Shriek