### PR TITLE
Foundry Data Sync - Connected Moves Fix Part 2

### DIFF
--- a/packs/core-abilities/gemma-magna.json
+++ b/packs/core-abilities/gemma-magna.json
@@ -22,59 +22,13 @@
         },
         "description": "<p>Trigger: The user resolves Magic Bounce.</p><p>Effect: The user gains +1 ATK and SPATK Stage for 5 Activations.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "power-gem",
-        "name": "Power Gem",
-        "type": "attack",
-        "traits": [
-          "missile",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 3
-        },
-        "category": "special",
-        "power": 80,
-        "accuracy": 100,
-        "types": [
-          "rock"
-        ],
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "traits": [
-          "defensive",
-          "interrupt-5"
-        ],
-        "name": "Magic Bounce",
-        "slug": "magic-bounce",
-        "type": "generic",
-        "cost": {
-          "activation": "free",
-          "powerPoints": 3,
-          "trigger": "<p>The user is hit by a Status-Category Attack.</p>"
-        },
-        "range": {
-          "target": "creature",
-          "distance": 20,
-          "unit": "m"
-        },
-        "description": "<p>Trigger: The user is hit by a Status-Category Attack.</p><p>Effect: The triggering attack fails to hit the user, and the triggering creature is instead targeted and hit with the triggering attack, applying the effects to the triggering creature if able.</p>",
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user resolves Magic Bounce.</p><p>Effect: Connection - Power Gem. The user gains +1 ATK and SPATK Stage for 5 Activations.</p><p>Passive: The user possesses Magic Bounce as an Extra Ability.</p>",
     "traits": [
       "connection",
-      "defensive"
+      "defensive",
+      "partial-automation"
     ],
     "slug": "gemma-magna",
     "_migration": {
@@ -83,5 +37,98 @@
     }
   },
   "_id": "YsVcdQuNToM9dqW3",
-  "effects": []
+  "effects": [
+    {
+      "name": "Gemma Magna",
+      "type": "passive",
+      "_id": "54tBcOxF67Pqe1hF",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.tmMi8VhcpLeLODLe",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": 0
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.NCo48ba4RZX6SSTM",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737402468602,
+        "modifiedTime": 1737402556658,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/grassy-surge.json
+++ b/packs/core-abilities/grassy-surge.json
@@ -42,36 +42,14 @@
         },
         "description": "<p>Passive: If a space within range possesses Grassy Terrain, the user is affected by Grassy Terrain.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "grassy-terrain",
-        "name": "Grassy Terrain",
-        "type": "attack",
-        "traits": [
-          "terrain"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 3
-        },
-        "category": "status",
-        "types": [
-          "grass"
-        ],
-        "description": "<p>Effect: The Terrain is set to Grassy Terrain for 3 rounds.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares Grassy Terrain.</p><p>Effect: Connection - Grassy Terrain. Increase the number of rounds Grassy Terrain persists by 2.</p><p>Passive: If a space within range possesses Grassy Terrain, the user is affected by Grassy Terrain.</p>",
     "traits": [
       "terrain",
       "connection",
-      "environ"
+      "environ",
+      "partial-automation"
     ],
     "slug": "grassy-surge",
     "_migration": {
@@ -80,5 +58,73 @@
     }
   },
   "_id": "OW4j1PXJrawxWJCJ",
-  "effects": []
+  "effects": [
+    {
+      "name": "Grassy Surge",
+      "type": "passive",
+      "_id": "Uo0sdozs6l5g7V8u",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.up4BWX3DVhQlhg79",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737402599713,
+        "modifiedTime": 1737402653137,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/guardian-of-nature.json
+++ b/packs/core-abilities/guardian-of-nature.json
@@ -42,38 +42,13 @@
         },
         "description": "<p>Passive: If a space within range possesses a Terrain with a Type that matches one of the user's Types, the user is affected by that Terrain.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "natures-madness",
-        "name": "Nature's Madness",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "blast-3"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "special",
-        "accuracy": 90,
-        "types": [
-          "fairy"
-        ],
-        "description": "<p>Effect: On hit, all valid targets have their current HP cut in half. This attack always deals a minimum of 1 HP in damage.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares Nature's Madness.</p><p>Effect: Connection - Nature's Madness. The user and any allies of the user's choice within a [Terrain] created by the user gain +1 DEF and SPDEF for 3 Activations.</p><p>Passive: If a space within range possesses a Terrain with a Type that matches one of the user's Types, the user is affected by that Terrain.</p>",
     "traits": [
       "legendary",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "guardian-of-nature",
     "_migration": {
@@ -82,5 +57,73 @@
     }
   },
   "_id": "7EzYhtyaG7PxGOL4",
-  "effects": []
+  "effects": [
+    {
+      "name": "Guardian of Nature",
+      "type": "passive",
+      "_id": "jI5105PtpxBY3IPa",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.IDXWn9iHZy95sqmc",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "free"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737402714994,
+        "modifiedTime": 1737402747893,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/high-tide.json
+++ b/packs/core-abilities/high-tide.json
@@ -21,8 +21,8 @@
           "target": "self",
           "unit": "m"
         },
-        "description": "<p>Trigger: The user is hit by an attack.</p><p>Effect: The user freely uses Tidal Surge.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user is hit by an attack.</p><p>Effect: The user freely uses Surf.</p>",
+        "img": "systems/ptr2e/img/svg/water_icon.svg"
       },
       {
         "slug": "surf",
@@ -49,37 +49,11 @@
         ],
         "description": "<p>Effect: The user may freely relocate themself to any open square in Range. This Attack's Power is doubled against Swimming targets.</p>",
         "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "tidal-surge",
-        "name": "Tidal Surge",
-        "type": "attack",
-        "traits": [
-          "field",
-          "push-2",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 3,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "special",
-        "power": 50,
-        "accuracy": 100,
-        "types": [
-          "water"
-        ],
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "description": "<p>Trigger: The user is hit by an attack.</p><p>Effect: Connection - Surf. The user freely uses High Tide.</p>",
+    "description": "<p>Trigger: The user is hit by an attack.</p><p>Effect: Connection - Surf. The user freely uses Surf.</p>",
     "traits": [
       "connection",
       "defensive"
@@ -91,5 +65,73 @@
     }
   },
   "_id": "RGLKXPraEM0GLnhU",
-  "effects": []
+  "effects": [
+    {
+      "name": "High Tide",
+      "type": "passive",
+      "_id": "DKBlJtZmBog2MKZy",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.wGUb0OCzpxaRB31M",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737403101825,
+        "modifiedTime": 1737403132788,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/hive-defense.json
+++ b/packs/core-abilities/hive-defense.json
@@ -23,34 +23,6 @@
         },
         "description": "<p>Trigger: The user is hit by a Physical- or Special-Category attack.</p><p>Effect: The user freely moves up to half of the Movement Score of their choice, and freely uses Infestation, including the triggering creature in its Blast area.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "infestation",
-        "name": "Infestation",
-        "type": "attack",
-        "traits": [
-          "trap",
-          "blast-1",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 5,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "special",
-        "power": 20,
-        "accuracy": 100,
-        "types": [
-          "bug"
-        ],
-        "description": "<p>Effect: All valid targets become @Affliction[bound] 5 and @Affliction[Infested] 5</p>",
-        "img": "systems/ptr2e/img/svg/bug_icon.svg",
-        "free": true
       }
     ],
     "description": "<p>Trigger: The user is hit by a Physical- or Special-Category attack.</p><p>Effect: Connection - Infestation. The user freely moves up to half of the Movement Score of their choice, and freely uses Infestation, including the triggering creature in its Blast area.</p>",
@@ -65,5 +37,73 @@
     }
   },
   "_id": "DBQiulsYTsFjbMc1",
-  "effects": []
+  "effects": [
+    {
+      "name": "Hive Defense",
+      "type": "passive",
+      "_id": "d5nfE8wT9ZrKC9t1",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.BIG6nxi9Dw2cWq9X",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737403169190,
+        "modifiedTime": 1737403195383,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/holographic-dominion.json
+++ b/packs/core-abilities/holographic-dominion.json
@@ -54,39 +54,11 @@
           "activation": "free"
         },
         "description": "<p>Passive: While @Affliction[transient], the user's Attacks deal twice as much damage, and the user gains 2 PP at the start of each of its Activations.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "shadow-force",
-        "name": "Shadow Force",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "set-up",
-          "pass-4",
-          "crushing",
-          "pierce",
-          "contact",
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "creature",
-          "distance": 1,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "physical",
-        "power": 120,
-        "accuracy": 100,
-        "types": [
-          "ghost"
-        ],
-        "description": "<p>Effect: Set-Up: The user gains @Affliction[invisible] 3 and @Affliction[transient] 3, and ends their activation.</p><p>Resolution: On their next activation, the user freely Moves up to two times the Movement Score of their choice, is cured of @Affliction[transient] and @Affliction[invisible], and then attacks with and resolves this attack.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Trigger: The user would be affected by a declared Action, Attack, or Ability.</p><p>Effect: Connection - Shadow Force. The triggering effect does not affect the user, and the user gains @Affliction[transient]. The user may use a Simple Action using 1 PP to gain or lose @Affliction[transient] as it wishes. Passive: While @Affliction[transient], the user's Attacks deal twice as much damage, and the user gains 2 PP at the start of each of its Activations.</p>",
@@ -102,5 +74,85 @@
     }
   },
   "_id": "ymmPtEzXzLSc9bOd",
-  "effects": []
+  "effects": [
+    {
+      "name": "Holographic Dominion",
+      "type": "passive",
+      "_id": "Q5UE1GjPXlzLk75a",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.3FUbV3cOXazvisJ0",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "damaging-attack-damage",
+            "value": 100,
+            "predicate": [
+              "effect:affliction:transient"
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737403251186,
+        "modifiedTime": 1737403346765,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/hypnotist.json
+++ b/packs/core-abilities/hypnotist.json
@@ -5,9 +5,7 @@
   "system": {
     "actions": [
       {
-        "traits": [
-          
-        ],
+        "traits": [],
         "name": "Hypnotist",
         "slug": "hypnotist-active",
         "type": "generic",
@@ -31,34 +29,18 @@
           "activation": "free"
         },
         "description": "<p>Passive: The user's Hypnosis has +30 Accuracy and has +5 Range.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "hypnosis",
-        "name": "Hypnosis",
-        "type": "attack",
-        "traits": [],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "creature",
-          "distance": 10,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "accuracy": 90,
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: On hit, the target is afflicted with @Affliction[drowsy] 5.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Effect: Connection - Hypnosis.  The user spends 5 PP and freely uses Hypnosis. Passive: The user's Hypnosis has +30 Accuracy and has +5 Range.</p>",
-    "traits": [],
+    "traits": [
+      "partial-automation",
+      "connection"
+    ],
     "slug": "hypnotist",
     "_migration": {
       "version": null,
@@ -66,5 +48,73 @@
     }
   },
   "_id": "NvSkgeJFdm9bintV",
-  "effects": []
+  "effects": [
+    {
+      "name": "Hypnotist",
+      "type": "passive",
+      "_id": "12kGPEsZxafjfNQ6",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.s4q86Yo0UJilvVI0",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737403414513,
+        "modifiedTime": 1737403434865,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/imposter.json
+++ b/packs/core-abilities/imposter.json
@@ -24,31 +24,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "transform",
-        "name": "Transform",
-        "type": "attack",
-        "traits": [
-          "move-locked",
-          "transform"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 20,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 4
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: The user selects one other creature in range and transforms into the target species, copying the target's Base ATK, DEF, SPATK, SPDEF, and SPD stats. The user also copies the target's current Abilities and Active List, as well as any [Stage Change] effects. The user remains transformed for 5 activations, or until they are switched out, combat ends, or are @Affliction[fainted].</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
         "slug": "transform-imposter",
         "name": "Transform (Imposter)",
         "type": "attack",
@@ -71,12 +46,14 @@
         ],
         "description": "<p>Effect: The user selects one other creature in range and transforms into the target species, copying the target's Base ATK, DEF, SPATK, SPDEF, and SPD stats. The user also copies the target's current Abilities and Active List, as well as any [Stage Change] effects. The user remains transformed for 10 activations, or until they are switched out, combat ends, or are @Affliction[fainted].</p>",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user enters combat.</p><p>Effect: Connection - Transform. The user spends 3 PP and freely uses Transform (Imposter). This cannot be interrupted. When using Transform, the user can spend an additional 2 PP to double the duration of Transform.</p>",
     "traits": [
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "imposter",
     "_migration": {
@@ -85,5 +62,73 @@
     }
   },
   "_id": "RSCXY3QdUF4xGD7O",
-  "effects": []
+  "effects": [
+    {
+      "name": "Imposter",
+      "type": "passive",
+      "_id": "d2OdvcYVlNPJcXw7",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.KYiKjOrakhVcye6X",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737403530404,
+        "modifiedTime": 1737403562307,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/inherited-resolve.json
+++ b/packs/core-abilities/inherited-resolve.json
@@ -56,36 +56,11 @@
           "activation": "free"
         },
         "description": "<p>Passive: While in Resolute Forme, the user may use its [Sharp] and [Horn] attacks as Special-Category attacks, the user's Reach increases by +1, and the user takes 15% less damage from all sources. When the user gains @Affliction[fainted] it transforms into its Ordinary Forme.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "secret-sword",
-        "name": "Secret Sword",
-        "type": "attack",
-        "traits": [
-          "pass-4",
-          "sharp",
-          "legendary",
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "creature",
-          "distance": 1,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 3
-        },
-        "category": "special",
-        "power": 85,
-        "accuracy": 100,
-        "types": [
-          "fighting"
-        ],
-        "description": "<p>Effect: This Attack's damage is calculated using the target's DEF.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Trigger: The user crosses the threshold to meet the [Desperation 1/2] Condition.</p><p>Effect: Connection - Secret Sword. The user transforms into its Resolute Forme. The user may spend 4 PP as a Simple Action to enter its Resolute Forme, or may do so as an Exploration Action.</p><p>Passive: While in Resolute Forme, the user may use its [Sharp] and [Horn] attacks as Special-Category attacks, the user's Reach increases by +1, and the user takes 15% less damage from all sources. When the user gains @Affliction[fainted] it transforms into its Ordinary Forme.</p>",
@@ -102,5 +77,73 @@
     }
   },
   "_id": "MksLcyHu34JEXutg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Inherited Resolve",
+      "type": "passive",
+      "_id": "my7j8cRoTuNCPUxq",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.odtntQAPOhX5PLEG",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737403720083,
+        "modifiedTime": 1737403744360,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/intrepid-sword.json
+++ b/packs/core-abilities/intrepid-sword.json
@@ -35,104 +35,17 @@
           "activation": "free"
         },
         "description": "<p>Passive: When first entering Combat in Crowned Forme, the Iron Head on the user's Active List is replaced with Behemoth Blade for the remainder of the combat. The user's default ATK Stage is +1.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "iron-head",
-        "name": "Iron Head",
-        "type": "attack",
-        "traits": [
-          "dash",
-          "push-2",
-          "flinch-chance-2",
-          "contact",
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "creature",
-          "distance": 1,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "physical",
-        "power": 80,
-        "accuracy": 100,
-        "types": [
-          "steel"
-        ],
-        "description": "<p>Effect: On hit, the target has a 30% chance of being Flinched.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "behemoth-blade",
-        "name": "Behemoth Blade",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "pass-4",
-          "sharp",
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "physical",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "steel"
-        ],
-        "variant": "iron-head",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "behemoth-blade-giant",
-        "name": "Behemoth Blade (Giant)",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "pass-4",
-          "sharp",
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6,
-          "trigger": "The target is Dynamaxed.</p>"
-        },
-        "category": "physical",
-        "power": 200,
-        "accuracy": 100,
-        "types": [
-          "steel"
-        ],
-        "description": "<p>Trigger: The target is Dynamaxed.</p>",
-        "free": true,
-        "variant": "behemoth-blade",
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Trigger: The user hits a creature that possess a higher CatMod than the user with Behemoth Blade.</p><p>Effect: Connection - Iron Head. The triggering creature gains @Affliction[fear] 7, and the user gains @Affliction[chanted] 7. Passive:  When first entering Combat in Crowned Forme, the Iron Head on the user's Active List is replaced with Behemoth Blade for the remainder of the combat. The user's default ATK Stage is +1.</p>",
     "traits": [
-      "legendary"
+      "legendary",
+      "partial-automation"
     ],
     "slug": "intrepid-sword",
     "_migration": {
@@ -141,5 +54,83 @@
     }
   },
   "_id": "oAcbRHt5mlUrMtux",
-  "effects": []
+  "effects": [
+    {
+      "name": "Intrepid Sword",
+      "type": "passive",
+      "_id": "CTvEpq4qEcMeSG9m",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.0rhyfVFsZ1asQIwv",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              },
+              {
+                "mode": 2,
+                "property": "",
+                "value": 0
+              },
+              {
+                "mode": 2,
+                "property": "",
+                "value": 0
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.nseOdT3vpRN0AW0K.ActiveEffect.SL5wDgqnuATW2IkH",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737403811338,
+        "modifiedTime": 1737403822374,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/kiloamps.json
+++ b/packs/core-abilities/kiloamps.json
@@ -16,35 +16,11 @@
           "activation": "free"
         },
         "description": "<p>Passive: The user's Electric-Type attacks can hit Ground-Type creatures.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "thunder-cage",
-        "name": "Thunder Cage",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "trap",
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "creature",
-          "distance": 10,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 1
-        },
-        "category": "special",
-        "power": 15,
-        "accuracy": 90,
-        "types": [
-          "electric"
-        ],
-        "description": "<p>Effect: On hit, the target becomes @Affliction[bound] 5. While @Affliction[bound], the target and any creatures within 3m of the @Affliction[bound] creature take a Tick of HP damage at the end of their activations.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       },
       {
         "slug": "thunder-cage-kiloamped",
@@ -72,14 +48,16 @@
           "electric"
         ],
         "description": "<p>Effect: On hit, the target becomes @Affliction[bound] 5. While @Affliction[bound], the target and any creatures within 3m of the @Affliction[bound] creature take a Tick of HP damage at the end of their activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user declares Thunder Cage.</p><p>Effect: Connection - Thunder Cage. The user spends 2 PP and causes triggering attack gains [Blast 3] until the user's next Activation. Passive: The user's Electric-Type attacks can hit Ground-Type creatures.</p>",
     "traits": [
       "legendary",
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "kiloamps",
     "_migration": {
@@ -88,5 +66,73 @@
     }
   },
   "_id": "KWIVOes0QET6D08F",
-  "effects": []
+  "effects": [
+    {
+      "name": "Kiloamps",
+      "type": "passive",
+      "_id": "IcBsptLuiRsm7ROR",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.WtsWkk7bobMJktAg",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737403884072,
+        "modifiedTime": 1737403913644,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/lets-roll.json
+++ b/packs/core-abilities/lets-roll.json
@@ -24,26 +24,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "defense-curl",
-        "name": "Defense Curl",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 2
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: The user gains @Affliction[curled] 5.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
         "slug": "defense-curl-rolled",
         "name": "Defense Curl (Rolled)",
         "type": "attack",
@@ -54,19 +34,21 @@
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 6
+          "powerPoints": 4
         },
         "category": "status",
         "types": [
           "normal"
         ],
         "description": "<p>Effect: The user gains @Affliction[curled] 9 and +1 SPD Stages for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/mole.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user enters combat.</p><p>Effect: Connection - Defense Curl. The user freely uses Defense Curl and may also spend 4 additional PP to use Defense Curl (Rolled).</p>",
     "traits": [
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "lets-roll",
     "_migration": {
@@ -75,5 +57,73 @@
     }
   },
   "_id": "NKwlORX98U7JMiNa",
-  "effects": []
+  "effects": [
+    {
+      "name": "Let's Roll",
+      "type": "passive",
+      "_id": "ERM6vPRGKJx1RBll",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.jKO1iK8Z81n7LQXt",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737403995872,
+        "modifiedTime": 1737404022817,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/lifestream.json
+++ b/packs/core-abilities/lifestream.json
@@ -37,39 +37,19 @@
           "activation": "free"
         },
         "description": "<p>Passive: The first time the user would gain @Affliction[fainted] in combat, it does not and recovers 8 Ticks of HP and is cured of all Status Afflictions.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "geomancy",
-        "name": "Geomancy",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "aura",
-          "set-up"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "self",
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "status",
-        "types": [
-          "fairy"
-        ],
-        "description": "<p>Effect: Set-up: The user begins to glow with mystical power, gaining @Affliction[braced] 1 and healing 3 Ticks of HP.</p><p>Resolution: The user gains +2 SPATK, SPDEF, and SPD Stages for 7 activations.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Trigger: The user resolves Geomancy.</p><p>Effect: Connection - Geomancy. All allies gain the Resolution Effect of the triggering attack. Passive: The first time the user would gain @Affliction[fainted] in combat, it does not and recovers 8 Ticks of HP and is cured of all Status Afflictions.</p>",
     "traits": [
       "legendary",
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "lifestream",
     "_migration": {
@@ -78,5 +58,73 @@
     }
   },
   "_id": "rGtND9ArYDiFiJe1",
-  "effects": []
+  "effects": [
+    {
+      "name": "Lifestream",
+      "type": "passive",
+      "_id": "HwIyjAZcGq8akByp",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.IDVUyCYBr3I1UAa9",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737404065515,
+        "modifiedTime": 1737404097033,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/loose-quills.json
+++ b/packs/core-abilities/loose-quills.json
@@ -23,31 +23,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "spikes",
-        "name": "Spikes",
-        "type": "attack",
-        "traits": [
-          "hazard",
-          "blast-4"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "types": [
-          "ground"
-        ],
-        "description": "<p>Effect: Sharp spikes are scattered in the [Blast X] area on standing surfaces. A creature that starts an Activation on a surface containing the Hazard takes a Tick of HP damage. A creature that moves through through a space touching a surface containing the Hazard takes a Tick of HP damage for every meter they travel. If a creature moves at least 3m through the Hazard this way during one Round, they lose another 4 Tick of HP.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
         "slug": "loose-spikes",
         "name": "Loose Spikes",
         "type": "attack",
@@ -71,7 +46,8 @@
         "description": "<p>Effect: Sharp spikes are scattered in the [Blast X] area on standing surfaces. A creature that starts an Activation on a surface containing the Hazard takes a Tick of HP damage. A creature that moves through through a space touching a surface containing the Hazard takes a Tick of HP damage for every meter they travel. If a creature moves at least 3m through the Hazard this way during one Round, they lose another 4 Tick of HP.</p>",
         "variant": "spikes",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user is hit by a [Contact] attack.</p><p>Effect: Connection - Spikes. The user has a 50% chance to freely use Loose Spikes.</p>",
@@ -85,5 +61,73 @@
     }
   },
   "_id": "rsv5mrwBBagNtAQd",
-  "effects": []
+  "effects": [
+    {
+      "name": "Loose Quills",
+      "type": "passive",
+      "_id": "c4cvs47LzRiGcWPd",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.sPdy5PU5itGhlL6e",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737404191773,
+        "modifiedTime": 1737404227981,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/loose-rocks.json
+++ b/packs/core-abilities/loose-rocks.json
@@ -23,30 +23,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "stealth-rock",
-        "name": "Stealth Rock",
-        "type": "attack",
-        "traits": [
-          "hazard",
-          "missile"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 8,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "types": [
-          "rock"
-        ],
-        "description": "<p>Effect: The user places 5 floating rock mine Hazards within Range. When a creature moves within 3m of a rock mine, it homes in on them, destroying itself and dealing a Tick of Rock-Type damage.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
         "slug": "stealth-shard",
         "name": "Stealth Shard",
         "type": "attack",
@@ -70,7 +46,8 @@
         "description": "<p>Effect: The user places 2 floating rock mine Hazards within Range. When a creature moves within 3m of a rock mine, it homes in on them, destroying itself and dealing a Tick of Rock-Type damage.</p>",
         "variant": "stealth-rock",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user is hit by a Physical or Special category attack.</p><p>Effect: Connection - Stealth Rock. The user has a 50% chance to freely use Stealth Shard.</p>",
@@ -84,5 +61,73 @@
     }
   },
   "_id": "o3CejPWadgrHGAej",
-  "effects": []
+  "effects": [
+    {
+      "name": "Loose Rocks",
+      "type": "passive",
+      "_id": "DypeCTupTZzYAhqt",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.JSSINn7yRN0wXMZ2",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737404255022,
+        "modifiedTime": 1737404277126,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/low-blow.json
+++ b/packs/core-abilities/low-blow.json
@@ -23,33 +23,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "feint-attack",
-        "name": "Feint Attack",
-        "type": "attack",
-        "traits": [
-          "dash",
-          "contact",
-          "danger-close",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 3
-        },
-        "category": "physical",
-        "power": 60,
-        "accuracy": 100,
-        "types": [
-          "dark"
-        ],
-        "img": "systems/ptr2e/img/svg/dark_icon.svg"
-      },
-      {
         "slug": "feint-attack-dastardly",
         "name": "Feint Attack (Dastardly)",
         "type": "attack",
@@ -77,12 +50,14 @@
           "dark"
         ],
         "description": "<p>Trigger: Activated by an Effect.</p>",
-        "img": "systems/ptr2e/img/svg/dark_icon.svg"
+        "img": "systems/ptr2e/img/svg/dark_icon.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: Connection - Feint Attack. The the user freely moves up to and using the Movement Score of their choice, and uses Feint Attack (Dastardly).</p",
     "traits": [
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "low-blow",
     "_migration": {
@@ -91,5 +66,73 @@
     }
   },
   "_id": "RCSnbau25ch2YFfx",
-  "effects": []
+  "effects": [
+    {
+      "name": "Low Blow",
+      "type": "passive",
+      "_id": "9QgtjNlTYujY8RnD",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.AtQsvtYLtT919vzU",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737404376517,
+        "modifiedTime": 1737404402837,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/lunar-presence.json
+++ b/packs/core-abilities/lunar-presence.json
@@ -20,55 +20,6 @@
           "target": "enemy",
           "unit": "m"
         }
-      },
-      {
-        "slug": "lunar-dance",
-        "name": "Lunar Dance",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "dance"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "status",
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: The user reduces their HP to 0 and gains @Affliction[fainted]. After the user gains @Affliction[fainted], the Target recovers all of its HP and PP, and is cured of all Status Conditions. If the user is an owned Pokemon and their Trainer has another Pokemon that is not @Affliction[fainted] in a Poke Ball, that Pokemon may be designated the target of this Attack.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "lunar-dance-full",
-        "name": "Lunar Dance (Full)",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "dance"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 10
-        },
-        "category": "status",
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: The user reduces their HP to 0 and gains @Affliction[fainted]. After the user gains @Affliction[fainted], the Target recovers all of its HP and PP, is cured of all Status Afflictions, and gains @Affliction[boosted] 7. If the user is an owned Pokemon and their Trainer has another Pokemon that is not @Affliction[fainted] in a Poke Ball, that Pokemon may be designated the target of this Attack.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares Lunar Dance</p><p>Effect: Connection - Lunar Dance. The creature targeted by the triggering attack gains @Affliction[boosted] 7. Passive: The user's Dark- and Fairy-Type attacks deal 50% more damage, and the user is considered to be Fairy-Type for the effects of Gloomy Weather.</p>",
@@ -113,6 +64,31 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.yj8uSVjgjqrwDUq6",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
           }
         ],
         "slug": null,
@@ -143,10 +119,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.2.0.3",
+        "systemVersion": "0.10.0-alpha.5.1.5",
         "createdTime": 1722260005393,
-        "modifiedTime": 1722260063456,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+        "modifiedTime": 1737404549933,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }
   ]

--- a/packs/core-abilities/magical-dust.json
+++ b/packs/core-abilities/magical-dust.json
@@ -23,31 +23,6 @@
         },
         "description": "<p>Trigger: The user is hit by a creature's [Contact] attack.</p><p>Effect: The user freely uses Magic Powder on the triggering creature.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "magic-powder",
-        "name": "Magic Powder",
-        "type": "attack",
-        "traits": [
-          "powder"
-        ],
-        "range": {
-          "target": "cone",
-          "distance": 3,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "accuracy": 100,
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: On hit, all valid targets have one of their Type(s) changed to Psychic for 5 activations. If they already have the Psychic Type, they lose one of their other Type(s), if applicable.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a creature's [Contact] attack.</p><p>Effect: Connection - Magic Powder. The user freely uses Magic Powder on the triggering creature.</p>",
@@ -61,5 +36,73 @@
     }
   },
   "_id": "rf1hhJ4YmPAxyC8I",
-  "effects": []
+  "effects": [
+    {
+      "name": "Magical Dust",
+      "type": "passive",
+      "_id": "giGTeTAcTmlBprNj",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.0nowTFFieneYl1lU",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737404593374,
+        "modifiedTime": 1737404616858,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/manifold-bridge.json
+++ b/packs/core-abilities/manifold-bridge.json
@@ -46,75 +46,6 @@
         },
         "description": "<p>Trigger: The user declares the use of an Action or Ability with a target other then Self.</p><p>Effect: The user freely moves, using Teleport Movement, to a spot within 8m of a target in Range.</p>",
         "img": "icons/svg/explosion.svg"
-      },{
-        "slug": "spacial-rend",
-        "name": "Spacial Rend",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "crit-2",
-          "sharp",
-          "blast-3",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7,
-          "delay": null,
-          "priority": null,
-          "trigger": null
-        },
-        "category": "special",
-        "power": 100,
-        "accuracy": 95,
-        "types": [
-          "dragon"
-        ],
-        "description": "<p>Effect: On hit, non-[Legendary] targets are @Affliction[lifted] 3.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
-      },
-      {
-        "slug": "spacial-rend-wave",
-        "name": "Spacial Rend (Wave)",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "crit-2",
-          "sharp",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "wide-line",
-          "distance": 9,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 11,
-          "delay": null,
-          "priority": null,
-          "trigger": null
-        },
-        "category": "special",
-        "power": 100,
-        "accuracy": 95,
-        "types": [
-          "dragon"
-        ],
-        "description": "<p>Effect: On hit, non-[Legendary] targets are @Affliction[lifted] 3.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "variant": "spacial-rend",
-        "free": true,
-        "slot": null
       }
     ],
     "description": "<p>Trigger: The user would be affected by a declared Action, Attack, or Ability.</p><p>Effect: Connection - Spacial Rend. The triggering effect does not affect the user, and the target is relocated 30-WC metres in the direction of the user's choice. When the user declares the use of an Action or Ability with a target other then Self, the user may use Tensor Contraction.</p>",
@@ -130,5 +61,78 @@
     }
   },
   "_id": "34jYiNQbDjMFeRrJ",
-  "effects": []
+  "effects": [
+    {
+      "name": "Manifold Bridge",
+      "type": "passive",
+      "_id": "VaXUcKDPtCNvJIiw",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.SrGEHvXVGd311qxA",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.1.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737404686587,
+        "modifiedTime": 1737404725859,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/minds-eye.json
+++ b/packs/core-abilities/minds-eye.json
@@ -15,34 +15,18 @@
           "activation": "free"
         },
         "description": "<p>Effect: While the user is affected with @Affliction[true-sight], their Normal- and Fighting-Type attacks gain [Danger Close] and deal Super Effective damage to Ghost-Type creatures.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "foresight",
-        "name": "Foresight",
-        "type": "attack",
-        "traits": [],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "self",
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 1
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: The user gains @Affliction[true-sight] 3 and can hit Ghost-Type creatures with Normal-Type and Fighting Type attacks while they have @Affliction[true-sight].</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Effect: Connection - Foresight. While the user is affected with @Affliction[true-sight], their Normal- and Fighting-Type attacks gain [Danger Close] and deal Super Effective damage to Ghost-Type creatures.</p>",
     "traits": [
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "minds-eye",
     "_migration": {
@@ -51,5 +35,73 @@
     }
   },
   "_id": "pQdq1Q6pVQqxKCJX",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mind's Eye",
+      "type": "passive",
+      "_id": "kkqjimAvS3lnN4ER",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.B5u8TLbX10kgSB9d",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737404815783,
+        "modifiedTime": 1737404843789,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/misty-surge.json
+++ b/packs/core-abilities/misty-surge.json
@@ -42,36 +42,14 @@
         },
         "description": "<p>Passive: If a space within range possesses Misty Terrain, the user is affected by Misty Terrain.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "misty-terrain",
-        "name": "Misty Terrain",
-        "type": "attack",
-        "traits": [
-          "terrain"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "status",
-        "types": [
-          "fairy"
-        ],
-        "description": "<p>Effect: The Terrain becomes Misty for 3 rounds.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares Misty Terrain.</p><p>Effect: Connection - Misty Terrain. Increase the number of rounds Misty Terrain persists by 2.</p><p>Passive: If a space within range possesses Misty Terrain, the user is affected by Misty Terrain.</p>",
     "traits": [
       "terrain",
       "connection",
-      "environ"
+      "environ",
+      "partial-automation"
     ],
     "slug": "misty-surge",
     "_migration": {
@@ -80,5 +58,73 @@
     }
   },
   "_id": "jaJfAYMqABXmyrY0",
-  "effects": []
+  "effects": [
+    {
+      "name": "Misty Surge",
+      "type": "passive",
+      "_id": "odUOByx2U1vwi2XP",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.4ExkYy1xjLbhUJbN",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737404897128,
+        "modifiedTime": 1737404928648,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/monkey-business.json
+++ b/packs/core-abilities/monkey-business.json
@@ -1,82 +1,107 @@
 {
-    "name": "Monkey Business",
-    "type": "ability",
-    "img": "systems/ptr2e/img/icons/ability_icon.webp",
-    "system": {
-      "actions": [
-        {
-          "traits": [
-            "interrupt-3"
-          ],
-          "name": "Monkey Business",
-          "slug": "monkey-business",
-          "type": "generic",
-          "cost": {
-            "activation": "free",
-            "powerPoints": 0,
-            "trigger": "<p>The user enters battle, or emerges from stealth.</p>",
-            "delay": null,
-            "priority": null
-          },
-          "range": {
-            "target": "self",
-            "distance": 0,
-            "unit": "m"
-          },
-          "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: The user freely moves up to and using the Movement Score of their choice, and uses Tickle. Upon resolving Tickle from this effect, the user gains +1 EVA and CRIT Stage for 5 Activations.</p>"
+  "name": "Monkey Business",
+  "type": "ability",
+  "img": "systems/ptr2e/img/icons/ability_icon.webp",
+  "system": {
+    "actions": [
+      {
+        "traits": [
+          "interrupt-3"
+        ],
+        "name": "Monkey Business",
+        "slug": "monkey-business",
+        "type": "generic",
+        "cost": {
+          "activation": "free",
+          "trigger": "<p>The user enters battle, or emerges from stealth.</p>"
         },
-        {
-            "slug": "tickle",
-            "name": "Tickle",
-            "type": "attack",
-            "traits": [
-              "social"
+        "range": {
+          "target": "self",
+          "unit": "m"
+        },
+        "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: The user freely moves up to and using the Movement Score of their choice, and uses Tickle. Upon resolving Tickle from this effect, the user gains +1 EVA and CRIT Stage for 5 Activations.</p>",
+        "img": "icons/svg/explosion.svg"
+      }
+    ],
+    "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: Connection - Tickle. The user freely moves up to and using the Movement Score of their choice, and uses Tickle. Upon resolving Tickle from this effect, the user gains +1 EVA and CRIT Stage for 5 Activations.</p>",
+    "traits": [
+      "connection",
+      "partial-automation"
+    ],
+    "slug": "monkey-business",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "ZP9lAceaW6YLSPoE",
+  "effects": [
+    {
+      "name": "Monkey Business",
+      "type": "passive",
+      "_id": "WwHJNEWWsqt7nctX",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-effect",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.d1lLjcyOH6nsTrJ0",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
             ],
-            "range": {
-              "target": "creature",
-              "distance": 1,
-              "unit": "m"
-            },
-            "cost": {
-              "activation": "complex",
-              "powerPoints": 2
-            },
-            "category": "status",
-            "accuracy": 100,
-            "types": [
-              "normal"
-            ],
-            "description": "<p>Effect: On hit, the target's ATK and DEF Stages are reduced by -1 for 5 activations.</p>",
-            "contestType": "",
-            "contestEffect": "",
-            "free": true,
-            "slot": null
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
           }
-      ],
-      "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: Connection - Tickle. The user freely moves up to and using the Movement Score of their choice, and uses Tickle. Upon resolving Tickle from this effect, the user gains +1 EVA and CRIT Stage for 5 Activations.</p>",
-      "traits": [
-        "connection"
-      ],
-      "slug": null,
-      "container": null
-    },
-    "_id": "ZP9lAceaW6YLSPoE",
-    "effects": [],
-    "sort": 0,
-    "ownership": {
-      "default": 0,
-      "tXAZ3QUgjuwX4gdV": 3
-    },
-    "flags": {},
-    "_stats": {
-      "compendiumSource": null,
-      "duplicateSource": null,
-      "coreVersion": "12.324",
-      "systemId": "ptr2e",
-      "systemVersion": "0.005",
-      "createdTime": 1716919240454,
-      "modifiedTime": 1716919240454,
-      "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-    },
-    "_key": "!items!ZP9lAceaW6YLSPoE"
-  }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737404980701,
+        "modifiedTime": 1737405029343,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
+}

--- a/packs/core-abilities/morning-fog.json
+++ b/packs/core-abilities/morning-fog.json
@@ -23,35 +23,13 @@
         },
         "description": "<p>Trigger: The user declares Foghorn.</p><p>Effect: The set Foggy Weather has its duration increased by +2 Rounds.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "foghorn",
-        "name": "Foghorn",
-        "type": "attack",
-        "traits": [
-          "weather"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: The Weather becomes Foggy for 3 rounds.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares Foghorn.</p><p>Effect: Connection - Foghorn. The set Foggy Weather has its duration increased by +2 Rounds.</p>",
     "traits": [
       "connection",
-      "weather"
+      "weather",
+      "partial-automation"
     ],
     "slug": "morning-fog",
     "_migration": {
@@ -60,5 +38,73 @@
     }
   },
   "_id": "LNMO8qdNnz530yQW",
-  "effects": []
+  "effects": [
+    {
+      "name": "Morning Fog",
+      "type": "passive",
+      "_id": "Ep6Z4oDF3bP0RLVq",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.9w7Zluo37ewy3NaQ",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737405124316,
+        "modifiedTime": 1737405148988,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/noctem.json
+++ b/packs/core-abilities/noctem.json
@@ -27,7 +27,9 @@
           "untyped"
         ],
         "category": "status",
-        "summon": "Compendium.ptr2e.core-summons.Item.4HGIp01teAMwQOe1"
+        "summon": "Compendium.ptr2e.core-summons.Item.4HGIp01teAMwQOe1",
+        "free": true,
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user declares New Moon.</p><p>Effect: Connection - New Moon. The set Gloomy Weather has its duration increased by +2 Rounds.</p>",
@@ -42,5 +44,73 @@
     }
   },
   "_id": "csKDGpV163qnxNun",
-  "effects": []
+  "effects": [
+    {
+      "name": "Noctem",
+      "type": "passive",
+      "_id": "qs9hq79clqVUttQM",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.hDb0r3fgTXBjN9SO",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737405191536,
+        "modifiedTime": 1737405224392,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/nonlocality-mechanism.json
+++ b/packs/core-abilities/nonlocality-mechanism.json
@@ -40,35 +40,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "sacred-sword",
-        "name": "Sacred Sword",
-        "type": "attack",
-        "traits": [
-          "pass-3",
-          "sharp",
-          "contact",
-          "danger-close",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "physical",
-        "power": 90,
-        "accuracy": 100,
-        "types": [
-          "fighting"
-        ],
-        "img": "systems/ptr2e/img/svg/fighting_icon.svg",
-        "free": true
-      },
-      {
         "slug": "sacred-sword-nonlocal",
         "name": "Sacred Sword (Nonlocal)",
         "type": "attack",
@@ -94,13 +65,15 @@
         ],
         "img": "systems/ptr2e/img/svg/psychic_icon.svg",
         "variant": "sacred-sword",
-        "free": true
+        "free": true,
+        "predicate": []
       }
     ],
     "description": "<p>Effect: Connection - Sacred Sword. For 3 PP as a Free Action, the next [Sharp] attack used by the user has its target change to Wide Line, its range to 8, and loses [Contact] and [Pass X] until the attack resolves.</p><p>Passive: The user deals 30% more damage to creatures that possess Types that are super effective against any of the user's Types, and the user may use Sacred Sword as a Psychic-Type attack.</p>",
     "traits": [
       "paradox",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "nonlocality-mechanism",
     "_migration": {
@@ -109,5 +82,73 @@
     }
   },
   "_id": "N0fiDUMwMeubxXc5",
-  "effects": []
+  "effects": [
+    {
+      "name": "Nonlocality Mechanism",
+      "type": "passive",
+      "_id": "xsEZXKuVD1A3GUsy",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.DCo1YEm46bRMBLbB",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737405282274,
+        "modifiedTime": 1737405337847,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/north-wind.json
+++ b/packs/core-abilities/north-wind.json
@@ -39,35 +39,12 @@
         },
         "description": "<p>Passive: The user is immune to negative effects from Snowy Weather.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "aurora-veil",
-        "name": "Aurora Veil",
-        "type": "attack",
-        "traits": [
-          "environ",
-          "shield"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "types": [
-          "ice"
-        ],
-        "description": "<p>Effect: For 3 Rounds, the user and its allies take half damage from damaging attacks. Aurora Veil may only be used in Snow Weather.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: Connection - Aurora Veil. The user freely uses Aurora Veil. </p><p>Passive: The user is immune to negative effects from Snowy Weather.</p>",
     "traits": [
-      "environ"
+      "environ",
+      "partial-automation"
     ],
     "slug": "north-wind",
     "_migration": {
@@ -76,5 +53,73 @@
     }
   },
   "_id": "rK8EVFd4WXdJNz1w",
-  "effects": []
+  "effects": [
+    {
+      "name": "North Wind",
+      "type": "passive",
+      "_id": "I86nLxhVzZIHap9z",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.XNNeBcOamkYG9YRY",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737405383574,
+        "modifiedTime": 1737405426394,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/oceans-wrath.json
+++ b/packs/core-abilities/oceans-wrath.json
@@ -21,41 +21,14 @@
         },
         "description": "Effect: While Rainy or Windy Weather is active, the user's Water-Type and [Wind] attacks gain [Crit 1] (or have their [Crit X] increased by +1) and the user attacks with them as if they have +2 ACC Stages.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "aeroblast",
-        "name": "Aeroblast",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "crit-3",
-          "wind",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "wide-line",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "special",
-        "power": 100,
-        "accuracy": 95,
-        "types": [
-          "flying"
-        ],
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "Effect: Connection - Aeroblast. While Rainy or Windy Weather is active, the user's Water-Type and [Wind] attacks gain [Crit 1] (or have their [Crit X] increased by +1) and the user attacks with them as if they have +2 ACC Stages.</p>",
     "traits": [
       "legendary",
       "connection",
-      "environ"
+      "environ",
+      "partial-automation"
     ],
     "slug": "oceans-wrath",
     "_migration": {
@@ -64,5 +37,73 @@
     }
   },
   "_id": "wVN3NvZnjyL0rhRT",
-  "effects": []
+  "effects": [
+    {
+      "name": "Ocean's Wrath",
+      "type": "passive",
+      "_id": "KZVLjyR0adTfopgQ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.UAWw1tjhxISdiuBw",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737405566757,
+        "modifiedTime": 1737405585294,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/olé.json
+++ b/packs/core-abilities/olé.json
@@ -1,83 +1,108 @@
 {
-    "name": "Olé",
-    "type": "ability",
-    "img": "systems/ptr2e/img/icons/ability_icon.webp",
-    "system": {
-      "actions": [
-        {
-          "traits": [
-            "interrupt-2",
-            "defensive"
-          ],
-          "name": "Olé",
-          "slug": "ole",
-          "type": "generic",
-          "cost": {
-            "activation": "simple",
-            "powerPoints": 2,
-            "trigger": "<p>The user is targeted by an Attack.</p>",
-            "delay": null,
-            "priority": null
-          },
-          "range": {
-            "target": "self",
-            "distance": 0,
-            "unit": "m"
-          },
-          "description": "<p>Trigger: The user is targeted by an Attack.</p><p>Effect: The user is treated as having +4 EVA against the triggering Attack. If the triggering attack misses, the triggering creature gains @Affliction[taunted] 5 and the user freely Moves 1 space using the Movement Score of their choice.</p>"
+  "name": "Olé",
+  "type": "ability",
+  "img": "icons/equipment/back/cloakcollared-red-gold.webp",
+  "system": {
+    "actions": [
+      {
+        "traits": [
+          "interrupt-2",
+          "defensive"
+        ],
+        "name": "Olé",
+        "slug": "ole",
+        "type": "generic",
+        "cost": {
+          "activation": "simple",
+          "powerPoints": 2,
+          "trigger": "<p>The user is targeted by an Attack.</p>"
         },
-        {
-            "slug": "taunt",
-            "name": "Taunt",
-            "type": "attack",
-            "traits": [
-              "social"
+        "range": {
+          "target": "self",
+          "unit": "m"
+        },
+        "description": "<p>Trigger: The user is targeted by an Attack.</p><p>Effect: The user is treated as having +4 EVA against the triggering Attack. If the triggering attack misses, the triggering creature gains @Affliction[taunted] 5 and the user freely Moves 1 space using the Movement Score of their choice.</p>",
+        "img": "icons/svg/explosion.svg"
+      }
+    ],
+    "description": "<p>Trigger: The user is targeted by an Attack.</p><p>Effect: Connection - Taunt. The user is treated as having +4 EVA against the triggering Attack. If the triggering attack misses, the triggering creature gains @Affliction[taunted] 5 and the user freely Moves 1 space using the Movement Score of their choice.</p>",
+    "traits": [
+      "connection"
+    ],
+    "slug": "olé",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "1YuofLNgejQeywbY",
+  "effects": [
+    {
+      "name": "Olé",
+      "type": "passive",
+      "_id": "fzZgeqHFPTU2F2L9",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.IB5iMsqBlnOZpPM9",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "tier"
+              }
             ],
-            "range": {
-              "target": "creature",
-              "distance": 10,
-              "unit": "m"
-            },
-            "cost": {
-              "activation": "complex",
-              "powerPoints": 5
-            },
-            "category": "status",
-            "accuracy": 100,
-            "types": [
-              "dark"
-            ],
-            "description": "<p>Effect: On hit, the target becomes @Affliction[taunted] 5.</p>",
-            "contestType": "",
-            "contestEffect": "",
-            "free": true,
-            "slot": null
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
           }
-      ],
-      "description": "<p>Trigger: The user is targeted by an Attack.</p><p>Effect: Connection - Taunt. The user is treated as having +4 EVA against the triggering Attack. If the triggering attack misses, the triggering creature gains @Affliction[taunted] 5 and the user freely Moves 1 space using the Movement Score of their choice.</p>",
-      "traits": [
-        "connection"
-      ],
-      "slug": null,
-      "container": null
-    },
-    "_id": "1YuofLNgejQeywbY",
-    "effects": [],
-    "sort": 0,
-    "ownership": {
-      "default": 0,
-      "tXAZ3QUgjuwX4gdV": 3
-    },
-    "flags": {},
-    "_stats": {
-      "compendiumSource": null,
-      "duplicateSource": null,
-      "coreVersion": "12.324",
-      "systemId": "ptr2e",
-      "systemVersion": "0.005",
-      "createdTime": 1716919240454,
-      "modifiedTime": 1716919240454,
-      "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-    },
-    "_key": "!items!1YuofLNgejQeywbY"
-  }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737405618153,
+        "modifiedTime": 1737405638688,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
+}

--- a/packs/core-abilities/orbital-tide.json
+++ b/packs/core-abilities/orbital-tide.json
@@ -20,27 +20,6 @@
         },
         "description": "Effect: All creatures within Range gain @Affliction[lifted] 5.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "gravity",
-        "name": "Gravity",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 8
-        },
-        "category": "status",
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: All creatures are @Affliction[grounded] 5.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "Effect: Connection - Gravity. All creatures within Range gain @Affliction[lifted] 5.</p>",
@@ -52,5 +31,73 @@
     }
   },
   "_id": "fwwRKQnqEjKl2jgl",
-  "effects": []
+  "effects": [
+    {
+      "name": "Gravity",
+      "type": "passive",
+      "_id": "w9pFVhx7uNqics9o",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.EGfHyGHlkgY53oIO",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737405699245,
+        "modifiedTime": 1737405721697,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/pantomime.json
+++ b/packs/core-abilities/pantomime.json
@@ -23,28 +23,6 @@
         },
         "description": "<p>Trigger: A creature resolves an attack.</p><p>Effect: The user freely uses Mimic on the triggering creature.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "mimic",
-        "name": "Mimic",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 3
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: Mimic copies the last attack the target used, and the attack is added to the user's Active List until the end of combat, the user switches out or the user gains @Affliction[fainted]. Mimic cannot be used if the user has a copied attack on its Active List.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: A creature resolves an attack.</p><p>Effect: Connection - Mimic. The user freely uses Mimic on the triggering creature.</p>",
@@ -58,5 +36,73 @@
     }
   },
   "_id": "7qVETPCsjTWTkXdd",
-  "effects": []
+  "effects": [
+    {
+      "name": "Pantomime",
+      "type": "passive",
+      "_id": "PxfvIMpWKQvgjPGM",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.U4kICZZkipfclLOn",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737405792348,
+        "modifiedTime": 1737405816306,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/perfect-specimen.json
+++ b/packs/core-abilities/perfect-specimen.json
@@ -35,35 +35,11 @@
           "activation": "free"
         },
         "description": "<p>Passive: The user has +1 default ATK and SPATK Stages.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "psystrike",
-        "name": "Psystrike",
-        "type": "attack",
-        "traits": [
-          "push-6",
-          "legendary",
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "creature",
-          "distance": 15,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "special",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Trigger: The user declares Psystrike.</p><p>Effect: Connection - Psystrike. The user can select up 5 additional targets with the triggering attack. Passive: The user has +1 default ATK and SPATK Stages.</p>",
@@ -78,5 +54,91 @@
     }
   },
   "_id": "7hopheHBAxN72Jon",
-  "effects": []
+  "effects": [
+    {
+      "name": "Perfect Specimen",
+      "type": "passive",
+      "_id": "2S8mD98VzwOO0Rsr",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.Myq3zLTugQJaKrEY",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "basic",
+            "key": "system.attributes.atk.stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.attributes.spa.stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737405877484,
+        "modifiedTime": 1737405996885,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Finished at Perfect Specimen fully automated. Pick up Part 3 with Periodic Orbit.
- Update Ability: Gemma Magna
- Update Ability: Grassy Surge
- Update Ability: Guardian of Nature
- Update Ability: High Tide
- Update Ability: Hive Defense
- Update Ability: Holographic Dominion
- Update Ability: Hypnotist
- Update Ability: Imposter
- Update Ability: Inherited Resolve
- Update Ability: Intrepid Sword
- Update Ability: Kiloamps
- Update Ability: Let's Roll
- Update Ability: Lifestream
- Update Ability: Loose Quills
- Update Ability: Loose Rocks
- Update Ability: Low Blow
- Update Ability: Lunar Presence
- Update Ability: Magical Dust
- Update Ability: Manifold Bridge
- Update Ability: Mind's Eye
- Update Ability: Misty Surge
- Update Ability: Monkey Business
- Update Ability: Morning Fog
- Update Ability: Noctem
- Update Ability: Nonlocality Mechanism
- Update Ability: North Wind
- Update Ability: Ocean's Wrath
- Update Ability: Olé
- Update Ability: Orbital Tide
- Update Ability: Pantomime
- Update Ability: Perfect Specimen