### PR TITLE
Foundry Data Sync - Fox Fixes 20/01/25 - Part 1 (Probably?)

### DIFF
--- a/packs/core-moves/bramble-shot.json
+++ b/packs/core-moves/bramble-shot.json
@@ -1,50 +1,99 @@
 {
-    "name": "Bramble Shot",
-    "type": "move",
-    "img": "systems/ptr2e/img/svg/grass_icon.svg",
-    "system": {
-      "slug": "bramble-shot",
-      "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[leech] 5.</p>",
-      "traits": [
-        "missile"
-      ],
-      "actions": [
-        {
-          "slug": "bramble-shot",
-          "name": "Bramble Shot",
-          "type": "attack",
-          "traits": [
-            "missile",
-            "pp-updated"
-          ],
-          "range": {
-            "target": "creature",
-            "distance": 10,
-            "unit": "m"
-          },
-          "cost": {
-            "activation": "complex",
-            "powerPoints": 3,
-            "delay": null,
+  "name": "Bramble Shot",
+  "type": "move",
+  "img": "systems/ptr2e/img/svg/grass_icon.svg",
+  "system": {
+    "slug": "bramble-shot",
+    "actions": [
+      {
+        "slug": "bramble-shot",
+        "name": "Bramble Shot",
+        "type": "attack",
+        "traits": [
+          "missile",
+          "pp-updated"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "category": "physical",
+        "power": 70,
+        "accuracy": 100,
+        "types": [
+          "grass"
+        ],
+        "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[leech] 5.</p>",
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
+      }
+    ],
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "lFR412cPGvZ3M7zk",
+  "effects": [
+    {
+      "name": "Bramble Shot",
+      "type": "passive",
+      "_id": "yte1I1a9euiPrYn5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "bramble-shot-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.leechconditiitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
             "priority": null,
-            "trigger": null
-          },
-          "category": "physical",
-          "power": 70,
-          "accuracy": 100,
-          "types": [
-            "grass"
-          ],
-          "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[leech] 5.</p>",
-          "contestType": "",
-          "contestEffect": "",
-          "free": false,
-          "slot": null
-        }
-      ],
-      "container": null,
-      "grade": "C"
-    },
-    "_id": "lFR412cPGvZ3M7zk",
-    "effects": []
-  }
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737332457352,
+        "modifiedTime": 1737332479161,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
+}

--- a/packs/core-moves/cupid-arrow.json
+++ b/packs/core-moves/cupid-arrow.json
@@ -1,50 +1,99 @@
 {
-    "name": "Cupid Arrow",
-    "type": "move",
-    "img": "systems/ptr2e/img/svg/fairy_icon.svg",
-    "system": {
-      "slug": "cupid-arrow",
-      "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[charmed] 5.</p>",
-      "traits": [
-        "missile"
-      ],
-      "actions": [
-        {
-          "slug": "cupid-arrow",
-          "name": "Cupid Arrow",
-          "type": "attack",
-          "traits": [
-            "missile",
-            "pp-updated"
-          ],
-          "range": {
-            "target": "creature",
-            "distance": 10,
-            "unit": "m"
-          },
-          "cost": {
-            "activation": "complex",
-            "powerPoints": 2,
-            "delay": null,
+  "name": "Cupid Arrow",
+  "type": "move",
+  "img": "systems/ptr2e/img/svg/fairy_icon.svg",
+  "system": {
+    "slug": "cupid-arrow",
+    "actions": [
+      {
+        "slug": "cupid-arrow",
+        "name": "Cupid Arrow",
+        "type": "attack",
+        "traits": [
+          "missile",
+          "pp-updated"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 2
+        },
+        "category": "physical",
+        "power": 50,
+        "accuracy": 100,
+        "types": [
+          "fairy"
+        ],
+        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[charmed] 5.</p>",
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
+      }
+    ],
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "lFR367cPGvZ3M7zk",
+  "effects": [
+    {
+      "name": "Cupid Arrow",
+      "type": "passive",
+      "_id": "gQbKvMBJniGgsHz4",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "cupid-arrow-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.charmedcondiitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
             "priority": null,
-            "trigger": null
-          },
-          "category": "physical",
-          "power": 50,
-          "accuracy": 100,
-          "types": [
-            "fairy"
-          ],
-          "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[charmed] 5.</p>",
-          "contestType": "",
-          "contestEffect": "",
-          "free": false,
-          "slot": null
-        }
-      ],
-      "container": null,
-      "grade": "D"
-    },
-    "_id": "lFR367cPGvZ3M7zk",
-    "effects": []
-  }
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737332505337,
+        "modifiedTime": 1737332529084,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
+}

--- a/packs/core-moves/devious-shot.json
+++ b/packs/core-moves/devious-shot.json
@@ -1,52 +1,100 @@
 {
-    "name": "Devious Shot",
-    "type": "move",
-    "img": "systems/ptr2e/img/svg/dark_icon.svg",
-    "system": {
-      "slug": "devious-shot",
-      "description": "<p>Effect: On hit, the target has a 30% chance of losing -1 DEF Stage for 5 Activations.</p>",
-      "traits": [
-        "missile",
-        "crit-1"
-      ],
-      "actions": [
-        {
-          "slug": "devious-shot",
-          "name": "Devious Shot",
-          "type": "attack",
-          "traits": [
-            "missile",
-            "crit-1",
-            "pp-updated"
-          ],
-          "range": {
-            "target": "creature",
-            "distance": 10,
-            "unit": "m"
-          },
-          "cost": {
-            "activation": "complex",
-            "powerPoints": 5,
-            "delay": null,
+  "name": "Devious Shot",
+  "type": "move",
+  "img": "systems/ptr2e/img/svg/dark_icon.svg",
+  "system": {
+    "slug": "devious-shot",
+    "actions": [
+      {
+        "slug": "devious-shot",
+        "name": "Devious Shot",
+        "type": "attack",
+        "traits": [
+          "missile",
+          "crit-1",
+          "pp-updated"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 5
+        },
+        "category": "physical",
+        "power": 80,
+        "accuracy": 100,
+        "types": [
+          "dark"
+        ],
+        "description": "<p>Effect: On hit, the target has a 30% chance of losing -1 DEF Stage for 5 Activations.</p>",
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
+      }
+    ],
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "lFR661cPGvZ3M7zk",
+  "effects": [
+    {
+      "name": "Devious Shot",
+      "type": "passive",
+      "_id": "22MLuQLcwsBGEDPK",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "devious-shot-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
             "priority": null,
-            "trigger": null
-          },
-          "category": "physical",
-          "power": 80,
-          "accuracy": 100,
-          "types": [
-            "dark"
-          ],
-          "description": "<p>Effect: On hit, the target has a 30% chance of losing -1 DEF Stage for 5 Activations.</p>",
-          "contestType": "",
-          "contestEffect": "",
-          "free": false,
-          "slot": null
-        }
-      ],
-      "container": null,
-      "grade": "B"
-    },
-    "_id": "lFR661cPGvZ3M7zk",
-    "effects": []
-  }
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737332550834,
+        "modifiedTime": 1737332577369,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
+}

--- a/packs/core-moves/gaia-force.json
+++ b/packs/core-moves/gaia-force.json
@@ -1,52 +1,111 @@
 {
-    "name": "Gaia Force",
-    "type": "move",
-    "img": "systems/ptr2e/img/svg/grass_icon.svg",
-    "system": {
-      "slug": "gaia-force",
-      "description": "",
-      "traits": [
-        "pulse",
-        "blast-2"
-      ],
-      "actions": [
-        {
-          "slug": "gaia-force",
-          "name": "Gaia Force",
-          "type": "attack",
-          "traits": [
-            "pulse",
-            "blast-2",
-            "pp-updated"
-          ],
-          "range": {
-            "target": "blast",
-            "distance": 10,
-            "unit": "m"
-          },
-          "cost": {
-            "activation": "complex",
-            "powerPoints": 5,
-            "delay": null,
+  "name": "Gaia Force",
+  "type": "move",
+  "img": "systems/ptr2e/img/svg/grass_icon.svg",
+  "system": {
+    "slug": "gaia-force",
+    "actions": [
+      {
+        "slug": "gaia-force",
+        "name": "Gaia Force",
+        "type": "attack",
+        "traits": [
+          "pulse",
+          "blast-2",
+          "pp-updated"
+        ],
+        "range": {
+          "target": "blast",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 5
+        },
+        "category": "special",
+        "power": 130,
+        "accuracy": 90,
+        "types": [
+          "grass"
+        ],
+        "description": "<p>Effect: On resolution, the user loses -1 SPATK and -1 SPDEF Stages for 5 Activations.</p>",
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
+      }
+    ],
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "1YuCkdlx4r8g3RJ3",
+  "effects": [
+    {
+      "name": "Gaia Force",
+      "type": "passive",
+      "_id": "tpcKEslaPAxfGyjO",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "gaia-force-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1JXumQz0QqthT9Iv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
             "priority": null,
-            "trigger": null
+            "ignored": false
           },
-          "category": "special",
-          "power": 130,
-          "accuracy": 90,
-          "types": [
-            "grass"
-          ],
-          "description": "<p>Effect: On resolution, the user loses -1 SPATK and -1 SPDEF Stages for 5 Activations.</p>",
-          "contestType": "",
-          "contestEffect": "",
-          "free": false,
-          "slot": null
-        }
-      ],
-      "container": null,
-      "grade": "B"
-    },
-    "_id": "1YuCkdlx4r8g3RJ3",
-    "effects": []
-  }
+          {
+            "type": "roll-effect",
+            "key": "gaia-force-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737332613369,
+        "modifiedTime": 1737332693863,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
+}

--- a/packs/core-moves/jump-kick.json
+++ b/packs/core-moves/jump-kick.json
@@ -4,12 +4,6 @@
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
     "slug": "jump-kick",
-    "description": "",
-    "traits": [
-      "crash-1-2",
-      "dash",
-      "contact"
-    ],
     "actions": [
       {
         "slug": "jump-kick",
@@ -19,7 +13,8 @@
           "crash-1-2",
           "dash",
           "contact",
-          "pp-updated"
+          "pp-updated",
+          "kick"
         ],
         "range": {
           "target": "creature",
@@ -28,10 +23,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 4
         },
         "category": "physical",
         "power": 100,
@@ -39,15 +31,16 @@
         "types": [
           "fighting"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "vNnq6o3D4pSZ4alY",
   "effects": []

--- a/packs/core-moves/lotus-pods.json
+++ b/packs/core-moves/lotus-pods.json
@@ -1,52 +1,100 @@
 {
-    "name": "Lotus Pods",
-    "type": "move",
-    "img": "systems/ptr2e/img/svg/normal_icon.svg",
-    "system": {
-      "slug": "lotus-pods",
-      "description": "",
-      "traits": [
-        "powder",
-        "blast-3"
-      ],
-      "actions": [
-        {
-          "slug": "lotus-pods",
-          "name": "Lotus Pods",
-          "type": "attack",
-          "traits": [
-            "powder",
-            "blast-3",
-            "pp-updated"
-          ],
-          "range": {
-            "target": "blast",
-            "distance": 10,
-            "unit": "m"
-          },
-          "cost": {
-            "activation": "complex",
-            "powerPoints": 8,
-            "delay": null,
+  "name": "Lotus Pods",
+  "type": "move",
+  "img": "systems/ptr2e/img/svg/normal_icon.svg",
+  "system": {
+    "slug": "lotus-pods",
+    "actions": [
+      {
+        "slug": "lotus-pods",
+        "name": "Lotus Pods",
+        "type": "attack",
+        "traits": [
+          "powder",
+          "blast-3",
+          "pp-updated"
+        ],
+        "range": {
+          "target": "blast",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 8
+        },
+        "category": "special",
+        "power": 75,
+        "accuracy": 100,
+        "types": [
+          "normal"
+        ],
+        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[drowsy] 5.</p>",
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
+      }
+    ],
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "n4rGUelHpp7rVQoM",
+  "effects": [
+    {
+      "name": "Lotus Pods",
+      "type": "passive",
+      "_id": "JIxipXrj6NK8Ecxi",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "lotus-pods-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.drowsycondititem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
             "priority": null,
-            "trigger": null
-          },
-          "category": "special",
-          "power": 75,
-          "accuracy": 100,
-          "types": [
-            "normal"
-          ],
-          "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[drowsy] 5.</p>",
-          "contestType": "",
-          "contestEffect": "",
-          "free": false,
-          "slot": null
-        }
-      ],
-      "container": null,
-      "grade": "B"
-    },
-    "_id": "n4rGUelHpp7rVQoM",
-    "effects": []
-  }
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737332742792,
+        "modifiedTime": 1737332763462,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
+}

--- a/packs/core-moves/shocking-stab.json
+++ b/packs/core-moves/shocking-stab.json
@@ -1,52 +1,100 @@
 {
-    "name": "Shocking-Stab",
-    "type": "move",
-    "img": "systems/ptr2e/img/svg/electric_icon.svg",
-    "system": {
-      "slug": "shocking-stab",
-      "description": "",
-      "traits": [
-        "horn",
-        "contact"
-      ],
-      "actions": [
-        {
-          "slug": "shocking-stab",
-          "name": "Shocking Stab",
-          "type": "attack",
-          "traits": [
-            "horn",
-            "contact",
-            "pp-updated"
-          ],
-          "range": {
-            "target": "creature",
-            "distance": 1,
-            "unit": "m"
-          },
-          "cost": {
-            "activation": "complex",
-            "powerPoints": 2,
-            "delay": null,
+  "name": "Shocking-Stab",
+  "type": "move",
+  "img": "systems/ptr2e/img/svg/electric_icon.svg",
+  "system": {
+    "slug": "shocking-stab",
+    "actions": [
+      {
+        "slug": "shocking-stab",
+        "name": "Shocking Stab",
+        "type": "attack",
+        "traits": [
+          "horn",
+          "contact",
+          "pp-updated"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 2
+        },
+        "category": "physical",
+        "power": 80,
+        "accuracy": 100,
+        "types": [
+          "electric"
+        ],
+        "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[paralysis] 5.</p>",
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
+      }
+    ],
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "VDWs6Y7AG2oVD8cN",
+  "effects": [
+    {
+      "name": "Shocking-Stab",
+      "type": "passive",
+      "_id": "X71TUpXsr8v6HVwP",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shocking-stab",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
             "priority": null,
-            "trigger": null
-          },
-          "category": "physical",
-          "power": 80,
-          "accuracy": 100,
-          "types": [
-            "electric"
-          ],
-          "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[paralysis] 5.</p>",
-          "contestType": "",
-          "contestEffect": "",
-          "free": false,
-          "slot": null
-        }
-      ],
-      "container": null,
-      "grade": "D"
-    },
-    "_id": "VDWs6Y7AG2oVD8cN",
-    "effects": []
-  }
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737332829832,
+        "modifiedTime": 1737332856198,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
+}

--- a/packs/core-moves/venom-shot.json
+++ b/packs/core-moves/venom-shot.json
@@ -1,52 +1,100 @@
 {
-    "name": "Venom Shot",
-    "type": "move",
-    "img": "systems/ptr2e/img/svg/poison_icon.svg",
-    "system": {
-      "slug": "venom-shot",
-      "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[poison] 5.</p>",
-      "traits": [
-        "missile",
-        "crit-1"
-      ],
-      "actions": [
-        {
-          "slug": "venom-shot",
-          "name": "Venom Shot",
-          "type": "attack",
-          "traits": [
-            "missile",
-            "crit-1",
-            "pp-updated"
-          ],
-          "range": {
-            "target": "creature",
-            "distance": 10,
-            "unit": "m"
-          },
-          "cost": {
-            "activation": "complex",
-            "powerPoints": 4,
-            "delay": null,
+  "name": "Venom Shot",
+  "type": "move",
+  "img": "systems/ptr2e/img/svg/poison_icon.svg",
+  "system": {
+    "slug": "venom-shot",
+    "actions": [
+      {
+        "slug": "venom-shot",
+        "name": "Venom Shot",
+        "type": "attack",
+        "traits": [
+          "missile",
+          "crit-1",
+          "pp-updated"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "category": "physical",
+        "power": 80,
+        "accuracy": 100,
+        "types": [
+          "poison"
+        ],
+        "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[poison] 5.</p>",
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
+      }
+    ],
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "lFR932cPGvZ3M7zk",
+  "effects": [
+    {
+      "name": "Venom Shot",
+      "type": "passive",
+      "_id": "eNQtklY6WVWfJcwy",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "venom-shot-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
             "priority": null,
-            "trigger": null
-          },
-          "category": "physical",
-          "power": 80,
-          "accuracy": 100,
-          "types": [
-            "poison"
-          ],
-          "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[poison] 5.</p>",
-          "contestType": "",
-          "contestEffect": "",
-          "free": false,
-          "slot": null
-        }
-      ],
-      "container": null,
-      "grade": "B"
-    },
-    "_id": "lFR932cPGvZ3M7zk",
-    "effects": []
-  }
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737332892623,
+        "modifiedTime": 1737332916063,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
+}

--- a/packs/core-moves/wildfire.json
+++ b/packs/core-moves/wildfire.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/fire_icon.svg",
   "system": {
     "slug": "wildfire",
-    "description": "<p>Effect: On hit, all valid targets are @Affliction[burn] 5.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "wildfire",
@@ -23,27 +19,79 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 2
         },
         "category": "status",
-        "power": null,
         "accuracy": 70,
         "types": [
           "fire"
         ],
         "description": "<p>Effect: On hit, all valid targets are @Affliction[burn] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "R2IOUm2aYm2BAheF",
-  "effects": []
+  "effects": [
+    {
+      "name": "Wildfire",
+      "type": "passive",
+      "_id": "aptIIKAZovPghALc",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "wildfire-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737332150669,
+        "modifiedTime": 1737332285198,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/withdraw.json
+++ b/packs/core-moves/withdraw.json
@@ -4,10 +4,6 @@
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
     "slug": "withdraw",
-    "description": "<p>Effect: The user gains +1 DEF Stage for 5 Activations.</p>",
-    "traits": [
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "withdraw",
@@ -18,32 +14,82 @@
         ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 1
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "water"
         ],
         "description": "<p>Effect: The user gains +1 DEF Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "PQBKLWDTfMtnglGy",
-  "effects": []
+  "effects": [
+    {
+      "name": "Withdraw",
+      "type": "passive",
+      "_id": "JSCnxA4rG9plfmfI",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "withdraw-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.sMystTj3FBJ00AZp",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737332321563,
+        "modifiedTime": 1737332341365,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/zap-cannon.json
+++ b/packs/core-moves/zap-cannon.json
@@ -4,11 +4,6 @@
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "system": {
     "slug": "zap-cannon",
-    "description": "",
-    "traits": [
-      "missile",
-      "blast-3"
-    ],
     "actions": [
       {
         "slug": "zap-cannon",
@@ -26,10 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 10,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 10
         },
         "category": "special",
         "power": 120,
@@ -38,15 +30,71 @@
           "electric"
         ],
         "description": "<p>Effect: On hit, all valid targets gain @Affliction[paralysis] 5.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "lSTQMYs44xeXh27N",
-  "effects": []
+  "effects": [
+    {
+      "name": "Zap Cannon",
+      "type": "passive",
+      "_id": "Yn9ZTJeoj4oH1PYt",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "zap-cannon-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737332383484,
+        "modifiedTime": 1737332407814,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/assault-armor-style.json
+++ b/packs/core-perks/assault-armor-style.json
@@ -20,14 +20,11 @@
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
         "description": "Effect: The target may use DEF in place of their ATK when using a Physical-Category Attack for 1 Activation.",
         "type": "generic",
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "icons/svg/explosion.svg"
       },
       {
         "name": "Assault Armor! (Self)",
@@ -38,23 +35,19 @@
         ],
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
         "description": "Effect: The user may use DEF in place of their ATK when using a Physical-Category Attack until the end of their next Activation.",
         "type": "generic",
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "slug": "assault-armor-style",
-    "description": "<p>Simple Action, 2 PP cost. Target self or allied creature. The affected creature may use DEF in place of their SPDEF when using a Physical-Category Attack until the end of their next full Activation.</p>",
+    "description": "<p>Simple Action, 2 PP cost. Target self or allied creature. The affected creature may use DEF in place of their ATK when using a Physical-Category Attack until the end of their next full Activation.</p>",
     "traits": [
       "command"
     ],
@@ -98,9 +91,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },

--- a/packs/core-species/delcatty.json
+++ b/packs/core-species/delcatty.json
@@ -30,8 +30,8 @@
     "traits": [
       "pokemon",
       "quadrupedal",
-      "underdog",
-      "darkvision-15"
+      "darkvision-15",
+      "tailed"
     ],
     "abilities": {
       "starting": [
@@ -52,10 +52,10 @@
       ],
       "advanced": [
         {
-          "slug": "natural-cure"
+          "slug": "scrappy"
         },
         {
-          "slug": "scrappy"
+          "slug": "pretty-princess"
         }
       ],
       "master": [
@@ -70,14 +70,6 @@
     "skills": [
       {
         "slug": "acrobatics",
-        "value": 65,
-        "rvs": 0,
-        "favourite": false,
-        "hidden": false,
-        "group": null
-      },
-      {
-        "slug": "climb",
         "value": 55,
         "rvs": 0,
         "favourite": false,
@@ -85,16 +77,16 @@
         "group": null
       },
       {
-        "slug": "conversation",
-        "value": 65,
+        "slug": "climb",
+        "value": 45,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
         "group": null
       },
       {
-        "slug": "intimidate",
-        "value": 20,
+        "slug": "conversation",
+        "value": 55,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -158,7 +150,7 @@
       },
       {
         "slug": "stealth",
-        "value": 65,
+        "value": 30,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -173,8 +165,16 @@
         "group": null
       },
       {
+        "slug": "swim",
+        "value": 30,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
         "slug": "track",
-        "value": 65,
+        "value": 45,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -196,215 +196,15 @@
     "moves": {
       "tutor": [
         {
-          "name": "headbutt",
-          "gen": "heartgold-soulsilver"
+          "name": "blizzard",
+          "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
           "name": "body-slam",
           "gen": "xd"
         },
         {
-          "name": "thunder-wave",
-          "gen": "xd"
-        },
-        {
-          "name": "mimic",
-          "gen": "xd"
-        },
-        {
-          "name": "defense-curl",
-          "gen": "emerald"
-        },
-        {
-          "name": "swift",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "dream-eater",
-          "gen": "xd"
-        },
-        {
-          "name": "substitute",
-          "gen": "xd"
-        },
-        {
-          "name": "snore",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "mud-slap",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "icy-wind",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "endure",
-          "gen": "emerald"
-        },
-        {
-          "name": "rollout",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "swagger",
-          "gen": "xd"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "iron-tail",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "psych-up",
-          "gen": "emerald"
-        },
-        {
-          "name": "uproar",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "helping-hand",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "hyper-voice",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "shock-wave",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "water-pulse",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "last-resort",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "sucker-punch",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "zen-headbutt",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "laser-focus",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "stomping-tantrum",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "ice-beam",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "blizzard",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "hyper-beam",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "strength",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "solar-beam",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "thunderbolt",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "thunder",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "dig",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "toxic",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "double-team",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "flash",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "rest",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "protect",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "return",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "frustration",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "safeguard",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "hidden-power",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "rain-dance",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "sunny-day",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "shadow-ball",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "rock-smash",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
           "name": "calm-mind",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "natural-gift",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "giga-impact",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "nasty-plot",
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
@@ -412,128 +212,328 @@
           "gen": "heartgold-soulsilver"
         },
         {
-          "name": "grass-knot",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
           "name": "charge-beam",
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
-          "name": "round",
+          "name": "confide",
           "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "defense-curl",
+          "gen": "emerald"
+        },
+        {
+          "name": "dig",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "double-team",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "dream-eater",
+          "gen": "xd"
         },
         {
           "name": "echoed-voice",
           "gen": "ultra-sun-ultra-moon"
         },
         {
+          "name": "endure",
+          "gen": "emerald"
+        },
+        {
+          "name": "flash",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "frustration",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "giga-impact",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "grass-knot",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "headbutt",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "helping-hand",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "hidden-power",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "hyper-beam",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "hyper-voice",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "ice-beam",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "icy-wind",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "iron-tail",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "laser-focus",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "last-resort",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "mimic",
+          "gen": "xd"
+        },
+        {
+          "name": "mud-slap",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "nasty-plot",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "natural-gift",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "protect",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "psych-up",
+          "gen": "emerald"
+        },
+        {
+          "name": "rain-dance",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "rest",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
           "name": "retaliate",
           "gen": "omega-ruby-alpha-sapphire"
         },
         {
-          "name": "work-up",
+          "name": "return",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "rock-smash",
           "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "rollout",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "round",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "safeguard",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "shadow-ball",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "shock-wave",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "solar-beam",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "stomping-tantrum",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "strength",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "substitute",
+          "gen": "xd"
+        },
+        {
+          "name": "sucker-punch",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "swagger",
+          "gen": "xd"
+        },
+        {
+          "name": "swift",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "thunder",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "thunder-wave",
+          "gen": "xd"
+        },
+        {
+          "name": "thunderbolt",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "toxic",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "uproar",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "water-pulse",
+          "gen": "ultra-sun-ultra-moon"
         },
         {
           "name": "wild-charge",
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "confide",
+          "name": "work-up",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "zen-headbutt",
           "gen": "ultra-sun-ultra-moon"
         }
       ],
       "levelUp": [
         {
-          "name": "double-slap",
-          "level": 1,
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "tackle",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "double-edge",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "tail-whip",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "growl",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "sing",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "fury-swipes",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "charm",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
           "name": "attract",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "heal-bell",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "fake-out",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "facade",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "covet",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "payback",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "copycat",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "disarming-voice",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "play-rough",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
         },
         {
           "name": "baby-doll-eyes",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "charm",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "copycat",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "covet",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "disarming-voice",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "double-edge",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "double-slap",
+          "gen": "ultra-sun-ultra-moon",
+          "level": 1
+        },
+        {
+          "name": "facade",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "fake-out",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "fury-swipes",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "growl",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "heal-bell",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "payback",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "play-rough",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "sing",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "tackle",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
+        },
+        {
+          "name": "tail-whip",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
         }
       ]
     },
@@ -569,17 +569,29 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.xUyfshSw2JNmUJ1n"
+      "uuid": "Compendium.ptr2e.core-species.Item.xUyfshSw2JNmUJ1n",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "forest",
       "city"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "nkomNz1cjlbVXI9e",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/ponyta.json
+++ b/packs/core-species/ponyta.json
@@ -31,10 +31,8 @@
       "pokemon",
       "quadrupedal",
       "heater",
-      "horned",
       "pack-mon",
-      "glow-3",
-      "underdog"
+      "glow-3"
     ],
     "abilities": {
       "starting": [
@@ -191,135 +189,7 @@
     "moves": {
       "tutor": [
         {
-          "name": "horn-drill",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "thrash",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "double-edge",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "low-kick",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "hypnosis",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "charm",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "morning-sun",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "captivate",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
           "name": "ally-switch",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "high-horsepower",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "headbutt",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "body-slam",
-          "gen": "xd"
-        },
-        {
-          "name": "flamethrower",
-          "gen": "crystal"
-        },
-        {
-          "name": "mimic",
-          "gen": "xd"
-        },
-        {
-          "name": "swift",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "substitute",
-          "gen": "xd"
-        },
-        {
-          "name": "snore",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "endure",
-          "gen": "emerald"
-        },
-        {
-          "name": "swagger",
-          "gen": "xd"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "iron-tail",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "heat-wave",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "strength",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "solar-beam",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "toxic",
-          "gen": "lets-go-pikachu-lets-go-eevee"
-        },
-        {
-          "name": "rage",
-          "gen": "yellow"
-        },
-        {
-          "name": "double-team",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "reflect",
-          "gen": "lets-go-pikachu-lets-go-eevee"
-        },
-        {
-          "name": "bide",
-          "gen": "yellow"
-        },
-        {
-          "name": "skull-bash",
-          "gen": "yellow"
-        },
-        {
-          "name": "rest",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "curse",
-          "gen": "crystal"
-        },
-        {
-          "name": "protect",
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
@@ -327,11 +197,63 @@
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
-          "name": "return",
+          "name": "bide",
+          "gen": "yellow"
+        },
+        {
+          "name": "body-slam",
+          "gen": "xd"
+        },
+        {
+          "name": "captivate",
           "gen": "ultra-sun-ultra-moon"
         },
         {
+          "name": "charm",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "confide",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "curse",
+          "gen": "crystal"
+        },
+        {
+          "name": "double-edge",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "double-team",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "echoed-voice",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "endure",
+          "gen": "emerald"
+        },
+        {
+          "name": "facade",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "flamethrower",
+          "gen": "crystal"
+        },
+        {
           "name": "frustration",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "headbutt",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "heat-wave",
           "gen": "ultra-sun-ultra-moon"
         },
         {
@@ -339,142 +261,218 @@
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "sunny-day",
+          "name": "high-horsepower",
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
-          "name": "will-o-wisp",
+          "name": "horn-drill",
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
-          "name": "facade",
+          "name": "hypnosis",
           "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "overheat",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "natural-gift",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "round",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "echoed-voice",
-          "gen": "ultra-sun-ultra-moon"
         },
         {
           "name": "incinerate",
           "gen": "omega-ruby-alpha-sapphire"
         },
         {
-          "name": "wild-charge",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "play-rough",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "confide",
+          "name": "iron-tail",
           "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "low-kick",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "mimic",
+          "gen": "xd"
+        },
+        {
+          "name": "morning-sun",
+          "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
           "name": "mystical-fire",
           "gen": "sword-shield"
         },
         {
+          "name": "natural-gift",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "overheat",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "play-rough",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "protect",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "rage",
+          "gen": "yellow"
+        },
+        {
+          "name": "reflect",
+          "gen": "lets-go-pikachu-lets-go-eevee"
+        },
+        {
+          "name": "rest",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "return",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "skull-bash",
+          "gen": "yellow"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "solar-beam",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
           "name": "solar-blade",
           "gen": "sword-shield"
+        },
+        {
+          "name": "strength",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "substitute",
+          "gen": "xd"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "swagger",
+          "gen": "xd"
+        },
+        {
+          "name": "swift",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "thrash",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "toxic",
+          "gen": "lets-go-pikachu-lets-go-eevee"
+        },
+        {
+          "name": "wild-charge",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "will-o-wisp",
+          "gen": "brilliant-diamond-and-shining-pearl"
         }
       ],
       "levelUp": [
         {
-          "name": "tackle",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "name": "growl",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
         },
         {
-          "name": "growl",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "name": "tackle",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
         },
         {
           "name": "tail-whip",
-          "level": 5,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 5
         },
         {
           "name": "ember",
-          "level": 10,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 10
         },
         {
           "name": "quick-attack",
-          "level": 10,
-          "gen": "lets-go-pikachu-lets-go-eevee"
+          "gen": "lets-go-pikachu-lets-go-eevee",
+          "level": 10
         },
         {
           "name": "double-kick",
-          "level": 15,
-          "gen": "lets-go-pikachu-lets-go-eevee"
+          "gen": "lets-go-pikachu-lets-go-eevee",
+          "level": 15
         },
         {
           "name": "flame-charge",
-          "level": 15,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 15
         },
         {
           "name": "agility",
-          "level": 20,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 20
         },
         {
           "name": "flame-wheel",
-          "level": 25,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 25
         },
         {
           "name": "stomp",
-          "level": 30,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 30
         },
         {
           "name": "fire-spin",
-          "level": 35,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 35
         },
         {
           "name": "take-down",
-          "level": 41,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 41
         },
         {
           "name": "bounce",
-          "level": 45,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 45
         },
         {
           "name": "inferno",
-          "level": 45,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 45
         },
         {
           "name": "fire-blast",
-          "level": 50,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 50
         },
         {
           "name": "flare-blitz",
-          "level": 55,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 55
         }
       ]
     },
@@ -503,18 +501,30 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.vNwcjY2sLrsWVTwg"
+      "uuid": "Compendium.ptr2e.core-species.Item.vNwcjY2sLrsWVTwg",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "forest",
       "woodland",
       "grassland"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "vNwcjY2sLrsWVTwg",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/skitty.json
+++ b/packs/core-species/skitty.json
@@ -30,8 +30,8 @@
     "traits": [
       "pokemon",
       "quadrupedal",
-      "underdog",
-      "darkvision-15"
+      "darkvision-15",
+      "tailed"
     ],
     "abilities": {
       "starting": [
@@ -52,10 +52,10 @@
       ],
       "advanced": [
         {
-          "slug": "natural-cure"
+          "slug": "scrappy"
         },
         {
-          "slug": "scrappy"
+          "slug": "pretty-princess"
         }
       ],
       "master": [
@@ -70,7 +70,7 @@
     "skills": [
       {
         "slug": "acrobatics",
-        "value": 50,
+        "value": 35,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -78,7 +78,7 @@
       },
       {
         "slug": "climb",
-        "value": 45,
+        "value": 25,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -86,15 +86,7 @@
       },
       {
         "slug": "conversation",
-        "value": 45,
-        "rvs": 0,
-        "favourite": false,
-        "hidden": false,
-        "group": null
-      },
-      {
-        "slug": "intimidate",
-        "value": 10,
+        "value": 35,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -126,7 +118,7 @@
       },
       {
         "slug": "navigate",
-        "value": 45,
+        "value": 25,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -134,7 +126,7 @@
       },
       {
         "slug": "negotiation",
-        "value": 45,
+        "value": 35,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -150,7 +142,7 @@
       },
       {
         "slug": "spot",
-        "value": 40,
+        "value": 30,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -158,7 +150,7 @@
       },
       {
         "slug": "stealth",
-        "value": 50,
+        "value": 15,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -173,8 +165,16 @@
         "group": null
       },
       {
+        "slug": "swim",
+        "value": 10,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
+      },
+      {
         "slug": "track",
-        "value": 50,
+        "value": 30,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -196,135 +196,7 @@
     "moves": {
       "tutor": [
         {
-          "name": "substitute",
-          "gen": "heartgold-soulsilver"
-        },
-        {
           "name": "baton-pass",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "psych-up",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "uproar",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "helping-hand",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "wish",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "fake-tears",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "tickle",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "cosmic-power",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "last-resort",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "sucker-punch",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "mud-bomb",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "zen-headbutt",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "simple-beam",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "headbutt",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "body-slam",
-          "gen": "xd"
-        },
-        {
-          "name": "thunder-wave",
-          "gen": "xd"
-        },
-        {
-          "name": "mimic",
-          "gen": "xd"
-        },
-        {
-          "name": "defense-curl",
-          "gen": "emerald"
-        },
-        {
-          "name": "swift",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "dream-eater",
-          "gen": "xd"
-        },
-        {
-          "name": "snore",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "mud-slap",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "icy-wind",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "endure",
-          "gen": "emerald"
-        },
-        {
-          "name": "rollout",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "swagger",
-          "gen": "xd"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "iron-tail",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "hyper-voice",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "shock-wave",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "water-pulse",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "ice-beam",
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
@@ -332,87 +204,11 @@
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
-          "name": "solar-beam",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "thunderbolt",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "thunder",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "dig",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "toxic",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "double-team",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "flash",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "rest",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "protect",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "return",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "frustration",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "safeguard",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "hidden-power",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "rain-dance",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "sunny-day",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "shadow-ball",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
+          "name": "body-slam",
+          "gen": "xd"
         },
         {
           "name": "calm-mind",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "natural-gift",
-          "gen": "heartgold-soulsilver"
-        },
-        {
-          "name": "nasty-plot",
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "grass-knot",
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
@@ -420,145 +216,349 @@
           "gen": "brilliant-diamond-and-shining-pearl"
         },
         {
-          "name": "round",
+          "name": "confide",
           "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "cosmic-power",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "defense-curl",
+          "gen": "emerald"
+        },
+        {
+          "name": "dig",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "double-team",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "dream-eater",
+          "gen": "xd"
         },
         {
           "name": "echoed-voice",
           "gen": "ultra-sun-ultra-moon"
         },
         {
+          "name": "endure",
+          "gen": "emerald"
+        },
+        {
+          "name": "fake-tears",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "flash",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "frustration",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "grass-knot",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "headbutt",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "helping-hand",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "hidden-power",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "hyper-voice",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "ice-beam",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "icy-wind",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "iron-tail",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "last-resort",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "mimic",
+          "gen": "xd"
+        },
+        {
+          "name": "mud-bomb",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "mud-slap",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "nasty-plot",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "natural-gift",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "protect",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "psych-up",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "rain-dance",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "rest",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
           "name": "retaliate",
           "gen": "omega-ruby-alpha-sapphire"
         },
         {
-          "name": "work-up",
+          "name": "return",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "rollout",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "round",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "safeguard",
           "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "shadow-ball",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "shock-wave",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "simple-beam",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "solar-beam",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "substitute",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "sucker-punch",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "swagger",
+          "gen": "xd"
+        },
+        {
+          "name": "swift",
+          "gen": "heartgold-soulsilver"
+        },
+        {
+          "name": "thunder",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "thunder-wave",
+          "gen": "xd"
+        },
+        {
+          "name": "thunderbolt",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "tickle",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "toxic",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "uproar",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "water-pulse",
+          "gen": "ultra-sun-ultra-moon"
         },
         {
           "name": "wild-charge",
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "confide",
-          "gen": "ultra-sun-ultra-moon"
+          "name": "wish",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "work-up",
+          "gen": "brilliant-diamond-and-shining-pearl"
+        },
+        {
+          "name": "zen-headbutt",
+          "gen": "brilliant-diamond-and-shining-pearl"
         }
       ],
       "levelUp": [
         {
-          "name": "tail-whip",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "name": "fake-out",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
         },
         {
           "name": "growl",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
         },
         {
-          "name": "fake-out",
-          "level": 1,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "tackle",
-          "level": 4,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "name": "tail-whip",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 1
         },
         {
           "name": "foresight",
-          "level": 4,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 4
+        },
+        {
+          "name": "tackle",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 4
         },
         {
           "name": "sing",
-          "level": 7,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 7
         },
         {
           "name": "attract",
-          "level": 10,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 10
         },
         {
           "name": "disarming-voice",
-          "level": 13,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 13
         },
         {
           "name": "double-slap",
-          "level": 16,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 16
         },
         {
           "name": "fury-swipes",
-          "level": 16,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 16
         },
         {
           "name": "copycat",
-          "level": 19,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 19
         },
         {
           "name": "feint-attack",
-          "level": 22,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 22
         },
         {
           "name": "payback",
-          "level": 22,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 22
         },
         {
           "name": "charm",
-          "level": 25,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 25
         },
         {
           "name": "wake-up-slap",
-          "level": 28,
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "facade",
-          "level": 31,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 28
         },
         {
           "name": "assist",
-          "level": 31,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 31
+        },
+        {
+          "name": "facade",
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 31
         },
         {
           "name": "covet",
-          "level": 34,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 34
         },
         {
           "name": "heal-bell",
-          "level": 37,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 37
         },
         {
           "name": "double-edge",
-          "level": 40,
-          "gen": "brilliant-diamond-and-shining-pearl"
-        },
-        {
-          "name": "captivate",
-          "level": 43,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 40
         },
         {
           "name": "baby-doll-eyes",
-          "level": 43,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 43
+        },
+        {
+          "name": "captivate",
+          "gen": "ultra-sun-ultra-moon",
+          "level": 43
         },
         {
           "name": "play-rough",
-          "level": 46,
-          "gen": "brilliant-diamond-and-shining-pearl"
+          "gen": "brilliant-diamond-and-shining-pearl",
+          "level": 46
         }
       ]
     },
@@ -594,17 +594,29 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.xUyfshSw2JNmUJ1n"
+      "uuid": "Compendium.ptr2e.core-species.Item.xUyfshSw2JNmUJ1n",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "forest",
       "city"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "xUyfshSw2JNmUJ1n",
-  "effects": [],
-  "folder": null
+  "effects": []
 }


### PR DESCRIPTION
Mopping up move automations with a couple of species fixes.
- Update Move: Wildfire
- Update Move: Withdraw
- Update Move: Zap Cannon
- Update Move: Bramble Shot
- Update Move: Cupid Arrow
- Update Move: Devious Shot
- Update Move: Gaia Force
- Update Move: Lotus Pods
- Update Move: Shocking-Stab
- Update Move: Venom Shot
- Update Move: Jump Kick
- Update Species: ponyta
- Update Perk: Assault Armor Style
- Update Species: skitty
- Update Species: delcatty