### PR TITLE
Foundry Data Sync - Fox Fixes - En Masse fixes for connection perks and abilities part 1

### DIFF
--- a/packs/core-abilities/aftermath.json
+++ b/packs/core-abilities/aftermath.json
@@ -47,7 +47,8 @@
           "normal"
         ],
         "description": "<p>Effect: The user's HP becomes 0 on attack resolution.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "slug": "self-destruct-restrained",
@@ -75,13 +76,15 @@
         "description": "<p>Effect: The user loses 8 Ticks of HP.</p>",
         "variant": "self-destruct",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user gains @Affliction[fainted].</p><p>Effect: Connection - Self-Destruct. The user freely uses Self-Destruct. The user cannot use this in response to gaining @Affliction[fainted] from setting its own HP to 0. When using Self-Destruct (separately from this Ability's Trigger Affliction), the user may spend an additional 4 PP to instead take damage equal to 1/2 their Max HP on resolving Self-Destruct instead of Fainting.</p>",
     "traits": [
       "explode",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "aftermath",
     "_migration": {
@@ -90,5 +93,73 @@
     }
   },
   "_id": "gubM49aBQUdUKGQv",
-  "effects": []
+  "effects": [
+    {
+      "name": "Aftermath",
+      "type": "passive",
+      "_id": "ubnSxw79GYj7ND3z",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.mooOpgSzALgXclFp",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392539694,
+        "modifiedTime": 1737392570829,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/ambush.json
+++ b/packs/core-abilities/ambush.json
@@ -22,42 +22,12 @@
         },
         "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: The user gains +4 CRIT Stages for 2 Activations.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "fake-out",
-        "name": "Fake Out",
-        "type": "attack",
-        "traits": [
-          "dash",
-          "priority-3",
-          "contact",
-          "flinch-5",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4,
-          "priority": 3
-        },
-        "category": "physical",
-        "power": 40,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: On hit, the target is Flinched.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: Connection - Fake Out. The user gains +4 CRIT Stages for 2 Activations.</p>",
     "traits": [
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "ambush",
     "_migration": {
@@ -66,5 +36,73 @@
     }
   },
   "_id": "VMPHWnc089Y3df9P",
-  "effects": []
+  "effects": [
+    {
+      "name": "Ambush",
+      "type": "passive",
+      "_id": "MgYBoLIFErTxjXtC",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.bETEHMYZpiBol842",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392621557,
+        "modifiedTime": 1737392646184,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/ancient-idol.json
+++ b/packs/core-abilities/ancient-idol.json
@@ -18,32 +18,12 @@
         },
         "description": "<p>Effect: The user uses DEF and SPDEF in place of ATK and SPATK respectively when attacking.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "cosmic-power",
-        "name": "Cosmic Power",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: The user gains +1 DEF and SPDEF Stage for 5 Activations.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Effect: Connection - Cosmic Power. The user uses DEF and SPDEF in place of ATK and SPATK respectively when attacking.</p>",
     "traits": [
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "ancient-idol",
     "_migration": {
@@ -52,5 +32,73 @@
     }
   },
   "_id": "YsTznXpuToM6dqWO",
-  "effects": []
+  "effects": [
+    {
+      "name": "Ancient Idol",
+      "type": "passive",
+      "_id": "PSpsM1kcp6qFhfyb",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.yF0XYtBJKJJstJDD",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392717182,
+        "modifiedTime": 1737392750057,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/bad-dreams.json
+++ b/packs/core-abilities/bad-dreams.json
@@ -20,38 +20,13 @@
         },
         "description": "<p>Effect: All other creatures on the field that would gain @Affliction[drowsy] instead gain @Affliction[nightmares].</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "dark-void",
-        "name": "Dark Void",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "blast-4"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "status",
-        "accuracy": 80,
-        "types": [
-          "dark"
-        ],
-        "description": "<p>Effect: On hit, all valid targets gain @Affliction[drowsy] 7.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Effect: Connection - Dark Void. All other creatures on the field that would gain @Affliction[drowsy] instead gain @Affliction[nightmares].</p>",
     "traits": [
       "legendary",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "bad-dreams",
     "_migration": {
@@ -60,5 +35,73 @@
     }
   },
   "_id": "CWnmOQJSLpNPlOVN",
-  "effects": []
+  "effects": [
+    {
+      "name": "Bad Dreams",
+      "type": "passive",
+      "_id": "D61PMB78clUblKK5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.1PokUazkRwGGoiG7",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392799179,
+        "modifiedTime": 1737392826880,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/beads-of-ruin.json
+++ b/packs/core-abilities/beads-of-ruin.json
@@ -45,14 +45,16 @@
         ],
         "description": "<p>Effect: On hit, all valid target's HP is cut in half. This attack always deals a minimum of 1 HP in damage.</p>",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Effect: Connection - Ruination. All other creatures have their SPDEF stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
     "traits": [
       "legendary",
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "beads-of-ruin",
     "_migration": {
@@ -61,5 +63,73 @@
     }
   },
   "_id": "sWdQIvH00vsGkCYB",
-  "effects": []
+  "effects": [
+    {
+      "name": "Treasure of Ruin",
+      "type": "passive",
+      "_id": "J2mZCtyIjIqYFGrQ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.6MiHI8QGhMknDms5",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392887779,
+        "modifiedTime": 1737392924919,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/blinding-one.json
+++ b/packs/core-abilities/blinding-one.json
@@ -21,108 +21,6 @@
         },
         "description": "<p>Effect: For the rest of the user's Activation, Prismatic Laser changes to Prismatic Beams.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "traits": [
-          "legendary"
-        ],
-        "name": "Blinding One",
-        "slug": "blinding-one-passive",
-        "type": "passive",
-        "cost": {
-          "activation": "free"
-        },
-        "description": "<p>Passive: the user gains the Perforate and Radiance Abilities. When the user deactivates its Ultra Burst and changes Formes, this Ability is replaced with Prism Armor.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "traits": [],
-        "name": "Radiance",
-        "slug": "radiance",
-        "type": "passive",
-        "cost": {
-          "activation": "free"
-        },
-        "range": {
-          "target": "aura",
-          "distance": 5,
-          "unit": "m"
-        },
-        "description": "<p>Effect: Allies within Range of the user take 25% less damage from Dark-Type attacks. Dark-Type Status-Category attacks fail to activate within Range.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "traits": [],
-        "name": "Perforate",
-        "slug": "perforate",
-        "type": "passive",
-        "cost": {
-          "activation": "free"
-        },
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "description": "<p>Effect: Attacks that the user gains STAB on are resisted one step less. These attacks that a target would normally be immune to are instead resisted one step.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "name": "Prismatic Beams",
-        "slug": "prismatic-beams",
-        "type": "attack",
-        "img": "icons/svg/explosion.svg",
-        "traits": [
-          "ray",
-          "legendary",
-          "4-strike",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 3,
-          "trigger": "<p>Enabled by an Ability.</p>"
-        },
-        "types": [
-          "psychic"
-        ],
-        "category": "special",
-        "power": 28,
-        "accuracy": 90,
-        "free": true,
-        "description": "<p>Trigger: Enabled by an Ability.</p>"
-      },
-      {
-        "name": "Prismatic Laser",
-        "slug": "prismatic-laser",
-        "type": "attack",
-        "img": "icons/svg/explosion.svg",
-        "traits": [
-          "ray",
-          "legendary",
-          "exhaust",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "line",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "types": [
-          "psychic"
-        ],
-        "category": "special",
-        "power": 160,
-        "accuracy": 100,
-        "free": true
       }
     ],
     "description": "<p>Effect: Connection - Prismatic Laser. For the rest of the user's Activation, For the rest of the user's Activation, Prismatic Laser changes to Prismatic Beams. Passive: the user gains the Perforate and Radiance Abilities. When the user deactivates its Ultra Burst and changes Formes, this Ability is replaced with Prism Armor.</p>",
@@ -137,5 +35,148 @@
     }
   },
   "_id": "0av2RvZk68FLy59c",
-  "effects": []
+  "effects": [
+    {
+      "name": "Blinding One",
+      "type": "passive",
+      "_id": "ldSbWulzqZif26U0",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.pxPNGM7NGikM7k8T",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.Aw94UJGslTkGPvJp",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": 0
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.fWJ3ImW09ZT9qvP1",
+            "predicate": [],
+            "allowDuplicate": false,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.KPnwU3nXFHkpeBOz",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737393255443,
+        "modifiedTime": 1737393524993,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/cheap-tactics.json
+++ b/packs/core-abilities/cheap-tactics.json
@@ -23,32 +23,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "scratch",
-        "name": "Scratch",
-        "type": "attack",
-        "traits": [
-          "sharp",
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex"
-        },
-        "category": "physical",
-        "power": 40,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
         "slug": "scratch-first-strike",
         "name": "Scratch (First Strike)",
         "type": "attack",
@@ -76,12 +50,14 @@
         "description": "<p>Trigger: Activated by an Ability's effect.</p>",
         "variant": "scratch",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: Connection - Scratch. The user gains +2 CRIT Stages for 2 Activations. Then, the user freely moves up to and using the Movement Score of their choice, and uses Scratch (First Strike).</p>",
     "traits": [
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "cheap-tactics",
     "_migration": {
@@ -90,5 +66,73 @@
     }
   },
   "_id": "LT52ALHpGUv5ypbC",
-  "effects": []
+  "effects": [
+    {
+      "name": "Cheap Tactics",
+      "type": "passive",
+      "_id": "4VtGrT26Xcbc3oBb",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.rpka3XlZLzOViXR7",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737393609305,
+        "modifiedTime": 1737393635485,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/chromatic-radiance.json
+++ b/packs/core-abilities/chromatic-radiance.json
@@ -42,71 +42,14 @@
         },
         "description": "<p>Trigger: The user recovers HP.</p><p>Effect: Allies within Range recover a Tick of HP. In Sunny Weather, this Ability triggers a second time.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "sacred-fire",
-        "name": "Sacred Fire",
-        "type": "attack",
-        "traits": [
-          "defrost",
-          "legendary",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "wide-line",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "physical",
-        "power": 100,
-        "accuracy": 95,
-        "types": [
-          "fire"
-        ],
-        "description": "<p>Effect: On hit, all valid targets have a 50% chance of gaining @Affliction[burn] 7.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "sacred-fire-burned",
-        "name": "Sacred Fire (Burned)",
-        "type": "attack",
-        "traits": [
-          "defrost",
-          "legendary",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "wide-line",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7,
-          "trigger": "<p>Valid target(s) have @Affliction[burn].</p>"
-        },
-        "category": "physical",
-        "power": 100,
-        "accuracy": 95,
-        "types": [
-          "fire"
-        ],
-        "description": "<p>Trigger: Valid target(s) have @Affliction[burn].</p><p>Effect: On hit, all valid targets have a 50% chance of gaining @Affliction[burn] 7 and a 50% chance of gaining @Affliction[splinter] 7.</p>",
-        "variant": "sacred-fire",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p> Effect: Connection - Sacred Fire. When using a Fire-Type attack while Sunny Weather is active, the user recovers 3 Ticks of HP. Any time the user recovers HP, allies within 10m recover a Tick of HP, which is doubled in Sunny Weather.</p>",
     "traits": [
       "connection",
       "legendary",
-      "environ"
+      "environ",
+      "partial-automation"
     ],
     "slug": "chromatic-radiance",
     "_migration": {
@@ -115,5 +58,78 @@
     }
   },
   "_id": "Z2D1B8HhNUAKWaKa",
-  "effects": []
+  "effects": [
+    {
+      "name": "Chromatic Radiance",
+      "type": "passive",
+      "_id": "A4v3GPvMrH6EhXw9",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.hoQZlSqWhAC3WujH",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737393714972,
+        "modifiedTime": 1737393853058,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/clinging-shadow.json
+++ b/packs/core-abilities/clinging-shadow.json
@@ -23,42 +23,14 @@
         },
         "description": "<p>The user gains @Affliction[transient] 2 and @Affliction[invisible] 2, and relocates itself to an open space within 2m of the target. The user is then Flinched. Until the user's next Activation, they freely move with the target as the target itself moves.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "phantom-force",
-        "name": "Phantom Force",
-        "type": "attack",
-        "traits": [
-          "set-up",
-          "crushing",
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 3
-        },
-        "category": "physical",
-        "power": 90,
-        "accuracy": 100,
-        "types": [
-          "ghost"
-        ],
-        "description": "<p>Effect: Set-Up: The user gains @Affliction[invisible] 1, and ends their activation.</p><p>Resolution: On their next activation, the user freely Moves up to one-and-a-half times the Movement Score of their choice and attacks with and resolve Phantom Force. This attack ignores the effects of [Shield] attacks when applying damage.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Effect: Connection - Phantom Force. The user gains @Affliction[transient] 2 and @Affliction[invisible] 2, and relocates itself to an open space within 2m of the target. The user is then Flinched. Until the user's next Activation, they freely move with the target as the target itself moves.</p>",
     "traits": [
       "legendary",
       "connection",
-      "delay-2"
+      "delay-2",
+      "partial-automation"
     ],
     "slug": "clinging-shadow",
     "_migration": {
@@ -67,5 +39,73 @@
     }
   },
   "_id": "nh8NRKZkGqUSsfzd",
-  "effects": []
+  "effects": [
+    {
+      "name": "Clinging Shadow",
+      "type": "passive",
+      "_id": "2Tun9fiKw0QJGdSe",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.hK17tJ4kinDuhKyh",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737393873368,
+        "modifiedTime": 1737393911713,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/coil-up.json
+++ b/packs/core-abilities/coil-up.json
@@ -20,27 +20,6 @@
         },
         "description": "<p>Trigger: The user enters combat.</p><p>Effect:The user's Coil gains [Priority 3] until the start of their next Activation, and the user freely uses Coil.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "coil",
-        "name": "Coil",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "types": [
-          "poison"
-        ],
-        "description": "<p>Effect: The user's ATK Stage, DEF Stage and ACC Stage are increased by +1 for 5 activations.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user enters combat.</p><p>Effect: Connection - Coil. The user's Coil gains [Priority 3] until the start of their next Activation, and the user freely uses Coil.</p>",
@@ -54,5 +33,73 @@
     }
   },
   "_id": "beY7ZLjNlYwBbHw4",
-  "effects": []
+  "effects": [
+    {
+      "name": "Coil Up",
+      "type": "passive",
+      "_id": "WbFGQOhSoYTaZUMb",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.7r57DxIctmNSW2oV",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "replaceSelf": true,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737395090460,
+        "modifiedTime": 1737395121164,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/cold-rebound.json
+++ b/packs/core-abilities/cold-rebound.json
@@ -22,33 +22,6 @@
         },
         "description": "<p>Trigger: The user is hit with a [Contact] attack.</p><p>Effect: The user freely attacks the triggering creature with Icy Wind.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "icy-wind",
-        "name": "Icy Wind",
-        "type": "attack",
-        "traits": [
-          "wind",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "wide-line",
-          "distance": 3,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "special",
-        "power": 55,
-        "accuracy": 95,
-        "types": [
-          "ice"
-        ],
-        "description": "<p>Effect: On hit, all valid targets lose -1 SPD Stage for 5 activations.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit with a [Contact] attack.</p><p>Effect: Connection - Icy Wind. The user freely attacks the triggering creature with Icy Wind.</p>",
@@ -62,5 +35,73 @@
     }
   },
   "_id": "Kon1lC8YU7SMt62P",
-  "effects": []
+  "effects": [
+    {
+      "name": "Cold Rebound",
+      "type": "passive",
+      "_id": "rKYJmmW5W66NtvkN",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.YoLEpica6f4PLgWO",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737395182970,
+        "modifiedTime": 1737395210925,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/corridors-of-time.json
+++ b/packs/core-abilities/corridors-of-time.json
@@ -49,34 +49,6 @@
         },
         "description": "<p>Trigger: The user declares an Action or Ability that consumes at least one Simple Action.</p><p>The number of Simple Actions the Triggering Action consumes are reduced by 1 ([Exhaust] Actions instead just lose [Exhaust]).</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "roar-of-time",
-        "name": "Roar of Time",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "exhaust",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 8,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 12
-        },
-        "category": "special",
-        "power": 150,
-        "accuracy": 90,
-        "types": [
-          "dragon"
-        ],
-        "description": "<p>Effect: On hit, all valid targets are @Affliction[slowed] 7. The user may spend 4 PP and change this attack's Range to <q>15m Cone<q> until their next Activation.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user would be affected by a declared Action, Attack, or Ability.</p><p>Effect: Connection - Roar of Time. The triggering effect does not affect the user, and effect's source is affected by Flinch. Then user gains +6 EVA for 2 Activations. When the user declares an Action or Ability that consumes at least one Simple Action, the user may spend 4 PP to reduce the number of Simple Actions that Action consumes by 1 ([Exhaust] Actions instead just lose [Exhaust]).</p>",
@@ -87,7 +59,8 @@
       "interrupt-7",
       "priority-5",
       "flinch-5",
-      "stage-change"
+      "stage-change",
+      "partial-automation"
     ],
     "slug": "corridors-of-time",
     "_migration": {
@@ -96,5 +69,73 @@
     }
   },
   "_id": "Zen8fn6P5ibzzf1l",
-  "effects": []
+  "effects": [
+    {
+      "name": "Corridors of Time",
+      "type": "passive",
+      "_id": "LmA9RqNABklWWACJ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.PTh9HrZFLR9vXBGN",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737395351936,
+        "modifiedTime": 1737395403815,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/cosmic-eclipse.json
+++ b/packs/core-abilities/cosmic-eclipse.json
@@ -34,40 +34,17 @@
           "activation": "free"
         },
         "description": "<p>Passive: The user's Ghost-Type attacks can hit Normal-Type creatures.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "moongeist-beam",
-        "name": "Moongeist Beam",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "ray",
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "line",
-          "distance": 15,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "special",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "ghost"
-        ],
-        "description": "<p>Effect: This attack is unaffected by the abilities of other creatures.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Trigger: The user declares Moongeist Beam</p><p>Effect: Connection - Moongeist Beam. The triggering attack has a 33% chance of inflicting @Affliction[cursed] 3 to valid targets on hit. Passive: The user's Ghost-Type attacks can hit Normal-Type creatures.</p>",
     "traits": [
-      "legendary"
+      "legendary",
+      "partial-automation"
     ],
     "slug": "cosmic-eclipse",
     "_migration": {
@@ -76,5 +53,73 @@
     }
   },
   "_id": "k9KxGgxPGZk9ohQj",
-  "effects": []
+  "effects": [
+    {
+      "name": "Cosmic Eclipse",
+      "type": "passive",
+      "_id": "a3jgHCGSIQv0OVVM",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.DaHQKPYCD2Qy7e4r",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737395450078,
+        "modifiedTime": 1737395480630,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/cosmic-luminance.json
+++ b/packs/core-abilities/cosmic-luminance.json
@@ -36,44 +36,18 @@
           "activation": "free"
         },
         "description": "<p>Passive: The user is immune to negative [Stage Change] effects, and extends the duration of positive [Stage Change] effects by 2 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "sunsteel-strike",
-        "name": "Sunsteel Strike",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "crushing",
-          "dash",
-          "pass-5",
-          "contact",
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "creature",
-          "distance": 1,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "physical",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "steel"
-        ],
-        "description": "<p>Effect: This attack is unaffected by the abilities of other creatures.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Trigger: The user declares Sunsteel Strike.</p><p>Effect: Connection - Sunsteel Strike. The user freely Moves up to half their Overland Score as Teleport Movement before attacking. Passive: The user is immune to negative [Stage Change] effects, and extends the duration of positive [Stage Change] effects by 2 Activations.</p>",
     "traits": [
       "legendary",
-      "defensive"
+      "defensive",
+      "partial-automation"
     ],
     "slug": "cosmic-luminance",
     "_migration": {
@@ -82,5 +56,73 @@
     }
   },
   "_id": "Xvm8FYgSs7r6OmiF",
-  "effects": []
+  "effects": [
+    {
+      "name": "Cosmic Luminance",
+      "type": "passive",
+      "_id": "EP9yWlU7UN490XbV",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.or4J9YDHZhM0slfc",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737395555020,
+        "modifiedTime": 1737395599732,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/coward.json
+++ b/packs/core-abilities/coward.json
@@ -23,32 +23,6 @@
         },
         "description": "<p>Trigger: The user enters combat.</p><p>Effect: The user freely uses Protect.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "protect",
-        "name": "Protect",
-        "type": "attack",
-        "traits": [
-          "shield",
-          "exhaust",
-          "interrupt-4"
-        ],
-        "range": {
-          "target": "creature",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7,
-          "trigger": "<p>The user is targeted by a Physical- or Special-Category Attack.</p>"
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Trigger: The user is targeted by a Physical- or Special-Category Attack.</p><p>Effect: The triggering attack fails, and additional attacks that target the user also fail until the user's next activation. Attacks failing to hit do not deal damage, activate secondary effects, or activate on-miss effects.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user enters combat.</p><p>Effect: Connection - Protect. The user freely uses Protect.</p>",
@@ -62,5 +36,73 @@
     }
   },
   "_id": "g680DJ9tRpAx9ou7",
-  "effects": []
+  "effects": [
+    {
+      "name": "Coward",
+      "type": "passive",
+      "_id": "8MLq4kVHCrR68E1R",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.DwzmkHqd28xR3P3c",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737395648457,
+        "modifiedTime": 1737395691324,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/crackling-fury.json
+++ b/packs/core-abilities/crackling-fury.json
@@ -24,42 +24,14 @@
         },
         "description": "<p>Trigger: The user declares an Attack.</p><p>Effect: The triggering Attack has its Power increase by 40%, and it gains [Recoil 1/6] until the end of the user's Activation. While the user meets the [Desperation 1/3] Condition, this bonus increases to 70%.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "plasma-fists",
-        "name": "Plasma Fists",
-        "type": "attack",
-        "traits": [
-          "punch",
-          "dash",
-          "legendary",
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 3
-        },
-        "category": "physical",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "electric"
-        ],
-        "description": "<p>Effect: On hit, all of the the user's Normal Type attacks become Electric Type for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares an Attack.</p><p>Effect: Connection - Plasma Fists. The triggering Attack has its Power increase by 40%, and it gains [Recoil 1/6] until the end of the user's Activation. While the user meets the [Desperation 1/3] Condition, this bonus increases to 70%.</p>",
     "traits": [
       "legendary",
       "connection",
-      "desperation-1-3"
+      "desperation-1-3",
+      "partial-automation"
     ],
     "slug": "crackling-fury",
     "_migration": {
@@ -68,5 +40,73 @@
     }
   },
   "_id": "khQIUEZFYnHOyXnu",
-  "effects": []
+  "effects": [
+    {
+      "name": "Crackling Fury",
+      "type": "passive",
+      "_id": "hqvtnHxlck560m5P",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.6ZvqfZJZMSaXsvuG",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737395743738,
+        "modifiedTime": 1737395775683,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/curious-medicine.json
+++ b/packs/core-abilities/curious-medicine.json
@@ -23,27 +23,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "haze",
-        "name": "Haze",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 3
-        },
-        "category": "status",
-        "types": [
-          "ice"
-        ],
-        "description": "<p>Effect: The Stat Stages of all creatures in the combat are reset to their default values.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
         "slug": "haze-allies",
         "name": "Haze (Allies)",
         "type": "attack",
@@ -63,7 +42,8 @@
         "description": "<p>Effect: The Stat Stages of all allied creatures in the combat are reset to their default values.</p>",
         "free": true,
         "variant": "haze",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "slug": "haze-foes",
@@ -85,7 +65,8 @@
         "description": "<p>Effect: The Stage of all enemy creatures in the combat are reset to their default values.</p>",
         "free": true,
         "variant": "haze",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user enters combat.</p><p>Effect: Connection - Haze. The user freely uses Haze. Whenever the user uses Haze, they can 2 PP to have either 1) the user and its allies or 2) foes be excluded from Haze's effect.</p>",
@@ -99,5 +80,73 @@
     }
   },
   "_id": "AEKdQTZi4O8tBpm5",
-  "effects": []
+  "effects": [
+    {
+      "name": "Curious Medicine",
+      "type": "passive",
+      "_id": "rkWHtztJEzqvpPmG",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.eaBKFWmCB4ZeKP2k",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737395811820,
+        "modifiedTime": 1737395858509,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/dauntless-shield.json
+++ b/packs/core-abilities/dauntless-shield.json
@@ -36,106 +36,17 @@
           "activation": "free"
         },
         "description": "<p>Passive: When first entering Combat in Crowned Forme, the Iron Head on the user's Active List is replaced with Behemoth Bash for the remainder of the combat. The user's default DEF Stage is +1.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "iron-head",
-        "name": "Iron Head",
-        "type": "attack",
-        "traits": [
-          "dash",
-          "push-2",
-          "flinch-chance-2",
-          "contact",
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "creature",
-          "distance": 1,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "physical",
-        "power": 80,
-        "accuracy": 100,
-        "types": [
-          "steel"
-        ],
-        "description": "<p>Effect: On hit, the target has a 30% chance of being Flinched.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "behemoth-bash",
-        "name": "Behemoth Bash",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "dash",
-          "crushing",
-          "contact",
-          "pass-4",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "physical",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "steel"
-        ],
-        "free": true,
-        "variant": "iron-head",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "behemoth-bash-giant",
-        "name": "Behemoth Bash (Giant)",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "dash",
-          "crushing",
-          "contact",
-          "pass-4",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6,
-          "trigger": "The target is Dynamaxed.</p>"
-        },
-        "category": "physical",
-        "power": 200,
-        "accuracy": 100,
-        "types": [
-          "steel"
-        ],
-        "description": "<p>Trigger: The target is Dynamaxed.</p>",
-        "variant": "behemoth-bash",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Trigger: The user hits a creature that possess a higher CatMod than the user with Behemoth Bash.</p><p>Effect: Connection - Iron Head. The triggering creature gains @Affliction[taunted] 7, and the user gains @Affliction[rebound] 7. Passive:  When first entering Combat in Crowned Forme, the Iron Head on the user's Active List is replaced with Behemoth Bash for the remainder of the combat. The user's default DEF Stage is +1.</p>",
     "traits": [
-      "legendary"
+      "legendary",
+      "partial-automation"
     ],
     "slug": "dauntless-shield",
     "_migration": {
@@ -144,5 +55,73 @@
     }
   },
   "_id": "nseOdT3vpRN0AW0K",
-  "effects": []
+  "effects": [
+    {
+      "name": "Dauntless Shield",
+      "type": "passive",
+      "_id": "SL5wDgqnuATW2IkH",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.0rhyfVFsZ1asQIwv",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737395977286,
+        "modifiedTime": 1737396021720,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/delta-stream.json
+++ b/packs/core-abilities/delta-stream.json
@@ -28,25 +28,6 @@
       {
         "traits": [
           "legendary",
-          "weather"
-        ],
-        "name": "Delta Stream (Active)",
-        "slug": "delta-stream-active",
-        "type": "generic",
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 10
-        },
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "description": "<p>Intense Winds Weather is set until it is overridden or the user gains @Affliction[fainted] or leaves combat. If the user gains @Affliction[fainted] or leaves combat while Intense Winds is present, the Weather is set to Wind for 5 Rounds.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "traits": [
-          "legendary",
           "weather",
           "interrupt-6",
           "phenomena"
@@ -56,8 +37,7 @@
         "type": "generic",
         "cost": {
           "activation": "complex",
-          "trigger": "<p>The user enters combat or when the user gains this Ability.</p>",
-          "powerPoints": 0
+          "trigger": "<p>The user enters combat or when the user gains this Ability.</p>"
         },
         "range": {
           "target": "field",
@@ -71,7 +51,8 @@
     "traits": [
       "legendary",
       "weather",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "delta-stream",
     "_migration": {
@@ -91,15 +72,21 @@
           {
             "type": "grant-item",
             "key": "",
-            "value": "Compendium.ptr2e.core-abilities.Item.u9S8zbICHVUBS1Gx",
+            "value": "Compendium.ptr2e.core-moves.Item.u9S8zbICHVUBS1Gx",
             "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
             "mode": 2,
             "priority": null,
             "ignored": false,
             "reevaluateOnUpdate": false,
             "inMemoryOnly": false,
             "allowDuplicate": true,
-            "alterations": [],
             "track": false,
             "replaceSelf": false,
             "onDeleteActions": {
@@ -136,9 +123,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "0.10.0-alpha.5.1.5",
         "createdTime": 1733069184244,
-        "modifiedTime": 1733069218211,
+        "modifiedTime": 1737396139550,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }

--- a/packs/core-abilities/desolate-land.json
+++ b/packs/core-abilities/desolate-land.json
@@ -56,8 +56,7 @@
         "type": "generic",
         "cost": {
           "activation": "complex",
-          "trigger": "<p>The user enters combat or when the user gains this Ability.</p>",
-          "powerPoints": 0
+          "trigger": "<p>The user enters combat or when the user gains this Ability.</p>"
         },
         "range": {
           "target": "field",
@@ -71,7 +70,8 @@
     "traits": [
       "legendary",
       "weather",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "desolate-land",
     "_migration": {
@@ -91,15 +91,21 @@
           {
             "type": "grant-item",
             "key": "",
-            "value": "Compendium.ptr2e.core-abilities.Item.oZFYMEJhZ3CZSNEZ",
+            "value": "Compendium.ptr2e.core-moves.Item.oZFYMEJhZ3CZSNEZ",
             "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
             "mode": 2,
             "priority": null,
             "ignored": false,
             "reevaluateOnUpdate": false,
             "inMemoryOnly": false,
             "allowDuplicate": true,
-            "alterations": [],
             "track": false,
             "replaceSelf": false,
             "onDeleteActions": {
@@ -136,9 +142,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "0.10.0-alpha.5.1.5",
         "createdTime": 1733069184244,
-        "modifiedTime": 1733069218211,
+        "modifiedTime": 1737396240444,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }

--- a/packs/core-abilities/destructive-design.json
+++ b/packs/core-abilities/destructive-design.json
@@ -33,53 +33,11 @@
           "activation": "free"
         },
         "description": "<p>Passive: the user gains the Ability Download.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "techno-blast",
-        "name": "Techno Blast",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "pulse",
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "wide-line",
-          "distance": 10,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "special",
-        "power": 120,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: Techno Blast's Type changes to match the <Type> of the user's held [Drive] item.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "traits": [],
-        "name": "Download",
-        "slug": "download",
-        "type": "generic",
-        "cost": {
-          "activation": "free",
-          "powerPoints": 3,
-          "trigger": "<p>At the start of battle, or when switched in.</p>"
-        },
-        "range": {
-          "target": "creature",
-          "distance": 15,
-          "unit": "m"
-        },
-        "description": "<p>Trigger: At the start of battle, or when switched in.</p><p>Effect: If the targeted creature's DEF stat is higher than its SPDEF, the user raises their SPATK Stage by +1 for 5 Activations. If the targeted creature's DEF stat is lower than its SPDEF Stat, the user raises their ATK Stage by +1 for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Effect: Connection - Techno Blast. The user may activate Download, ignoring the Ability's normal triggering Affliction. Passive: the user gains the Ability Download.</p>",
@@ -94,5 +52,98 @@
     }
   },
   "_id": "kHHBW7Auyfs6t4yE",
-  "effects": []
+  "effects": [
+    {
+      "name": "Destructive Design",
+      "type": "passive",
+      "_id": "qG2cImyJbkWVCohT",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.gWjoYU30cvj8Vu4L",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.QFVLE2P6t5x6QRMN",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737396339571,
+        "modifiedTime": 1737396402790,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/diamond-domain.json
+++ b/packs/core-abilities/diamond-domain.json
@@ -5,33 +5,6 @@
   "system": {
     "actions": [
       {
-        "slug": "diamond-storm",
-        "name": "Diamond Storm",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "sharp",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 4,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "physical",
-        "power": 100,
-        "accuracy": 95,
-        "types": [
-          "rock"
-        ],
-        "description": "<p>Effect: After this attack resolves, the user has a 33% chance of raising their DEF Stage by +1 for 8 activations.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
         "slug": "diamond-storm-misty",
         "name": "Diamond Storm (Misty)",
         "type": "attack",
@@ -59,7 +32,8 @@
         "variant": "diamond-storm",
         "free": true,
         "description": "<p>The user is affected by Misty Terrain.</p><p>Effect: After this attack resolves, the user has a 33% chance of raising their DEF Stage by +1 for 8 activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "traits": [
@@ -83,7 +57,8 @@
     "description": "<p>Trigger: The user is affected by Misty Terrain and declares Diamond Storm.</p><p>Effect: Connection - Diamond Storm. The user can choose to use Diamond Storm at a Range of \"6m Cone\" until the end of their Activation.</p><p>Passive: While affected by Misty Terrain, the user's Diamond Storm also causes the user to have a 33% chance of raising their SPDEF Stage by +1 for 8 Activations, and the user and their allies possess the Ability Clear Body. The user and all allies within Range are always under the effects of Misty Terrain.</p>",
     "traits": [
       "legendary",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "diamond-domain",
     "_migration": {
@@ -92,5 +67,73 @@
     }
   },
   "_id": "G8xPqBtaBQVqlqwV",
-  "effects": []
+  "effects": [
+    {
+      "name": "Diamond Domain",
+      "type": "passive",
+      "_id": "sTV4y2HbdK7SPPGy",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.tksxYaXVMrev5G2D",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737396490208,
+        "modifiedTime": 1737396535183,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/dimensional-rifts.json
+++ b/packs/core-abilities/dimensional-rifts.json
@@ -25,69 +25,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "hyperspace-hole",
-        "name": "Hyperspace Hole",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "danger-close",
-          "pierce",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 20,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5,
-          "trigger": "<p>The user is in its Confined Forme.</p>"
-        },
-        "category": "special",
-        "power": 80,
-        "accuracy": 100,
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Trigger: The user is in its Confined Forme.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "hyperspace-fury",
-        "name": "Hyperspace Fury",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "crushing",
-          "punch",
-          "danger-close",
-          "pierce",
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4,
-          "trigger": "<p>The user is in its Unbound Forme.</p>"
-        },
-        "category": "physical",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "dark"
-        ],
-        "free": true,
-        "description": "<p>The user is in its Unbound Forme.</p><p>Effect: On hit, the user loses -1 DEF Stage for 5 activations.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
         "slug": "hyperspace-fury-unbound",
         "name": "Hyperspace Fury (Unbound)",
         "type": "attack",
@@ -119,7 +56,8 @@
         "free": true,
         "variant": "hyperspace-fury",
         "description": "<p>The user is in its Unbound Forme.</p><p>Effect: On resolution, the user loses -1 DEF Stage for 5 activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "slug": "hyperspace-fury-all-out",
@@ -153,7 +91,8 @@
         "free": true,
         "variant": "hyperspace-fury",
         "description": "<p>The user is in its Unbound Forme.</p><p>Effect: On resolution, the user loses -1 DEF Stage for 5 activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "traits": [
@@ -166,7 +105,11 @@
           "activation": "free"
         },
         "description": "<p>Passive: The user can choose to originate their attacks (other than Hyperspace Hole and Hyperspace Fury) any space within 10m of the user, and any such spaces can be treated as the user's space for originating Abilities (such as Magician). When in Unbound Forme, the user's Hyperspace Hole is replaced with Hyperspace Fury.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "range": {
+          "target": "enemy",
+          "unit": "m"
+        }
       }
     ],
     "description": "<p>Trigger: The user declares Hyperspace Hole or Hyperspace Fury.</p><p>Effect: Connection - Hyperspace Hole. At the end of a round, the user freely uses Metronome for each active Rift, originating its effect from a Rift that has not had a Metronome resolved through it, on a nearby target chosen by the user. A Rift lasts for 3 Rounds. When declaring Hyperspace Fury, the user can use Hyperspace Fury (Unbound) and Hyperspace Fury (All-Out).</p><p>Passive: The user can choose to originate their attacks (other than Hyperspace Hole and Hyperspace Fury) any space within 10m of the user, and any such spaces can be treated as the user's space for originating Abilities (such as Magician). When in Unbound Forme, the user's Hyperspace Hole is replaced with Hyperspace Fury.</p>",
@@ -181,5 +124,98 @@
     }
   },
   "_id": "0VYQA1KldrgnPZL7",
-  "effects": []
+  "effects": [
+    {
+      "name": "Dimensional Rifts",
+      "type": "passive",
+      "_id": "2La4pa52nRGWCHps",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.45AOpbdj7b05bGeT",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.i7b6zggR16BmZOQm",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737396590591,
+        "modifiedTime": 1737396698139,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/dread-wings.json
+++ b/packs/core-abilities/dread-wings.json
@@ -36,44 +36,19 @@
           "activation": "free"
         },
         "description": "<p>Passive: The user's Dark-Type attacks are now Super Effective against Fairy-Type creatures.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "oblivion-wing",
-        "name": "Oblivion Wing",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "drain-3-4",
-          "ray",
-          "aura",
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "line",
-          "distance": 8,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "special",
-        "power": 80,
-        "accuracy": 100,
-        "types": [
-          "flying"
-        ],
-        "description": "<p>Effect: This attack is considered both Flying and Dark Type.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Trigger: The user causes a creature to gain @Affliction[fainted] with Oblivion Wing.</p><p>Effect: Connection - Oblivion Wing. The user gains 4 Ticks of HP.</p><p>Passive: The user's Dark-Type attacks are now Super Effective against Fairy-Type creatures.</p>",
     "traits": [
       "legendary",
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "dread-wings",
     "_migration": {
@@ -82,5 +57,73 @@
     }
   },
   "_id": "5BvWFPMPoP3eGWWs",
-  "effects": []
+  "effects": [
+    {
+      "name": "Dread Wings",
+      "type": "passive",
+      "_id": "9q1DRg2wFKGesdyJ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.dByLKnrdqTOoQg2O",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.5BvWFPMPoP3eGWWs.ActiveEffect.9q1DRg2wFKGesdyJ",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737396824976,
+        "modifiedTime": 1737396869862,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/drizzle.json
+++ b/packs/core-abilities/drizzle.json
@@ -11,10 +11,10 @@
         ],
         "name": "Drizzle",
         "slug": "drizzle",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
+          "powerPoints": 4,
           "trigger": "<p>The user declares Rain Dance.</p>"
         },
         "range": {
@@ -22,37 +22,14 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user declares Rain Dance.</p><p>Effect: The set Rainy Weather has its duration increased by +2 Rounds.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "rain-dance",
-        "name": "Rain Dance",
-        "type": "attack",
-        "traits": [
-          "weather",
-          "dance"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "status",
-        "types": [
-          "water"
-        ],
-        "description": "<p>Effect: The Weather becomes Rainy for 3 rounds.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/magic/air/weather-clouds-rain.webp"
       }
     ],
     "description": "<p>Trigger: The user declares Rain Dance.</p><p>Effect: Connection - Rain Dance. The set Rainy Weather has its duration increased by +2 Rounds.</p>",
     "traits": [
       "connection",
-      "weather"
+      "weather",
+      "partial-automation"
     ],
     "slug": "drizzle",
     "_migration": {
@@ -61,5 +38,73 @@
     }
   },
   "_id": "0UrN28D0QVbkJHQf",
-  "effects": []
+  "effects": [
+    {
+      "name": "Drizzle",
+      "type": "passive",
+      "_id": "NP00BsjZu8KZffoK",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.tILTZn18N9r8H7cs",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.action.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737397228064,
+        "modifiedTime": 1737397258724,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/drought.json
+++ b/packs/core-abilities/drought.json
@@ -23,34 +23,13 @@
         },
         "description": "<p>Trigger: The user declares Sunny Day.</p><p>Effect: The set Sunny Weather has its duration increased by +2 Rounds.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "sunny-day",
-        "name": "Sunny Day",
-        "type": "attack",
-        "traits": [
-          "weather"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "status",
-        "types": [
-          "fire"
-        ],
-        "description": "<p>Effect: The Weather becomes Sunny for 3 rounds.</p>",
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares Sunny Day.</p><p>Effect: Connection - Sunny Day. The set Sunny Weather has its duration increased by +2 Rounds.</p>",
     "traits": [
       "connection",
-      "weather"
+      "weather",
+      "partial-automation"
     ],
     "slug": "drought",
     "_migration": {
@@ -59,5 +38,73 @@
     }
   },
   "_id": "o9y5NB42vrAfxz7L",
-  "effects": []
+  "effects": [
+    {
+      "name": "Drought",
+      "type": "passive",
+      "_id": "177y4emwACuj6djX",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.oZFYMEJhZ3CZSNEZ",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737397324717,
+        "modifiedTime": 1737397365980,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/dust-cloud.json
+++ b/packs/core-abilities/dust-cloud.json
@@ -24,55 +24,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "sand-attack",
-        "name": "Sand Attack",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "cone",
-          "distance": 3,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2
-        },
-        "category": "status",
-        "accuracy": 100,
-        "types": [
-          "ground"
-        ],
-        "description": "<p>Effect: On hit, all valid targets lose -1 ACC Stage for 5 activations.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "sand-attack-dusty",
-        "name": "Sand Attack (Dusty)",
-        "type": "attack",
-        "traits": [
-          "environ"
-        ],
-        "range": {
-          "target": "cone",
-          "distance": 3,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2,
-          "trigger": "<p>Dusty Weather is present.</p>"
-        },
-        "category": "status",
-        "accuracy": 100,
-        "types": [
-          "ground"
-        ],
-        "description": "<p>Trigger: Dusty Weather is present.</p><p>Effect: On hit, all valid targets lose -2 ACC Stage for 5 activations.</p>",
-        "variant": "sand-attack",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
         "slug": "dust-cloud",
         "name": "Dust Cloud",
         "type": "attack",
@@ -94,7 +45,8 @@
         "description": "<p>Effect: On hit, all valid targets lose -1 ACC Stage for 5 activations.</p>",
         "variant": "sand-attack",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "slug": "dust-cloud-dusty",
@@ -121,12 +73,14 @@
         "description": "<p>Trigger: Dusty Weather is present.</p><p>Effect: On hit, all valid targets lose -2 ACC Stage for 5 activations.</p>",
         "variant": "sand-attack",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user enters combat.</p><p>Effect: Connection - Sand Attack. The user freely uses Dust Cloud or Dust Cloud (Dusty).</p>",
     "traits": [
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "dust-cloud",
     "_migration": {
@@ -135,5 +89,78 @@
     }
   },
   "_id": "1u2SNaKakrSMUV4N",
-  "effects": []
+  "effects": [
+    {
+      "name": "Dust Cloud",
+      "type": "passive",
+      "_id": "ntw7tNz4PH8JdQ2c",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.RNsjfgPa66NJ8zR7",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.1.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737397441460,
+        "modifiedTime": 1737397494266,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/electric-surge.json
+++ b/packs/core-abilities/electric-surge.json
@@ -42,36 +42,14 @@
         },
         "description": "<p>Passive: If a space within range possesses Electric Terrain, the user is affected by Electric Terrain.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "electric-terrain",
-        "name": "Electric Terrain",
-        "type": "attack",
-        "traits": [
-          "terrain"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 3
-        },
-        "category": "status",
-        "types": [
-          "electric"
-        ],
-        "description": "<p>Effect: The Terrain type is set to Electric Terrain for 3 rounds.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares Electric Terrain.</p><p>Effect: Connection - Electric Terrain. Increase the number of rounds Electric Terrain persists by 2.</p><p>Passive: If a space within range possesses Electric Terrain, the user is affected by Electric Terrain.</p>",
     "traits": [
       "terrain",
       "connection",
-      "environ"
+      "environ",
+      "partial-automation"
     ],
     "slug": "electric-surge",
     "_migration": {
@@ -80,5 +58,73 @@
     }
   },
   "_id": "dfgFR3b6OQ51IFij",
-  "effects": []
+  "effects": [
+    {
+      "name": "Electric Surge",
+      "type": "passive",
+      "_id": "Il1P7XTHneiESWml",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.dPSChKwDs2PiIA7p",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737397548253,
+        "modifiedTime": 1737397575744,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/electromorphosis.json
+++ b/packs/core-abilities/electromorphosis.json
@@ -13,7 +13,6 @@
         "type": "generic",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
           "trigger": "<p>The user is damaged by a Physical or Special-Category Attack.</p>"
         },
         "range": {
@@ -21,28 +20,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user is damaged by a Physical or Special-Category Attack.</p><p>Effect: The user freely uses Charge.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "charge",
-        "name": "Charge",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "types": [
-          "electric"
-        ],
-        "description": "<p>Effect: The user gains @Affliction[charged] 1 and +1 SPDEF Stage 5 Activations.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/svg/electric_icon.svg"
       }
     ],
     "description": "<p>Trigger: The user is damaged by a Physical or Special-Category Attack. </p><p>Effect: Connection - Charge. The user freely uses Charge.</p>",
@@ -57,5 +35,73 @@
     }
   },
   "_id": "j9Tw0Acw7QTDno46",
-  "effects": []
+  "effects": [
+    {
+      "name": "Electromorphosis",
+      "type": "passive",
+      "_id": "KsomcafLsRQWDVf1",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.SyYgWBDdxlHBpXS6",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737397621209,
+        "modifiedTime": 1737397679993,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/embody-aspect.json
+++ b/packs/core-abilities/embody-aspect.json
@@ -106,35 +106,6 @@
         },
         "description": "<p>Effect: The user possesses Sturdy and Solid Rock as Extra Abilities, gains the Rock Type, may use Ivy Cudgel as Rock Type, and has its Tera Type replaced with Rock. While the user is Terastallized, they have +1 default DEF Stage.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "ivy-cudgel",
-        "name": "Ivy Cudgel",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "crit-2",
-          "blast-1",
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 2,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "physical",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "grass"
-        ],
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Effect: Connection - Ivy Cudgel. While the user has a specific [Oni Mask] item equipped in a [Worn] slot, they gain the following benefits:</p><p>- Teal Mask: the user possesses Defiant and Antitoxin as Extra Abilities and has its Tera Type replaced with Grass. While the user is Terastallized, they have +1 default SPD Stage.</p><p>- Wellspring Mask: the user possesses Water Absorb and Seaweed as Extra Abilities, gains the Water Type, may use Ivy Cudgel as Water Type, and has its Tera Type replaced with Water. While the user is Terastallized, they have +1 default SPDEF Stage.</p><p>- Hearthflame Mask: the user possesses Mold Breaker and Flaming Soul as Extra Abilities. gains the Fire  Type, may use Ivy Cudgel as Fire Type, and has its Tera Type replaced with Fire. While the user is Terastallized, they have +1 default ATK Stage.</p><p>- Cornerstone Mask: the user possesses Sturdy and Solid Rock as Extra Abilities, gains the Rock Type, may use Ivy Cudgel as Rock Type, and has its Tera Type replaced with Rock. While the user is Terastallized, they have +1 default DEF Stage.</p>",
@@ -144,7 +115,8 @@
       "connection",
       "phenomenon",
       "forme-change",
-      "legendary"
+      "legendary",
+      "partial-automation"
     ],
     "slug": "embody-aspect",
     "_migration": {
@@ -153,5 +125,73 @@
     }
   },
   "_id": "kuCAeacxyPBxz7On",
-  "effects": []
+  "effects": [
+    {
+      "name": "Embody Aspect",
+      "type": "passive",
+      "_id": "5wX7VzteMyJ6ezMP",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.uSp7iRwvQHZZ3M1Y",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737397735979,
+        "modifiedTime": 1737397773940,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/emergency-exit.json
+++ b/packs/core-abilities/emergency-exit.json
@@ -23,34 +23,6 @@
         },
         "description": "<p>Trigger: An attack is resolved against the user and the user meets the [Desperation 1/2] Condition.</p><p>Effect: The user freely Moves up to half of a Movement Score of their choice, and freely attacks a valid target with U-Turn.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "u-turn",
-        "name": "U-Turn",
-        "type": "attack",
-        "traits": [
-          "dash",
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "physical",
-        "power": 70,
-        "accuracy": 100,
-        "types": [
-          "bug"
-        ],
-        "description": "<p>Effect: On hit, the user may freely move themselves up to half of the Movement Score of their choice away from the target. If the user is an owned Pokémon, they may then immediately be returned their Poké Ball and another Pokémon may immediately be sent out in their place.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: An attack is resolved against the user and the user meets the [Desperation 1/2] Condition.</p><p>Effect: Connection - U-Turn. The user freely Moves up to half of a Movement Score of their choice, and freely attacks a valid target with U-Turn.</p>",
@@ -66,5 +38,73 @@
     }
   },
   "_id": "bSQ3oOt942UWmFTc",
-  "effects": []
+  "effects": [
+    {
+      "name": "Emergency Exit",
+      "type": "passive",
+      "_id": "161NjhuJ3DbODxyk",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.DTnhRJBYhTBapjIK",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737397810021,
+        "modifiedTime": 1737397842062,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/energy-forge.json
+++ b/packs/core-abilities/energy-forge.json
@@ -1,7 +1,7 @@
 {
   "name": "Energy Forge",
   "type": "ability",
-  "img": "systems/ptr2e/img/icons/ability_icon.webp",
+  "img": "icons/tools/smithing/crucible.webp",
   "system": {
     "actions": [
       {
@@ -16,16 +16,14 @@
         "cost": {
           "activation": "free",
           "powerPoints": 4,
-          "trigger": "<p>The user resolves Fortify.</p>",
-          "delay": null,
-          "priority": null
+          "trigger": "<p>The user resolves Fortify.</p>"
         },
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
-        "description": "<p>Trigger: The user resolves Fortify.</p><p>Effect: The user gains +1 default DEF and SPDEF Stages.</p>"
+        "description": "<p>Trigger: The user resolves Fortify.</p><p>Effect: The user gains +1 default DEF and SPDEF Stages.</p>",
+        "img": "icons/svg/explosion.svg"
       },
       {
         "traits": [
@@ -37,79 +35,120 @@
         "slug": "energy-forge",
         "type": "passive",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "range": {
           "target": "aura",
           "distance": 10,
           "unit": "m"
         },
-        "description": "<p>Passive: The user and all creatures within Range increase the Power of their Dragon- and Steel-Type attacks by 20%.</p>"
-      },
-      {
-        "slug": "fortify",
-        "name": "Fortify",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "aura",
-          "set-up"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 8,
-          "delay": null,
-          "priority": null,
-          "trigger": null
-        },
-        "category": "status",
-        "power": null,
-        "accuracy": null,
-        "types": [
-          "steel"
-        ],
-        "description": "<p>Effect: Set-Up: the user radiates an uplifting Power, with the user gaining @Affliction[braced] 1 and @Affliction[harden] 7, and healing 3 Ticks of HP.</p><p>Resolution: The user and all allies within range gain +1 DEF and SPDEF Stages for 7 activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": true,
-        "slot": null
+        "description": "<p>Passive: The user and all creatures within Range increase the Power of their Dragon- and Steel-Type attacks by 20%.</p>",
+        "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Trigger: The user resolves Fortify.</p><p>Effect: Connection - Fortify. When the user resolves Fortify, they gain +1 default DEF and SPDEF Stages. Passive: The user and all creatures within 10m increase the Power of their Dragon- and Steel-Type attacks by 20%.</p>",
+    "description": "<p>Trigger: The user resolves Fortify.</p><p>Effect: Connection - Fortify. When the user resolves Fortify, they gain +1 DEF and SPDEF Stages for 5 activations. Passive: The user and all creatures within 10m increase the Power of their Dragon- and Steel-Type attacks by 20%.</p>",
     "traits": [
       "legendary",
       "defensive",
-      "aura"
+      "aura",
+      "partial-automation"
     ],
-    "slug": null,
-    "container": null
+    "slug": "energy-forge",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "XUoFs30VOQeUd2BU",
-  "effects": [],
-  "folder": null,
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.324",
-    "systemId": "ptr2e",
-    "systemVersion": "0.005",
-    "createdTime": 1716919240454,
-    "modifiedTime": 1716919240454,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!XUoFs30VOQeUd2BU"
+  "effects": [
+    {
+      "name": "Energy Forge",
+      "type": "passive",
+      "_id": "a57yoptGzthOKL6D",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.Y1uDok1TyCvhGqDG",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "roll-effect",
+            "key": "fortify-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.sMystTj3FBJ00AZp",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "fortify-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.jEX7s3GbbAtzgyS3",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737397898752,
+        "modifiedTime": 1737398013510,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/evaporate.json
+++ b/packs/core-abilities/evaporate.json
@@ -1,7 +1,7 @@
 {
   "name": "Evaporate",
   "type": "ability",
-  "img": "systems/ptr2e/img/svg/ice_icon.svg",
+  "img": "systems/ptr2e/img/svg/fire_icon.svg",
   "system": {
     "actions": [
       {
@@ -23,29 +23,6 @@
         },
         "description": "<p>Trigger: The user is hit by a Water-Type attack.</p><p>Effect: The user takes half damage from the attack and is unaffected by the triggering Attack's effects. Then, the user freely uses Mist.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "mist",
-        "name": "Mist",
-        "type": "attack",
-        "traits": [
-          "shield"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 3
-        },
-        "category": "status",
-        "types": [
-          "ice"
-        ],
-        "description": "<p>Effect: For 3 rounds, the user and its allies cannot have their stat Stages reduced.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a Water-Type attack.</p><p>Effect: Connection - Mist. The user takes half damage from the attack and is unaffected the triggering Attack's effects. Then, the user freely uses Mist.</p>",
@@ -60,5 +37,73 @@
     }
   },
   "_id": "tSF30sI3iDjAAYyW",
-  "effects": []
+  "effects": [
+    {
+      "name": "Evaporate",
+      "type": "passive",
+      "_id": "Tle6tVwzMzA7aUoR",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.kUNtCRHzgIlTVu9W",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737398118242,
+        "modifiedTime": 1737398160431,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/flash-fire.json
+++ b/packs/core-abilities/flash-fire.json
@@ -23,27 +23,6 @@
         },
         "description": "<p>Trigger: The user is hit by a Fire-Type attack.</p><p>Effect: The user takes no damage from the triggering attack and is not affected by the triggering attack's effect. Then, the user freely uses Stoke.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "stoke",
-        "name": "Stoke",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "types": [
-          "fire"
-        ],
-        "description": "<p>Effect: The user gains @Affliction[stoked] 1 and +1 SPD Stage for 5 Activations.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a Fire-Type attack.</p><p>Effect: Connection - Stoke. The user takes no damage from the triggering attack and is not affected by the triggering attack's effect. Then, the user freely uses Stoke.</p>",
@@ -58,5 +37,73 @@
     }
   },
   "_id": "A89H4xiNBvel78X6",
-  "effects": []
+  "effects": [
+    {
+      "name": "Flash Fire",
+      "type": "passive",
+      "_id": "LDYjzLioVKUBufMy",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.51bKgpaPceb1kg5n",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737398204591,
+        "modifiedTime": 1737398235552,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/forecast.json
+++ b/packs/core-abilities/forecast.json
@@ -16,183 +16,11 @@
           "activation": "free"
         },
         "description": "<p>Passive: The user's Stats increase by 20% while a [Weather] is present, and 40% while an Intense [Weather] is present. The user's Forme changes to match one of the current active [Weather]s (user's choice whenever a Weather is set, returning to its normal Forme in Clear Weather.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "weather-ball",
-        "name": "Weather Ball",
-        "type": "attack",
-        "traits": [
-          "pulse",
-          "missile",
-          "environ",
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "creature",
-          "distance": 10,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "special",
-        "power": 50,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "weather-ball-weather",
-        "name": "Weather Ball (Weather)",
-        "type": "attack",
-        "traits": [
-          "pulse",
-          "missile",
-          "environ",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "special",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "variant": "weather-ball",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "weather-ball-intense-weather",
-        "name": "Weather Ball (Intense Weather)",
-        "type": "attack",
-        "traits": [
-          "pulse",
-          "missile",
-          "environ",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "special",
-        "power": 150,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "variant": "weather-ball",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "weather-ball-casted",
-        "name": "Weather Ball (Casted)",
-        "type": "attack",
-        "traits": [
-          "pulse",
-          "missile",
-          "environ",
-          "blast-3",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "special",
-        "power": 50,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "variant": "weather-ball",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "weather-ball-weather-casted",
-        "name": "Weather Ball (Weather Casted)",
-        "type": "attack",
-        "traits": [
-          "pulse",
-          "missile",
-          "environ",
-          "blast-3",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "special",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "variant": "weather-ball",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "weather-ball-intense-weather-casted",
-        "name": "Weather Ball (Intense Weather Casted)",
-        "type": "attack",
-        "traits": [
-          "pulse",
-          "missile",
-          "environ",
-          "blast-3",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "special",
-        "power": 150,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "variant": "weather-ball",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Trigger: The user declares Weather Ball.</p><p>Effect: Connection - Weather Ball.  The user adds [Blast 3] to the triggering attack for the rest of their Activation. Passive: The user's Stats increase by 20% while a [Weather] is present, and 40% while an Intense [Weather] is present. The user's Forme changes to match one of the current active [Weather]s (user's choice whenever a Weather is set, returning to its normal Forme in Clear Weather.</p>",
@@ -208,5 +36,83 @@
     }
   },
   "_id": "1hYY0Ae6pdN5rN9b",
-  "effects": []
+  "effects": [
+    {
+      "name": "Forecast",
+      "type": "passive",
+      "_id": "Xc41auYOo6RH0KBd",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.cZHbswFvDLxTRSq2",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.1.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.2.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737398314673,
+        "modifiedTime": 1737398383069,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/foretold.json
+++ b/packs/core-abilities/foretold.json
@@ -37,63 +37,6 @@
           "target": "enemy",
           "unit": "m"
         }
-      },
-      {
-        "slug": "future-sight",
-        "name": "Future Sight",
-        "type": "attack",
-        "traits": [
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "special",
-        "power": 120,
-        "accuracy": 100,
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: When this attack is used, it deals its damage to the target at the start of the user's first Activation in the following Round.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "future-sight",
-        "name": "Future Sight",
-        "type": "attack",
-        "traits": [
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null,
-          "trigger": null
-        },
-        "category": "special",
-        "power": 120,
-        "accuracy": 100,
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: When this attack is used, it deals its damage to the target at the start of the user's first Activation in the following Round.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": true,
-        "slot": null
       }
     ],
     "description": "<p>Trigger: An enemy creature enters combat.</p><p>Effect: Connection - Future Sight. The user freely uses Future Sight on the triggering creature. Passive: The user has +1 default EVA Stage.</p>",
@@ -109,7 +52,7 @@
   "_id": "iwAF8yC0xgaUwmjK",
   "effects": [
     {
-      "name": "Foretold Passive",
+      "name": "Foretold",
       "type": "passive",
       "_id": "rZ0KChgC4SprpxNZ",
       "img": "systems/ptr2e/img/icons/effect_icon.webp",
@@ -117,12 +60,37 @@
         "changes": [
           {
             "type": "basic",
-            "key": "system.battleStats.evasion.Stage",
+            "key": "system.battleStats.evasion.stage",
             "value": 1,
             "predicate": [],
             "mode": 2,
             "priority": null,
             "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "key": "Compendium.ptr2e.core-moves.Item.mFTIJjM1A7Ty1vBb",
+            "value": "Compendium.ptr2e.core-moves.Item.mFTIJjM1A7Ty1vBb",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
           }
         ],
         "slug": null,
@@ -153,10 +121,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.2.0.3",
+        "systemVersion": "0.10.0-alpha.5.1.5",
         "createdTime": 1722259246709,
-        "modifiedTime": 1722259264297,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+        "modifiedTime": 1737398514469,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }
   ]

--- a/packs/core-abilities/sword-of-ruin.json
+++ b/packs/core-abilities/sword-of-ruin.json
@@ -45,14 +45,16 @@
         ],
         "description": "<p>Effect: On hit, all valid target's HP is cut in half. This attack always deals a minimum of 1 HP in damage.</p>",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Effect: Connection - Ruination. All other creatures have their DEF stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
     "traits": [
       "legendary",
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "sword-of-ruin",
     "_migration": {
@@ -61,5 +63,73 @@
     }
   },
   "_id": "mScBrZRMBkCr97fh",
-  "effects": []
+  "effects": [
+    {
+      "name": "Treasure of Ruin",
+      "type": "passive",
+      "_id": "YgWmBGhvm5CC56gf",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.6MiHI8QGhMknDms5",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.sWdQIvH00vsGkCYB.ActiveEffect.J2mZCtyIjIqYFGrQ",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392977380,
+        "modifiedTime": 1737392977380,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/tablets-of-ruin.json
+++ b/packs/core-abilities/tablets-of-ruin.json
@@ -45,14 +45,16 @@
         ],
         "description": "<p>Effect: On hit, all valid target's HP is cut in half. This attack always deals a minimum of 1 HP in damage.</p>",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Effect: Connection - Ruination. All other creatures have their ATK stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
     "traits": [
       "legendary",
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "tablets-of-ruin",
     "_migration": {
@@ -61,5 +63,73 @@
     }
   },
   "_id": "5KUeoSGMw8YWNwDO",
-  "effects": []
+  "effects": [
+    {
+      "name": "Treasure of Ruin",
+      "type": "passive",
+      "_id": "gyzlusEjK4iMgITC",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.6MiHI8QGhMknDms5",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.sWdQIvH00vsGkCYB.ActiveEffect.J2mZCtyIjIqYFGrQ",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392939156,
+        "modifiedTime": 1737392939156,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/vessel-of-ruin.json
+++ b/packs/core-abilities/vessel-of-ruin.json
@@ -45,14 +45,16 @@
         ],
         "description": "<p>Effect: On hit, all valid target's HP is cut in half. This attack always deals a minimum of 1 HP in damage.</p>",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Effect: Connection - Ruination. All other creatures have their SPATK stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
     "traits": [
       "legendary",
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "vessel-of-ruin",
     "_migration": {
@@ -61,5 +63,73 @@
     }
   },
   "_id": "97i4MiUWeQPLtv3G",
-  "effects": []
+  "effects": [
+    {
+      "name": "Treasure of Ruin",
+      "type": "passive",
+      "_id": "oSU2QsG2BuMUYQMc",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.6MiHI8QGhMknDms5",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.sWdQIvH00vsGkCYB.ActiveEffect.J2mZCtyIjIqYFGrQ",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392957010,
+        "modifiedTime": 1737392957010,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/berserker.json
+++ b/packs/core-perks/berserker.json
@@ -5,163 +5,7 @@
   "_id": "fTAcIGm5QGWoKB1D",
   "img": "systems/ptr2e/img/icons/physical_icon.png",
   "system": {
-    "actions": [
-      {
-        "slug": "rage",
-        "name": "Rage",
-        "type": "attack",
-        "traits": [
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null
-        },
-        "category": "physical",
-        "power": 20,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: The user gains @Affliction[enraged] 2. While @Affliction[enraged], if the user is hit by a damaging attack, they gain +1 ATK Stage for 5 activations.</p>",
-        "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
-      },
-      {
-        "name": "Frenzy Rush",
-        "slug": "frenzy-rush",
-        "type": "attack",
-        "img": "icons/svg/explosion.svg",
-        "traits": [
-          "5-strike",
-          "contact",
-          "sharp",
-          "jaw",
-          "horn",
-          "punch",
-          "kick",
-          "weapon",
-          "exhaust",
-          "basic",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
-        },
-        "types": [
-          "normal"
-        ],
-        "category": "physical",
-        "power": 30,
-        "accuracy": 75,
-        "variant": null,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
-      },
-      {
-        "slug": "work-up",
-        "name": "Work Up",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "self",
-          "unit": "m",
-          "distance": 0
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: The user raises their ATK and SPATK Stages by +1 for 5 activations.</p>",
-        "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
-      },
-      {
-        "slug": "work-up-enraged",
-        "name": "Work Up (Enraged)",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "self",
-          "unit": "m",
-          "distance": 0
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 3,
-          "trigger": "<p>The user is @Affliction[enraged].</p>",
-          "delay": null,
-          "priority": null
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Trigger: The user is @Affliction[enraged].</p><p>Effect: The user gains +1 ATK and SPATK Stages for 5 activations.</p>",
-        "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
-      }
-    ],
+    "actions": [],
     "slug": "berserker",
     "description": "<p>Gain the [Berserker] trait and gain access to the [Berserker] Tutor List. The user learns Rage, Work Up, and Frenzy Rush.</p>",
     "traits": [],
@@ -212,9 +56,6 @@
     "autoUnlock": [
       "trait:berserker"
     ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
@@ -276,15 +117,21 @@
           {
             "type": "grant-item",
             "key": "",
-            "value": "Compendium.ptr2e.core-moves.Item.DymPJiI57iCzqLp1",
+            "value": "Compendium.ptr2e.core-moves.Item.Zsg9MXOaKH3vAb6q",
             "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.1.free",
+                "value": "true"
+              }
+            ],
             "mode": 2,
             "priority": null,
             "ignored": false,
             "reevaluateOnUpdate": false,
             "inMemoryOnly": false,
             "allowDuplicate": true,
-            "alterations": [],
             "track": false,
             "replaceSelf": false,
             "onDeleteActions": {
@@ -292,7 +139,6 @@
               "granter": "cascade"
             }
           }
-
         ],
         "slug": null,
         "traits": [],
@@ -322,10 +168,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.4.1",
+        "systemVersion": "0.10.0-alpha.5.1.5",
         "createdTime": 1732232360900,
-        "modifiedTime": 1732232368578,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+        "modifiedTime": 1737391812514,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }
   ]

--- a/packs/core-perks/chansey-medicine.json
+++ b/packs/core-perks/chansey-medicine.json
@@ -16,14 +16,11 @@
         ],
         "range": {
           "target": "creature",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
         "category": "status",
         "types": [
@@ -31,18 +28,7 @@
         ],
         "description": "<p>Effect: The target recovers 4 Ticks of HP.</p>",
         "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
+        "predicate": []
       }
     ],
     "slug": "chansey-medicine",
@@ -58,8 +44,12 @@
     ],
     "cost": 1,
     "_migration": {
-      "version": null,
-      "previous": null
+      "version": 0.11,
+      "previous": {
+        "schema": null,
+        "foundry": "12.331",
+        "system": "0.10.0-alpha.5.1.2"
+      }
     },
     "nodes": [
       {
@@ -93,9 +83,7 @@
     "autoUnlock": [
       "trait:healer"
     ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
+    "originSlug": "chansey-medicine",
     "global": true,
     "webs": []
   },
@@ -118,8 +106,27 @@
           },
           {
             "type": "grant-item",
-            "key": "",
-            "value": "Compendium.ptr2e.core-moves.Item.6OK8vhZYljL4X7cd",
+            "key": "rage",
+            "value": "Compendium.ptr2e.core-moves.Item.W85QPAFdQRYn5Yfp",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "workUp",
+            "value": "Compendium.ptr2e.core-moves.Item.DymPJiI57iCzqLp1",
             "predicate": [],
             "mode": 2,
             "priority": null,
@@ -138,7 +145,7 @@
           {
             "type": "grant-item",
             "key": "",
-            "value": "Compendium.ptr2e.core-moves.Item.Zsg9MXOaKH3vAb6q",
+            "value": 0,
             "predicate": [],
             "mode": 2,
             "priority": null,
@@ -153,7 +160,7 @@
               "grantee": "detach",
               "granter": "cascade"
             }
-          }          
+          }
         ],
         "slug": null,
         "traits": [],
@@ -163,7 +170,7 @@
       },
       "disabled": false,
       "duration": {
-        "startTime": null,
+        "startTime": 0,
         "seconds": null,
         "combat": null,
         "rounds": null,
@@ -177,16 +184,29 @@
       "transfer": true,
       "statuses": [],
       "sort": 0,
-      "flags": {},
+      "flags": {
+        "ptr2e": {
+          "itemGrants": {
+            "rage": {
+              "id": "RDgSQIbNjQvDgq1t",
+              "onDelete": "detach"
+            },
+            "workUp": {
+              "id": "AWK4YzjeM0jv7ot8",
+              "onDelete": "detach"
+            }
+          }
+        }
+      },
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-perks.Item.OWyKxGQEmvucwXQw.ActiveEffect.jYRRns43LCZAkrHB",
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.4.1",
-        "createdTime": 1732231695711,
-        "modifiedTime": 1732231705543,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": null,
+        "modifiedTime": 1737391927301,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }
   ]

--- a/packs/core-perks/drill-sergeant.json
+++ b/packs/core-perks/drill-sergeant.json
@@ -6,80 +6,7 @@
       "version": 0.109,
       "previous": null
     },
-    "actions": [
-      {
-        "slug": "dragon-cheer",
-        "name": "Dragon Cheer",
-        "type": "attack",
-        "traits": [
-          "sonic"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 5,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
-        },
-        "category": "status",
-        "types": [
-          "dragon"
-        ],
-        "description": "<p>Effect: The user and all allies in range gain +1 CRIT Stage for 5 activations. Dragon-type creature instead gain +2 CRIT Stages for 5 activations.</p>",
-        "slot": 3,
-        "img": "systems/ptr2e/img/svg/dragon_icon.svg",
-        "free": true,
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
-      },
-      {
-        "slug": "coaching",
-        "name": "Coaching",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "emanation",
-          "distance": 3,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null
-        },
-        "category": "status",
-        "types": [
-          "fighting"
-        ],
-        "description": "<p>Effect: The user and all allies in range gain +1 ATK and DEF Stage for 5 activations.</p>",
-        "free": true,
-        "img": "systems/ptr2e/img/perk-icons/Orders_Training.svg",
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
-      }
-    ],
+    "actions": [],
     "description": "<p>You learn the moves Dragon Cheer and Coaching, and gain them as Connected Moves.</p>",
     "traits": [],
     "prerequisites": [
@@ -115,14 +42,104 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "img": "systems/ptr2e/img/perk-icons/Orders_Training.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Drill Sergeant",
+      "type": "passive",
+      "_id": "42H6epwnrk9UnKyT",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.VoiUETAcuekeVO32",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.F4GCikgU29LS0wu7",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392003677,
+        "modifiedTime": 1737392098018,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "_id": "F4l5fiHA0sXoMbx6",
   "folder": "PAZ8zWUPw7Azm5V6"
 }

--- a/packs/core-perks/formation-attacks.json
+++ b/packs/core-perks/formation-attacks.json
@@ -19,64 +19,21 @@
         "slug": "formation-attacks",
         "description": "<p>When within Reach of a creature, you gain +1 ACC on Attacks against that creature for every other Pack Member that is also within Reach of that creature.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
-      },
-      {
-        "slug": "beat-up",
-        "name": "Beat Up",
-        "type": "attack",
-        "traits": [
-          "dash",
-          "x-strike",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
-        },
-        "category": "physical",
-        "power": 15,
-        "accuracy": 100,
-        "types": [
-          "dark"
-        ],
-        "description": "<p>This attacks's [X-Stike] value is equal to 1 plus the number of allied creatures that have the target within their Reach, to a maximum of 15 hits.</p>",
-        "free": true,
-        "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-        "variant": null,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
+        }
       }
     ],
     "slug": "formation-attacks",
-    "traits": [],
+    "traits": [
+      "partial-automation"
+    ],
     "_migration": {
       "version": null,
       "previous": null
@@ -103,14 +60,79 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "_id": "zW2fOBtO1e0LEv2K",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Formation Attacks",
+      "type": "passive",
+      "_id": "KUJ5npMcKFqDTNcA",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.V9TPmNdhcCvnw98x",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737391341790,
+        "modifiedTime": 1737391374354,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "UZGN1glVNXLieg48"
 }

--- a/packs/core-perks/hexcraft.json
+++ b/packs/core-perks/hexcraft.json
@@ -7,7 +7,7 @@
   "system": {
     "actions": [],
     "slug": "hexcraft",
-    "description": "<p>You gain access to the [Haxcraft] trait and Tutor List, and you learn Spite, Grudge, and Night Shade.</p>",
+    "description": "<p>You gain access to the [Hexcraft] trait and Tutor List, and you learn Spite, Grudge, and Night Shade.</p>",
     "traits": [],
     "prerequisites": [
       {
@@ -51,9 +51,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
@@ -73,6 +70,63 @@
             "mode": 2,
             "priority": null,
             "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.K2lzFMHQ5Ey3bnzZ",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.fUiCzF9ucUhoJLBq",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.9ajTWumV2CHLWvWK",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
           }
         ],
         "slug": null,
@@ -91,7 +145,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>You gain access to the [Hexcraft] trait and Tutor List, and you learn Spite, Grudge, and Night Shade.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -103,10 +157,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.0.0",
+        "systemVersion": "0.10.0-alpha.5.1.5",
         "createdTime": 1732231964521,
-        "modifiedTime": 1732564242928,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+        "modifiedTime": 1737392158961,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }
   ]

--- a/packs/core-perks/kinetic-dispersion.json
+++ b/packs/core-perks/kinetic-dispersion.json
@@ -23,26 +23,14 @@
         "cost": {
           "activation": "complex",
           "powerPoints": 5,
-          "trigger": "The user is damaged by a Physical damaging attack.",
-          "delay": null,
-          "priority": null
+          "trigger": "The user is damaged by a Physical damaging attack."
         },
         "types": [
           "fighting"
         ],
         "category": "physical",
         "free": true,
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
+        "predicate": []
       }
     ],
     "description": "<p>The user learns the Move Tenkan. Counter and Tenkan become Connected.</p>",
@@ -78,13 +66,78 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Kinetic Dispersion",
+      "type": "passive",
+      "_id": "PvatmwIJyl93iCf1",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.TzmxWMEVbUTipXGX",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392192863,
+        "modifiedTime": 1737392222392,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "_id": "3V5NjQw7ytHQmxw7"
 }

--- a/packs/core-perks/punishment-ward.json
+++ b/packs/core-perks/punishment-ward.json
@@ -39,11 +39,101 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Punishment Ward",
+      "type": "passive",
+      "_id": "GphBDlZViLi47BWK",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.Do4KJ9riUaghCF4B",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.Co4KJ9riUaghDK9Z",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737391430809,
+        "modifiedTime": 1737391507930,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/relay-race.json
+++ b/packs/core-perks/relay-race.json
@@ -7,44 +7,8 @@
       "version": 0.109,
       "previous": null
     },
-    "actions": [
-      {
-        "slug": "baton-pass",
-        "name": "Baton Pass",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "self",
-          "unit": "m",
-          "distance": 0
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: This attack can only be used by an owned Pokemon. The user switches with an allied Pokemon, returning to their owned Pokeball in the process. The ally gains the user’s [Stage Change] effects, [Pseudo Affliction]s, and other beneficial effects.</p>",
-        "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
-      }
-    ],
-    "description": "<p>You learn and are able to use Baton Pass on behalf of your Pokemon, switching them out as if they had used the Move themselves.</p>",
+    "actions": [],
+    "description": "<p>You learn and are able to use Baton Pass on behalf of your Pokemon, switching them out as if they had used the Move themselves.<br><br>Connection: Baton Pass</p>",
     "traits": [],
     "prerequisites": [
       "trait:trainer",
@@ -74,13 +38,78 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "img": "systems/ptr2e/img/perk-icons/Juggler.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Relay Race",
+      "type": "passive",
+      "_id": "Mph3cxdVSfe9UtGo",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.OhO8s2Gaw1AAnuJl",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392260800,
+        "modifiedTime": 1737392301952,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "_id": "jdQ27YKL5LkVTATx"
 }

--- a/packs/core-perks/screen-setter.json
+++ b/packs/core-perks/screen-setter.json
@@ -15,93 +15,15 @@
         "description": "<p>When using either Light Screen or Reflect, you may spend 3PP to also use the other one as a Free Action at [Interrupt 2].</p>",
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
         "type": "generic",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null
-      },
-      {
-        "slug": "reflect",
-        "name": "Reflect",
-        "type": "attack",
-        "traits": [
-          "shield"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m",
-          "distance": 0
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
-        },
-        "category": "status",
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: For 3 rounds, the user and all allies take 50% less damage from Physical attacks.</p>",
-        "free": true,
-        "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
-      },
-      {
-        "slug": "light-screen",
-        "name": "Light Screen",
-        "type": "attack",
-        "traits": [
-          "shield"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m",
-          "distance": 0
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
-        },
-        "category": "status",
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: For 3 rounds, the user and all allies take 50% less damage from Special attacks.</p>",
-        "free": true,
-        "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
+          "unit": "m"
+        }
       }
     ],
     "slug": "screen-setter",
@@ -137,14 +59,79 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "_id": "cnTPWqYXmGaFZfBd",
   "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Screen Setter",
+      "type": "passive",
+      "_id": "32yj5ObQZdmyiwFN",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.gSRNdRZt5vRCzqwM",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737391538266,
+        "modifiedTime": 1737391569234,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "KcpEanpX82Cu6Dqh"
 }

--- a/packs/core-perks/seeing-red.json
+++ b/packs/core-perks/seeing-red.json
@@ -5,46 +5,7 @@
   "_id": "ZPI6ynhdFdYyxJUx",
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
-    "actions": [
-      {
-        "slug": "rage",
-        "name": "Rage",
-        "type": "attack",
-        "traits": [
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null
-        },
-        "category": "physical",
-        "power": 20,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: The user gains @Affliction[enraged] 2. While @Affliction[enraged], if the user is hit by a damaging attack, they gain +1 ATK Stage for 5 activations.</p>",
-        "img": "systems/ptr2e/img/svg/fighting_icon.svg",
-        "free": true,
-        "variant": null,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
-      }
-    ],
+    "actions": [],
     "slug": "seeing-red",
     "description": "<p>When you would gain @Affliction[enraged], the set duration increases by +3 Stacks.<br><br>Connection: Rage</p>",
     "traits": [],
@@ -79,9 +40,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
@@ -103,6 +61,31 @@
             "mode": 2,
             "priority": null,
             "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.6OK8vhZYljL4X7cd",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
           }
         ],
         "slug": null,
@@ -133,10 +116,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "0.10.0-alpha.5.1.5",
         "createdTime": 1733496068419,
-        "modifiedTime": 1733496094596,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+        "modifiedTime": 1737391150981,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }
   ]

--- a/packs/core-perks/weak-spot.json
+++ b/packs/core-perks/weak-spot.json
@@ -14,18 +14,12 @@
         "type": "passive",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
-        "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "hidden": false
+        "img": "icons/svg/explosion.svg"
       },
       {
         "slug": "focus-energy",
@@ -36,14 +30,11 @@
         ],
         "range": {
           "target": "creature",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
         "category": "status",
         "types": [
@@ -52,17 +43,7 @@
         "description": "Effect: The user's gain +1 CRIT stage for 5 activations.",
         "free": true,
         "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
+        "predicate": []
       },
       {
         "slug": "laser-focus",
@@ -73,14 +54,11 @@
         ],
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
         "category": "status",
         "types": [
@@ -88,18 +66,7 @@
         ],
         "description": "Effect: The user gains +4 CRIT stages for 2 activations.",
         "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
+        "predicate": []
       }
     ],
     "slug": "weak-spot",
@@ -138,11 +105,95 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Weak Spot",
+      "type": "passive",
+      "_id": "xwhPSQA6Qpr33ewK",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.9gYKmjjtwxu0i5GC",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.783co7i5n9s15xpq",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737391595802,
+        "modifiedTime": 1737391652332,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-species/capsakid.json
+++ b/packs/core-species/capsakid.json
@@ -17,117 +17,69 @@
     "moves": {
       "levelUp": [
         {
-          "name": "leer",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "name": "leafage",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
-          "name": "leafage",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "name": "leer",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "bite",
-          "level": 4,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 4
         },
         {
           "name": "growth",
-          "level": 10,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 10
         },
         {
           "name": "razor-leaf",
-          "level": 13,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 13
         },
         {
           "name": "sunny-day",
-          "level": 17,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 17
         },
         {
           "name": "bullet-seed",
-          "level": 21,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 21
         },
         {
           "name": "headbutt",
-          "level": 24,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 24
         },
         {
           "name": "zen-headbutt",
-          "level": 28,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 28
         },
         {
           "name": "crunch",
-          "level": 38,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 38
         },
         {
           "name": "seed-bomb",
-          "level": 44,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 44
         },
         {
           "name": "solar-beam",
-          "level": 48,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 48
         }
       ],
       "tutor": [
         {
-          "name": "leech-seed",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rollout",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "ingrain",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "worry-seed",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rage-powder",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "take-down",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rest",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "super-fang",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "substitute",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "thief",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "protect",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sandstorm",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "giga-drain",
+          "name": "endeavor",
           "gen": "scarlet-violet"
         },
         {
@@ -135,7 +87,7 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "sleep-talk",
+          "name": "energy-ball",
           "gen": "scarlet-violet"
         },
         {
@@ -143,23 +95,7 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "helping-hand",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "endeavor",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "magical-leaf",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "energy-ball",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "leaf-storm",
+          "name": "giga-drain",
           "gen": "scarlet-violet"
         },
         {
@@ -167,7 +103,55 @@
           "gen": "scarlet-violet"
         },
         {
+          "name": "grassy-glide",
+          "gen": "scarlet-violet"
+        },
+        {
           "name": "grassy-terrain",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "helping-hand",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "ingrain",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "leaf-storm",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "leech-seed",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "magical-leaf",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "protect",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rage-powder",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rest",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rollout",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sandstorm",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sleep-talk",
           "gen": "scarlet-violet"
         },
         {
@@ -175,7 +159,15 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "grassy-glide",
+          "name": "substitute",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "super-fang",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "take-down",
           "gen": "scarlet-violet"
         },
         {
@@ -183,7 +175,15 @@
           "gen": "scarlet-violet"
         },
         {
+          "name": "thief",
+          "gen": "scarlet-violet"
+        },
+        {
           "name": "trailblaze",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "worry-seed",
           "gen": "scarlet-violet"
         }
       ]
@@ -225,17 +225,25 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.KDH54QZSvua6M2gf"
+      "uuid": "Compendium.ptr2e.core-species.Item.KDH54QZSvua6M2gf",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "number": 951,
     "traits": [
       "pokemon",
       "delectable",
-      "heater",
-      "underdog"
+      "heater"
     ],
     "diet": [
       "photosynthesis"
@@ -251,15 +259,15 @@
       ],
       "basic": [
         {
-          "slug": "klutz"
+          "slug": "moody"
         },
         {
-          "slug": "heatproof"
+          "slug": "flame-body"
         }
       ],
       "advanced": [
         {
-          "slug": "solar-power"
+          "slug": "berserk"
         },
         {
           "slug": "liquid-ooze"
@@ -267,10 +275,10 @@
       ],
       "master": [
         {
-          "slug": "shed-skin"
+          "slug": "caustic-heat"
         },
         {
-          "slug": "flame-body"
+          "slug": "solar-power"
         }
       ]
     },
@@ -281,7 +289,12 @@
           "value": 5
         }
       ],
-      "secondary": []
+      "secondary": [
+        {
+          "type": "swim",
+          "value": 3
+        }
+      ]
     },
     "skills": [
       {
@@ -374,7 +387,7 @@
       },
       {
         "slug": "stealth",
-        "value": 40,
+        "value": 35,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -387,15 +400,26 @@
         "favourite": false,
         "hidden": false,
         "group": null
+      },
+      {
+        "slug": "swim",
+        "value": 15,
+        "rvs": 0,
+        "favourite": false,
+        "hidden": false,
+        "group": null
       }
     ],
     "habitats": [
       "desert",
       "badland"
     ],
-    "slug": "capsakid"
+    "slug": "capsakid",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "KDH54QZSvua6M2gf",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/mienfoo.json
+++ b/packs/core-species/mienfoo.json
@@ -17,7 +17,7 @@
       "primary": [
         {
           "type": "overland",
-          "value": 6
+          "value": 7
         }
       ],
       "secondary": [
@@ -32,8 +32,7 @@
       "bipedal",
       "well-built",
       "aura-user",
-      "telepath",
-      "underdog"
+      "telepath"
     ],
     "abilities": {
       "starting": [
@@ -41,31 +40,31 @@
           "slug": "inner-focus"
         },
         {
-          "slug": "limber"
+          "slug": "regenerator"
         }
       ],
       "basic": [
         {
-          "slug": "regenerator"
+          "slug": "reckless"
         },
         {
-          "slug": "iron-fist"
+          "slug": "limber"
         }
       ],
       "advanced": [
         {
-          "slug": "reckless"
+          "slug": "scrappy"
         },
         {
-          "slug": "scrappy"
+          "slug": "tough-claws"
         }
       ],
       "master": [
         {
-          "slug": "steel-toed"
+          "slug": "speed-force"
         },
         {
-          "slug": "speed-force"
+          "slug": "feline-prowess"
         }
       ]
     },
@@ -96,7 +95,7 @@
       },
       {
         "slug": "conversation",
-        "value": 50,
+        "value": 40,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -120,7 +119,7 @@
       },
       {
         "slug": "listen",
-        "value": 50,
+        "value": 40,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -152,7 +151,7 @@
       },
       {
         "slug": "running",
-        "value": 45,
+        "value": 35,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -160,7 +159,7 @@
       },
       {
         "slug": "spot",
-        "value": 45,
+        "value": 35,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -176,7 +175,7 @@
       },
       {
         "slug": "survival",
-        "value": 50,
+        "value": 40,
         "rvs": 0,
         "favourite": false,
         "hidden": false,
@@ -214,223 +213,111 @@
     "moves": {
       "levelUp": [
         {
-          "name": "pound",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
           "name": "detect",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
-          "name": "meditate",
-          "level": 5,
-          "gen": "ultra-sun-ultra-moon"
+          "name": "pound",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "fake-out",
-          "level": 5,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 5
+        },
+        {
+          "name": "meditate",
+          "gen": "ultra-sun-ultra-moon",
+          "level": 5
         },
         {
           "name": "reversal",
-          "level": 10,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 10
         },
         {
           "name": "fury-swipes",
-          "level": 15,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 15
         },
         {
           "name": "double-slap",
-          "level": 17,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 17
         },
         {
           "name": "quick-guard",
-          "level": 20,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 20
         },
         {
           "name": "swift",
-          "level": 21,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 21
         },
         {
           "name": "force-palm",
-          "level": 25,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 25
         },
         {
           "name": "u-turn",
-          "level": 30,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 30
         },
         {
           "name": "drain-punch",
-          "level": 35,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 35
         },
         {
           "name": "jump-kick",
-          "level": 37,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 37
         },
         {
           "name": "hone-claws",
-          "level": 40,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 40
         },
         {
           "name": "aura-sphere",
-          "level": 45,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 45
         },
         {
           "name": "bounce",
-          "level": 51,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 51
         },
         {
           "name": "calm-mind",
-          "level": 55,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 55
         },
         {
           "name": "high-jump-kick",
-          "level": 60,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 60
         }
       ],
       "tutor": [
         {
-          "name": "low-kick",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "endure",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "baton-pass",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "vital-throw",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "focus-punch",
+          "name": "acrobatics",
           "gen": "scarlet-violet"
         },
         {
-          "name": "smelling-salts",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "knock-off",
+          "name": "aerial-ace",
           "gen": "scarlet-violet"
-        },
-        {
-          "name": "feint",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "me-first",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "ally-switch",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "snore",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "helping-hand",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "role-play",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "dual-chop",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "coaching",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "mega-punch",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "swords-dance",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "mega-kick",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "take-down",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "strength",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "dig",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "toxic",
-          "gen": "ultra-sun-ultra-moon"
         },
         {
           "name": "agility",
           "gen": "scarlet-violet"
         },
         {
-          "name": "double-team",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "reflect",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "focus-energy",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "rest",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-slide",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "substitute",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "protect",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "swagger",
+          "name": "ally-switch",
           "gen": "ultra-sun-ultra-moon"
         },
         {
@@ -438,59 +325,11 @@
           "gen": "sword-shield"
         },
         {
-          "name": "return",
+          "name": "baton-pass",
           "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "frustration",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "hidden-power",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "rain-dance",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sunny-day",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "psych-up",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rock-smash",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "facade",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "taunt",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "revenge",
-          "gen": "sword-shield"
         },
         {
           "name": "brick-break",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "rock-tomb",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "aerial-ace",
           "gen": "scarlet-violet"
         },
         {
@@ -502,6 +341,90 @@
           "gen": "scarlet-violet"
         },
         {
+          "name": "coaching",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "confide",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "dig",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "double-team",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "dual-chop",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "endure",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "facade",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "feint",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "focus-blast",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "focus-energy",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "focus-punch",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "frustration",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "grass-knot",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "helping-hand",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "hidden-power",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "knock-off",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "low-kick",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "low-sweep",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "me-first",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "mega-kick",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "mega-punch",
+          "gen": "sword-shield"
+        },
+        {
           "name": "payback",
           "gen": "sword-shield"
         },
@@ -510,27 +433,27 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "focus-blast",
+          "name": "power-up-punch",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "protect",
           "gen": "scarlet-violet"
         },
         {
-          "name": "stone-edge",
+          "name": "psych-up",
           "gen": "scarlet-violet"
         },
         {
-          "name": "grass-knot",
+          "name": "rain-dance",
           "gen": "scarlet-violet"
         },
         {
-          "name": "low-sweep",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "round",
+          "name": "reflect",
           "gen": "sword-shield"
         },
         {
-          "name": "acrobatics",
+          "name": "rest",
           "gen": "scarlet-violet"
         },
         {
@@ -538,20 +461,88 @@
           "gen": "sword-shield"
         },
         {
-          "name": "work-up",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "confide",
+          "name": "return",
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "power-up-punch",
+          "name": "revenge",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "rock-slide",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "rock-smash",
           "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "rock-tomb",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "role-play",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "smelling-salts",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "stone-edge",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "strength",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "substitute",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "swagger",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "swords-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "take-down",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "taunt",
+          "gen": "scarlet-violet"
         },
         {
           "name": "tera-blast",
           "gen": "scarlet-violet"
+        },
+        {
+          "name": "toxic",
+          "gen": "ultra-sun-ultra-moon"
         },
         {
           "name": "trailblaze",
@@ -560,6 +551,14 @@
         {
           "name": "upper-hand",
           "gen": "scarlet-violet"
+        },
+        {
+          "name": "vital-throw",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "work-up",
+          "gen": "sword-shield"
         }
       ]
     },
@@ -592,13 +591,25 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.9m6R9pPyomlHykNU"
+      "uuid": "Compendium.ptr2e.core-species.Item.9m6R9pPyomlHykNU",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "9m6R9pPyomlHykNU",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/whirlipede.json
+++ b/packs/core-species/whirlipede.json
@@ -17,7 +17,7 @@
       "primary": [
         {
           "type": "overland",
-          "value": 7
+          "value": 8
         }
       ],
       "secondary": [
@@ -32,8 +32,8 @@
       "many-legged",
       "blindsense-15",
       "wallclimber",
-      "underdog",
-      "venomous"
+      "venomous",
+      "horned"
     ],
     "abilities": {
       "starting": [
@@ -177,208 +177,128 @@
       "spe": 47
     },
     "types": [
-      "bug",
-      "poison"
+      "poison",
+      "bug"
     ],
     "moves": {
       "levelUp": [
         {
-          "name": "poison-sting",
-          "level": 1,
-          "gen": "sword-shield"
-        },
-        {
           "name": "defense-curl",
-          "level": 1,
-          "gen": "sword-shield"
-        },
-        {
-          "name": "protect",
-          "level": 1,
-          "gen": "sword-shield"
-        },
-        {
-          "name": "rollout",
-          "level": 1,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 1
         },
         {
           "name": "iron-defense",
-          "level": 1,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 1
         },
         {
-          "name": "pursuit",
-          "level": 12,
-          "gen": "ultra-sun-ultra-moon"
+          "name": "poison-sting",
+          "gen": "sword-shield",
+          "level": 1
+        },
+        {
+          "name": "protect",
+          "gen": "sword-shield",
+          "level": 1
+        },
+        {
+          "name": "rollout",
+          "gen": "sword-shield",
+          "level": 1
         },
         {
           "name": "poison-tail",
-          "level": 12,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 12
+        },
+        {
+          "name": "pursuit",
+          "gen": "ultra-sun-ultra-moon",
+          "level": 12
         },
         {
           "name": "screech",
-          "level": 16,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 16
         },
         {
           "name": "bug-bite",
-          "level": 20,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 20
         },
         {
           "name": "venoshock",
-          "level": 26,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 26
         },
         {
           "name": "take-down",
-          "level": 32,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 32
         },
         {
           "name": "steamroller",
-          "level": 37,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 37
         },
         {
           "name": "agility",
-          "level": 38,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 38
         },
         {
           "name": "toxic",
-          "level": 44,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 44
         },
         {
           "name": "rock-climb",
-          "level": 46,
-          "gen": "ultra-sun-ultra-moon"
+          "gen": "ultra-sun-ultra-moon",
+          "level": 46
         },
         {
           "name": "venom-drench",
-          "level": 50,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 50
         },
         {
           "name": "double-edge",
-          "level": 56,
-          "gen": "sword-shield"
+          "gen": "sword-shield",
+          "level": 56
         }
       ],
       "tutor": [
         {
-          "name": "snore",
+          "name": "attract",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "confide",
           "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "black-2-white-2"
-        },
-        {
-          "name": "endeavor",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "signal-beam",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "steel-roller",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "skitter-smack",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "pin-missile",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "solar-beam",
-          "gen": "sword-shield"
         },
         {
           "name": "double-team",
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "rest",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "substitute",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "sludge-bomb",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "spikes",
-          "gen": "sword-shield"
+          "name": "endeavor",
+          "gen": "ultra-sun-ultra-moon"
         },
         {
           "name": "endure",
           "gen": "sword-shield"
         },
         {
-          "name": "swagger",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "attract",
+          "name": "facade",
           "gen": "sword-shield"
-        },
-        {
-          "name": "return",
-          "gen": "ultra-sun-ultra-moon"
         },
         {
           "name": "frustration",
           "gen": "ultra-sun-ultra-moon"
         },
         {
-          "name": "hidden-power",
-          "gen": "ultra-sun-ultra-moon"
-        },
-        {
-          "name": "sunny-day",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "rock-smash",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "facade",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "secret-power",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
           "name": "gyro-ball",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "payback",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "toxic-spikes",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "poison-jab",
-          "gen": "sword-shield"
-        },
-        {
-          "name": "round",
           "gen": "sword-shield"
         },
         {
@@ -386,16 +306,96 @@
           "gen": "sword-shield"
         },
         {
-          "name": "struggle-bug",
-          "gen": "omega-ruby-alpha-sapphire"
-        },
-        {
-          "name": "confide",
+          "name": "hidden-power",
           "gen": "ultra-sun-ultra-moon"
         },
         {
           "name": "infestation",
           "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "payback",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "pin-missile",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "poison-jab",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "rest",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "return",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "rock-smash",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "round",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "secret-power",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "signal-beam",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "skitter-smack",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "black-2-white-2"
+        },
+        {
+          "name": "sludge-bomb",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "snore",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "solar-beam",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "spikes",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "steel-roller",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "struggle-bug",
+          "gen": "omega-ruby-alpha-sapphire"
+        },
+        {
+          "name": "substitute",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "sword-shield"
+        },
+        {
+          "name": "swagger",
+          "gen": "ultra-sun-ultra-moon"
+        },
+        {
+          "name": "toxic-spikes",
+          "gen": "sword-shield"
         }
       ]
     },
@@ -439,6 +439,10 @@
                 "item": null,
                 "level": null,
                 "knownMove": null
+              },
+              "perk": {
+                "x": 15,
+                "y": 15
               }
             }
           ],
@@ -447,13 +451,25 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.dNt6z45d0K3reNSu"
+      "uuid": "Compendium.ptr2e.core-species.Item.dNt6z45d0K3reNSu",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "SlHjp3QF6Z4Mgau4",
-  "effects": [],
-  "folder": null
+  "effects": []
 }


### PR DESCRIPTION
Also sprinkled in are some small fixes for species
- Update Perk: Seeing Red
- Update Perk: Formation Attacks
- Update Perk: Punishment Ward
- Update Perk: Screen Setter
- Update Perk: Weak Spot
- Update Perk: Berserker
- Update Perk: Chansey Medicine
- Update Perk: Drill Sergeant
- Update Perk: Hexcraft
- Update Perk: Kinetic Dispersion
- Update Perk: Relay Race
- Update Ability: Aftermath
- Update Ability: Ambush
- Update Ability: Ancient Idol
- Update Ability: Bad Dreams
- Update Ability: Beads of Ruin
- Update Ability: Tablets of Ruin
- Update Ability: Vessel of Ruin
- Update Ability: Sword of Ruin
- Update Ability: Blinding One
- Update Ability: Cheap Tactics
- Update Ability: Chromatic Radiance
- Update Ability: Clinging Shadow
- Update Ability: Coil Up
- Update Ability: Cold Rebound
- Update Ability: Corridors of Time
- Update Ability: Cosmic Eclipse
- Update Ability: Cosmic Luminance
- Update Ability: Coward
- Update Ability: Crackling Fury
- Update Ability: Curious Medicine
- Update Ability: Dauntless Shield
- Update Ability: Delta Stream
- Update Ability: Desolate Land
- Update Ability: Destructive Design
- Update Ability: Diamond Domain
- Update Ability: Dimensional Rifts
- Update Ability: Dread Wings
- Update Species: whirlipede
- Update Species: capsakid
- Update Species: mienfoo
- Update Ability: Drizzle
- Update Ability: Drought
- Update Ability: Dust Cloud
- Update Ability: Electric Surge
- Update Ability: Electromorphosis
- Update Ability: Embody Aspect
- Update Ability: Emergency Exit
- Update Ability: Energy Forge
- Update Ability: Evaporate
- Update Ability: Flash Fire
- Update Ability: Forecast
- Update Ability: Foretold