### PR TITLE
Foundry Data Sync - Connection Ability Fixes Part 4

### DIFF
--- a/packs/core-abilities/beads-of-ruin.json
+++ b/packs/core-abilities/beads-of-ruin.json
@@ -21,38 +21,14 @@
         },
         "description": "<p>Effect: All other creatures have their SPDEF stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "ruination",
-        "name": "Ruination",
-        "type": "attack",
-        "traits": [
-          "legendary"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "special",
-        "accuracy": 90,
-        "types": [
-          "dark"
-        ],
-        "description": "<p>Effect: On hit, all valid target's HP is cut in half. This attack always deals a minimum of 1 HP in damage.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Effect: Connection - Ruination. All other creatures have their SPDEF stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
     "traits": [
       "legendary",
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "beads-of-ruin",
     "_migration": {
@@ -61,5 +37,73 @@
     }
   },
   "_id": "sWdQIvH00vsGkCYB",
-  "effects": []
+  "effects": [
+    {
+      "name": "Treasure of Ruin",
+      "type": "passive",
+      "_id": "J2mZCtyIjIqYFGrQ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.6MiHI8QGhMknDms5",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392887779,
+        "modifiedTime": 1737392924919,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/periodic-orbit.json
+++ b/packs/core-abilities/periodic-orbit.json
@@ -22,34 +22,6 @@
         },
         "description": "<p>Trigger: The user's next Activation after resolving Wish, Future Sight, or Doom Desire.</p><p>Effect: The user freely resolves the attack once more. Periodic Orbit cannot be activated in response to another resolution resulting from a previous Activation of Periodic Orbit.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "doom-desire",
-        "name": "Doom Desire",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "blast-3",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 25,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "special",
-        "power": 140,
-        "accuracy": 100,
-        "types": [
-          "steel"
-        ],
-        "description": "<p>Effect: When this attack is declared, the user rolls to hit valid target(s) at the start of the user's first Activation in the following Round.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user's next Activation after resolving Wish, Future Sight, or Doom Desire.</p><p>Effect: Connection - Doom Desire. The user freely resolves the attack once more. Periodic Orbit cannot be activated in response to another resolution resulting from a previous Activation of Periodic Orbit.</p>",
@@ -63,5 +35,73 @@
     }
   },
   "_id": "7E8xYrokAEsjJ9NW",
-  "effects": []
+  "effects": [
+    {
+      "name": "Periodic Orbit",
+      "type": "passive",
+      "_id": "5V2MCRnpc1Hem3ZX",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.0idrtcsbkR1V3St0",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737417496311,
+        "modifiedTime": 1737417547605,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/phantom-devicer.json
+++ b/packs/core-abilities/phantom-devicer.json
@@ -37,52 +37,11 @@
           "activation": "free"
         },
         "description": "<p>Passive: While in their base Forme, the user also has the Ability Static. While in another Forme due to possessing an appliance, they instead have the Ability Ectobiologist.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "thunder-shock",
-        "name": "Thunder Shock",
-        "type": "attack",
-        "traits": [
-          "pp-updated"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "creature",
-          "distance": 10,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 1
-        },
-        "category": "special",
-        "power": 40,
-        "accuracy": 100,
-        "types": [
-          "electric"
-        ],
-        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[paralysis] 5.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "traits": [
-          "defensive"
-        ],
-        "name": "Static",
-        "slug": "static",
-        "type": "passive",
-        "cost": {
-          "activation": "free",
-          "trigger": "<p>The user is hit by a [Contact] attack.</p>"
-        },
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "description": "<p>Trigger: The user is hit by a [Contact] attack.</p><p>Effect: The triggering creature has a 30% chance of gaining @Affliction[paralysis] 5.</p>",
-        "img": "icons/svg/explosion.svg"
+        }
       }
     ],
     "description": "<p>Trigger: The user is adjacent to an unoccupied appliance.</p><p>Effect: Connection: Thunder Shock. The user possesses the triggering object, changing Forme as appropriate.  They can spend 2 PP as a Complex Action to exit an appliance, changing into their base Forme. This can be separately done as an Exploration Action without consuming PP. When in a separate Forme, the user's Connected Thunder Shock is swapped for an appropriate Attack based on the Forme:</p><p>- Heat: Overheat</p><p>- Wash: Hydro Pump</p><p>- Frost: Blizzard</p><p>- Fan: Hurricane</p><p>- Mow: Leaf Storm</p><p>Passive: While in their base Forme, the user also has the Ability Static. While in another Forme due to possessing an appliance, they instead have the Ability Ectobiologist.</p>",
@@ -98,5 +57,98 @@
     }
   },
   "_id": "F0sV19dmngv5CVe9",
-  "effects": []
+  "effects": [
+    {
+      "name": "Phantom Devicer",
+      "type": "passive",
+      "_id": "BVIESZVMHgk0NEkT",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.g0tf8DHabi55oj5C",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.WNpGnjZkiWLOta0C",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737417652483,
+        "modifiedTime": 1737417721437,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/pickpocket.json
+++ b/packs/core-abilities/pickpocket.json
@@ -5,33 +5,6 @@
   "system": {
     "actions": [
       {
-        "slug": "thief",
-        "name": "Thief",
-        "type": "attack",
-        "traits": [
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2
-        },
-        "category": "physical",
-        "power": 60,
-        "accuracy": 100,
-        "types": [
-          "dark"
-        ],
-        "description": "<p>Effect: On hit, the user steals a random item in the target's [Accessory], [Belt], or [Held] slots and equips it to itself in a [Held] slot. If the user already has a [Held] slot occupied, the stolen item is dropped on the ground in a square adjacent to the user.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
         "slug": "thief-pickpocket",
         "name": "Thief (Pickpocket)",
         "type": "attack",
@@ -57,12 +30,14 @@
         "description": "<p>Effect: On hit, the user steals a random item in the target's [Accessory], [Belt], or [Held] slots and equips it to itself in a [Held] slot. If the user already has a [Held] slot occupied, the stolen item may either be added to the user's Inventory, or the user freely uses Fling to Bewstow the item to an allied creature.</p>",
         "variant": "thief",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Effect: Connection - Thief. On hitting with Thief (Pickpocket), the user steals a random item in the target's [Accessory], [Belt], or [Held] slots and equips it to itself in a [Held] slot. If the user already has a [Held] slot occupied, the stolen item may either be added to the user's Inventory, or the user freely uses Fling to Bewstow the item to an allied creature.</p>",
     "traits": [
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "pickpocket",
     "_migration": {
@@ -71,5 +46,73 @@
     }
   },
   "_id": "RbNW8PmXowslwwP3",
-  "effects": []
+  "effects": [
+    {
+      "name": "Pickpocket",
+      "type": "passive",
+      "_id": "ediOw0qtvQtGNirV",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.jxorjVcjferdaDBc",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737417843881,
+        "modifiedTime": 1737417894502,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/poison-puppeteer.json
+++ b/packs/core-abilities/poison-puppeteer.json
@@ -23,39 +23,13 @@
         },
         "description": "<p>Trigger: The user @Affliction[poison]s or @Affliction[blight]s a creature.</p><p>Effect: The affected creature is afflicted with @Affliction[confused] 5.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "malignant-chain",
-        "name": "Malignant Chain",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 5,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "special",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "poison"
-        ],
-        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[blight] 8 and a 50% chance of gaining @Affliction[paralysis] 5.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user @Affliction[poison]s or @Affliction[blight]s a creature.</p><p>Effect: Connection - Malignant Chain. The affected creature is afflicted with @Affliction[confused] 5.</p>",
     "traits": [
       "legendary",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "poison-puppeteer",
     "_migration": {
@@ -64,5 +38,73 @@
     }
   },
   "_id": "V5KPS8wGvbHysehP",
-  "effects": []
+  "effects": [
+    {
+      "name": "Poison Puppeteer",
+      "type": "passive",
+      "_id": "AprbwnunoFLXdtPW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.fFKx2U3ztyLCAuRH",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737417932578,
+        "modifiedTime": 1737417985654,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/pollution.json
+++ b/packs/core-abilities/pollution.json
@@ -23,35 +23,13 @@
         },
         "description": "<p>Trigger: The user creates Smoggy Weather.</p><p>Effect: The triggering effect's duration is increased by +2.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "acid-rain",
-        "name": "Acid Rain",
-        "type": "attack",
-        "traits": [
-          "weather"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "status",
-        "types": [
-          "poison"
-        ],
-        "description": "<p>Effect: The weather becomes Smoggy for 3 rounds.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user creates Smoggy Weather.</p><p>Effect: Connection - Acid Rain. The triggering effect's duration is increased by +2.</p>",
     "traits": [
       "connection",
-      "weather"
+      "weather",
+      "partial-automation"
     ],
     "slug": "pollution",
     "_migration": {
@@ -60,5 +38,73 @@
     }
   },
   "_id": "Yk1KzsEkovUtCx6L",
-  "effects": []
+  "effects": [
+    {
+      "name": "Pollution",
+      "type": "passive",
+      "_id": "26woZudx1pcxWNeo",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.ufutclHyzVOmKmdi",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737418014094,
+        "modifiedTime": 1737418034839,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/powder-burst.json
+++ b/packs/core-abilities/powder-burst.json
@@ -23,34 +23,6 @@
         },
         "description": "<p>Trigger: The user is hit by a creature's [Contact] attack.</p><p>Effect: The user freely uses Powder on the triggering creature.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "powder",
-        "name": "Powder",
-        "type": "attack",
-        "traits": [
-          "powder",
-          "blast-1",
-          "explode",
-          "priority-1"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 5,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 5,
-          "priority": 1
-        },
-        "category": "status",
-        "types": [
-          "bug"
-        ],
-        "description": "<p>Effect: All valid targets are covered in a flammable Powder for 5 activations. If a creature covered in Powder attempts to use a Fire-typed move, the attack fails and they deal 4 Ticks of their HP as damage to themselves and all adjacent creatures, and the Powder is removed. If a creature covered in Powder is hit by a Fire-type move, they deal 4 Ticks of their HP as damage to themselves and all adjacent creatures, and the Powder is removed.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a creature's [Contact] attack.</p><p>Effect: Connection - Powder. The user freely uses Powder on the triggering creature.</p>",
@@ -64,5 +36,73 @@
     }
   },
   "_id": "rG1hiJ4YmPcXyC8I",
-  "effects": []
+  "effects": [
+    {
+      "name": "Powder Burst",
+      "type": "passive",
+      "_id": "bUTkpGQibJIPA4DT",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.XOezqCVXnuNgBQRS",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737418067090,
+        "modifiedTime": 1737418091292,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/power-construct.json
+++ b/packs/core-abilities/power-construct.json
@@ -25,34 +25,6 @@
         },
         "description": "<p>Trigger: The user crosses the [Desperation 1/2] threshold, and is not in their Complete Forme.</p><p>Effect: The user transforms into their Complete Forme for the the rest of the Combat, gaining @Affliction[braced] 3 and recovering 8 Ticks of HP.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "core-enforcer",
-        "name": "Core Enforcer",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "blast-5",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 10
-        },
-        "category": "special",
-        "power": 100,
-        "accuracy": 100,
-        "types": [
-          "dragon"
-        ],
-        "description": "<p>Effect: On hit, all valid targets gain @Affliction[nullified] 7. On resultion, the user gains a Tick of HP.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user crosses the [Desperation 1/2] threshold, and is not in their Complete Forme.</p><p>Effect: Connection - Core Enforcer. The user transforms into their Complete Forme for the the rest of the Combat, gaining @Affliction[braced] 3 and recovering 8 Ticks of HP.</p><p><Passive: When the resolves Core Enforcer, they recover a Tick of HP.</p>",
@@ -61,7 +33,8 @@
       "forme-change",
       "connection",
       "desperation-1-2",
-      "healing"
+      "healing",
+      "partial-automation"
     ],
     "slug": "power-construct",
     "_migration": {
@@ -70,5 +43,73 @@
     }
   },
   "_id": "3fzi5kHXfB9DZ2Ew",
-  "effects": []
+  "effects": [
+    {
+      "name": "Power Construct",
+      "type": "passive",
+      "_id": "EEAvHJNgE1NTSMkU",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.Dga2700B3ulU2Op0",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737418125833,
+        "modifiedTime": 1737418150556,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/primordial-sea.json
+++ b/packs/core-abilities/primordial-sea.json
@@ -3,7 +3,7 @@
   "type": "ability",
   "img": "systems/ptr2e/img/item-icons/blue%20orb.webp",
   "system": {
-   "actions": [
+    "actions": [
       {
         "traits": [
           "legendary",
@@ -56,8 +56,7 @@
         "type": "generic",
         "cost": {
           "activation": "complex",
-          "trigger": "<p>The user enters combat or when the user gains this Ability.</p>",
-          "powerPoints": 0
+          "trigger": "<p>The user enters combat or when the user gains this Ability.</p>"
         },
         "range": {
           "target": "field",
@@ -71,7 +70,8 @@
     "traits": [
       "legendary",
       "weather",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "primordial-sea",
     "_migration": {
@@ -91,15 +91,21 @@
           {
             "type": "grant-item",
             "key": "",
-            "value": "Compendium.ptr2e.core-abilities.Item.tILTZn18N9r8H7cs",
+            "value": "Compendium.ptr2e.core-moves.Item.tILTZn18N9r8H7cs",
             "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
             "mode": 2,
             "priority": null,
             "ignored": false,
             "reevaluateOnUpdate": false,
             "inMemoryOnly": false,
             "allowDuplicate": true,
-            "alterations": [],
             "track": false,
             "replaceSelf": false,
             "onDeleteActions": {
@@ -136,9 +142,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "0.10.0-alpha.5.1.5",
         "createdTime": 1733069184244,
-        "modifiedTime": 1733069218211,
+        "modifiedTime": 1737418277833,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }

--- a/packs/core-abilities/psychic-surge.json
+++ b/packs/core-abilities/psychic-surge.json
@@ -42,36 +42,14 @@
         },
         "description": "<p>Passive: If a space within range possesses Psychic Terrain, the user is affected by Psychic Terrain.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "psychic-terrain",
-        "name": "Psychic Terrain",
-        "type": "attack",
-        "traits": [
-          "terrain"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 3
-        },
-        "category": "status",
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: The Terrain type is set to Psychic Terrain for 3 rounds.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares Psychic Terrain.</p><p>Effect: Connection - Psychic Terrain. Increase the number of rounds Psychic Terrain persists by 2.</p><p>Passive: If a space within range possesses Psychic Terrain, the user is affected by Psychic Terrain.</p>",
     "traits": [
       "terrain",
       "connection",
-      "environ"
+      "environ",
+      "partial-automation"
     ],
     "slug": "psychic-surge",
     "_migration": {
@@ -80,5 +58,73 @@
     }
   },
   "_id": "lW75LfBFpHkKWpPA",
-  "effects": []
+  "effects": [
+    {
+      "name": "Psychic Surge",
+      "type": "passive",
+      "_id": "1NOOgSia33P7xYZR",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.McNMuaosHAbgfV8b",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737418371174,
+        "modifiedTime": 1737418405097,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/regression-field.json
+++ b/packs/core-abilities/regression-field.json
@@ -3,54 +3,7 @@
   "type": "ability",
   "img": "systems/ptr2e/img/icons/status_icon.png",
   "system": {
-    "actions": [
-      {
-        "slug": "trick-room",
-        "name": "Trick Room",
-        "type": "attack",
-        "traits": [
-          "room"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 8
-        },
-        "category": "status",
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: The Room is set to Trick Room for 3 Rounds.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "trick-room",
-        "name": "Trick Room",
-        "type": "attack",
-        "traits": [
-          "room",
-          "priority-5"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 11,
-          "priority": 5
-        },
-        "category": "status",
-        "types": [
-          "psychic"
-        ],
-        "description": "<p>Effect: The Room is set to Trick Room for 5 Rounds.</p>",
-        "img": "icons/svg/explosion.svg"
-      }
-    ],
+    "actions": [],
     "description": "<p>Trigger: The user declares Trick Room.</p><p>Effect: Connection - Trick Room. The set Trick Room lasts 5 rounds, and the triggering attack gains [Priority 5] until the end of the user's Activation.</p>",
     "traits": [
       "room",
@@ -63,5 +16,73 @@
     }
   },
   "_id": "vHlzzoEuyzHoBsbT",
-  "effects": []
+  "effects": [
+    {
+      "name": "Regression Field",
+      "type": "passive",
+      "_id": "4WTJUYRZ3bskzqNB",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.0o8uUraEHLc4mDq4",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737418447843,
+        "modifiedTime": 1737418486380,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/rejection.json
+++ b/packs/core-abilities/rejection.json
@@ -1,71 +1,108 @@
 {
-    "name": "Rejection",
-    "type": "ability",
-    "img": "systems/ptr2e/img/icons/ability_icon.webp",
-    "system": {
-      "actions": [
-        {
-          "traits": [
-            "defensive"
-          ],
-          "name": "Rejection",
-          "slug": "rejection",
-          "type": "generic",
-          "cost": {
-            "activation": "free",
-            "powerPoints": 2,
-            "trigger": "<p>The user is hit with a [Contact] attack.</p>"
-          },
-          "range": {
-            "target": "creature",
-            "distance": 10,
-            "unit": "m"
-          },
-          "description": "<p>Trigger: The user is hit with a [Contact] attack.</p><p>Effect: The user freely uses Quash on the triggering creature.</p>",
-          "img": "icons/svg/explosion.svg"
+  "name": "Rejection",
+  "type": "ability",
+  "img": "systems/ptr2e/img/icons/ability_icon.webp",
+  "system": {
+    "actions": [
+      {
+        "traits": [
+          "defensive"
+        ],
+        "name": "Rejection",
+        "slug": "rejection",
+        "type": "generic",
+        "cost": {
+          "activation": "free",
+          "powerPoints": 2,
+          "trigger": "<p>The user is hit with a [Contact] attack.</p>"
         },
-        {
-            "slug": "quash",
-            "name": "Quash",
-            "type": "attack",
-            "traits": [
-              "priority-1"
-            ],
-            "range": {
-              "target": "creature",
-              "distance": 10,
-              "unit": "m"
-            },
-            "cost": {
-              "activation": "simple",
-              "powerPoints": 3,
-              "delay": null,
-              "priority": 1,
-              "trigger": null
-            },
-            "category": "status",
-            "power": null,
-            "accuracy": 100,
-            "types": [
-              "dark"
-            ],
-            "description": "<p>Effect: On hit, the target's next action is a [Delay 3] action.</p>",
-            "contestType": "",
-            "contestEffect": "",
-            "free": false,
-            "slot": null
-          }
-      ],
-      "description": "<p>Trigger: The user is hit with a [Contact] attack.</p><p>Effect: Connection - Quash. The user freely uses Quash on the triggering creature.</p>",
-      "traits": [
-        "defensive"
-      ],
-      "slug": "rejection",
-      "_migration": {
-        "version": null,
-        "previous": null
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "description": "<p>Trigger: The user is hit with a [Contact] attack.</p><p>Effect: The user freely uses Quash on the triggering creature.</p>",
+        "img": "icons/svg/explosion.svg"
       }
-    },
-    "_id": "PVMMcD4lN3u4j8wQ",
-    "effects": []
-  }
+    ],
+    "description": "<p>Trigger: The user is hit with a [Contact] attack.</p><p>Effect: Connection - Quash. The user freely uses Quash on the triggering creature.</p>",
+    "traits": [
+      "defensive"
+    ],
+    "slug": "rejection",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "PVMMcD4lN3u4j8wQ",
+  "effects": [
+    {
+      "name": "Rejection",
+      "type": "passive",
+      "_id": "hS1vbJiU0rL7yGvl",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.mMcNWWrDSmtvCIiv",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737418536695,
+        "modifiedTime": 1737418564305,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
+}

--- a/packs/core-abilities/relic-soloist.json
+++ b/packs/core-abilities/relic-soloist.json
@@ -84,7 +84,8 @@
         ],
         "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[drowsy] 7.</p>",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "traits": [],
@@ -129,5 +130,123 @@
     }
   },
   "_id": "RsbFvEb7DqMVwhMr",
-  "effects": []
+  "effects": [
+    {
+      "name": "Relic Soloist",
+      "type": "passive",
+      "_id": "x4G83Hdl9sFOm24K",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.n4rGUelHpp7rVQoz",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.8GEZyBul46p9V0Fn",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.ne1QgdwhvAXeeaX8",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737418623784,
+        "modifiedTime": 1737418767640,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/relic-variation.json
+++ b/packs/core-abilities/relic-variation.json
@@ -56,66 +56,6 @@
         },
         "description": "<p>Effect: The user transforms into its Aria Forme.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "relic-dance",
-        "name": "Relic Dance",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "dance",
-          "pass-6",
-          "push-2",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "physical",
-        "power": 75,
-        "accuracy": 100,
-        "types": [
-          "fighting"
-        ],
-        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[splinter] 7 and @Affliction[confused] 7.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "traits": [],
-        "name": "Capoeira",
-        "slug": "capoeira",
-        "type": "passive",
-        "cost": {
-          "activation": "free"
-        },
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "description": "<p>Effect: The user's [Kick] Attacks also have [Dance], and the user's [Dance] Attacks have their Power increased by 30%.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "traits": [],
-        "name": "Benevolent Gift",
-        "slug": "benevolent-gift",
-        "type": "passive",
-        "cost": {
-          "activation": "free"
-        },
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "description": "<p>Effect: The duration of effects caused or created by the user is increased by 2.</p>",
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user resolves Relic Dance</p><p>Effect: Connection - Relic Dance. The user transforms into its Aria Forme. The user may also change Formes as either a Simple Action (4 PP), or as a Downtime Action. Passive: The user possesses the Abilities - Capoeira and Benevolent Gift",
@@ -130,5 +70,123 @@
     }
   },
   "_id": "PymIM1w7V6kBwEwm",
-  "effects": []
+  "effects": [
+    {
+      "name": "Relic Variation",
+      "type": "passive",
+      "_id": "IB3QcxOq04bXsOqi",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.1XrF5LK5RjlKyxAf",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.ziFVuKuam7P7iQIP",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.ne1QgdwhvAXeeaX8",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737419769520,
+        "modifiedTime": 1737419887457,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/righteous-blade.json
+++ b/packs/core-abilities/righteous-blade.json
@@ -20,41 +20,13 @@
         },
         "description": "<p>Effect: The user's [Sharp] attacks gain [Crit 1] and [Pass 2], or have their [Crit X] and [Pass X] increased by +1 and +2, respectively. The user deals 30% more damage to creatures that possess Types that are super effective against any of the user's Types.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "sacred-sword",
-        "name": "Sacred Sword",
-        "type": "attack",
-        "traits": [
-          "pass-3",
-          "sharp",
-          "contact",
-          "danger-close",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "physical",
-        "power": 90,
-        "accuracy": 100,
-        "types": [
-          "fighting"
-        ],
-        "free": true,
-        "img": "systems/ptr2e/img/svg/fighting_icon.svg"
       }
     ],
     "description": "<p>Effect: Connection - Sacred Sword. The user's [Sharp] attacks gain [Crit 1] and [Pass 2], or have their [Crit X] and [Pass X] increased by +1 and +2, respectively. The user deals 30% more damage to creatures that possess Types that are super effective against any of the user's Types.</p>",
     "traits": [
       "legendary",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "righteous-blade",
     "_migration": {
@@ -63,5 +35,73 @@
     }
   },
   "_id": "zg5sYoaRgYtAA9ql",
-  "effects": []
+  "effects": [
+    {
+      "name": "Righteous Blade",
+      "type": "passive",
+      "_id": "EsmLceYUr7hVPc7S",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.DCo1YEm46bRMBLbB",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737419939995,
+        "modifiedTime": 1737419964161,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/sand-spit.json
+++ b/packs/core-abilities/sand-spit.json
@@ -1,7 +1,7 @@
 {
   "name": "Sand Spit",
   "type": "ability",
-  "img": "systems/ptr2e/img/icons/ability_icon.webp",
+  "img": "systems/ptr2e/img/svg/ground_icon.svg",
   "system": {
     "actions": [
       {
@@ -22,55 +22,6 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user would be hit by an attack.</p><p>Effect: The user freely uses Sand Attack or Sand Attack (Dusty) on the attacking creature, and then the triggering attack is rerolled. The rerolled attack does not cost additional PP nor can it trigger this Ability again.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "sand-attack",
-        "name": "Sand Attack",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "cone",
-          "distance": 3,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2
-        },
-        "category": "status",
-        "accuracy": 100,
-        "types": [
-          "ground"
-        ],
-        "description": "<p>Effect: On hit, all valid targets lose -1 ACC Stage for 5 activations.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "sand-attack-dusty",
-        "name": "Sand Attack (Dusty)",
-        "type": "attack",
-        "traits": [
-          "environ"
-        ],
-        "range": {
-          "target": "cone",
-          "distance": 3,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2,
-          "trigger": "<p>Dusty Weather is present.</p>"
-        },
-        "category": "status",
-        "accuracy": 100,
-        "types": [
-          "ground"
-        ],
-        "description": "<p>Trigger: Dusty Weather is present.</p><p>Effect: On hit, all valid targets lose -2 ACC Stage for 5 activations.</p>",
-        "variant": "sand-attack",
-        "free": true,
         "img": "icons/svg/explosion.svg"
       },
       {
@@ -96,7 +47,8 @@
         "description": "<p>Effect: On hit, all valid targets lose -1 ACC Stage for 5 activations.</p>",
         "variant": "sand-attack",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "slug": "sand-attack-sand-spit-dusty",
@@ -124,13 +76,15 @@
         "description": "<p>Trigger: Dusty Weather is present.</p><p>Effect: On hit, all valid targets lose -2 ACC Stage for 5 activations.</p>",
         "variant": "sand-attack",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user would hit by an attack.</p><p>Effect: Connection - Sand Attack. The user freely uses Sand Attack or Sand Attack (Dusty) on the attacking creature, and then the triggering attack is rerolled. The rerolled attack does not cost additional PP nor can it trigger this Ability again. When using Sand Attack, the user can spend an additional 2 PP to use it as a 25 Power Physical-Category Attack.</p>",
     "traits": [
       "connection",
-      "defensive"
+      "defensive",
+      "partial-automation"
     ],
     "slug": "sand-spit",
     "_migration": {
@@ -139,5 +93,78 @@
     }
   },
   "_id": "yWHCeJWiLgFtmIkV",
-  "effects": []
+  "effects": [
+    {
+      "name": "Sand Spit",
+      "type": "passive",
+      "_id": "BMfcAsHi3HrVlcRA",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.RNsjfgPa66NJ8zR7",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.1.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737420066036,
+        "modifiedTime": 1737420101649,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/sand-stream.json
+++ b/packs/core-abilities/sand-stream.json
@@ -1,7 +1,7 @@
 {
   "name": "Sand Stream",
   "type": "ability",
-  "img": "systems/ptr2e/img/svg/ground_icon.svg",
+  "img": "systems/ptr2e/img/svg/rock_icon.svg",
   "system": {
     "actions": [
       {
@@ -23,35 +23,13 @@
         },
         "description": "<p>Trigger: The user declares Sandstorm.</p><p>Effect: The Dusty Weather set by the user has its duration extended by 2 Rounds.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "sandstorm",
-        "name": "Sandstorm",
-        "type": "attack",
-        "traits": [
-          "weather"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "status",
-        "types": [
-          "rock"
-        ],
-        "description": "<p>Effect: The weather becomes Sandy for 3 rounds.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares Sandstorm.</p><p>Effect: Connection - Sandstorm. The Dusty Weather set by the user has its duration extended by 2 Rounds.</p>",
     "traits": [
       "connection",
-      "weather"
+      "weather",
+      "partial-automation"
     ],
     "slug": "sand-stream",
     "_migration": {
@@ -60,5 +38,73 @@
     }
   },
   "_id": "ZUDn8BmM24w3WHx9",
-  "effects": []
+  "effects": [
+    {
+      "name": "Sand Stream",
+      "type": "passive",
+      "_id": "41EmKjgI7EIdGS5b",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.CUj5LvNodz0DfdaJ",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737420151974,
+        "modifiedTime": 1737420180107,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/seed-sower.json
+++ b/packs/core-abilities/seed-sower.json
@@ -23,53 +23,6 @@
         },
         "description": "<p>Trigger: The user is hit by an attack. </p><p>Effect: The user freely uses Leech Seed on the triggering creature.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "leech-seed",
-        "name": "Leech Seed",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "creature",
-          "distance": 5,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 7
-        },
-        "category": "status",
-        "accuracy": 90,
-        "types": [
-          "grass"
-        ],
-        "description": "<p>Effect: On hit, the target gains @Affliction[leech] 5.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "leech-seed-bind",
-        "name": "Leech Seed (Bind)",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "creature",
-          "distance": 5,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 9
-        },
-        "category": "status",
-        "accuracy": 90,
-        "types": [
-          "grass"
-        ],
-        "description": "<p>Effect: On hit, the target gains @Affliction[leech] 5 and @Affliction[bound] 5.</p>",
-        "variant": "leech-seed",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by an attack. </p><p>Effect: Connection - Leech Seed. The user freely uses Leech Seed on the triggering creature. When using Leech Seed, the user can spend an additional 2 PP to have Leech Seed also apply @Affliction[bound] 5.</p>",
@@ -84,5 +37,73 @@
     }
   },
   "_id": "jwoQX0T7EjhPr26M",
-  "effects": []
+  "effects": [
+    {
+      "name": "Seed Sower",
+      "type": "passive",
+      "_id": "0O15DMhJdn2tw9Fa",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.2LTnEFDRe24I7AQT",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737420230501,
+        "modifiedTime": 1737420253998,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/shear-fault.json
+++ b/packs/core-abilities/shear-fault.json
@@ -22,62 +22,6 @@
         },
         "description": "<p>Trigger: The user is hit by a super effective Attack or by a Critical Hit.</p><p>Effect: The user freely uses Aftershock or Aftershock (Follow-Up) on an creature..</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "name": "Aftershock",
-        "slug": "aftershock",
-        "type": "attack",
-        "img": "icons/svg/explosion.svg",
-        "traits": [
-          "delay-3",
-          "earthbound"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 5,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6,
-          "delay": 3
-        },
-        "types": [
-          "ground"
-        ],
-        "category": "physical",
-        "power": 50,
-        "accuracy": 100
-      },
-      {
-        "name": "Aftershock (Follow-Up)",
-        "slug": "aftershock-follow-up",
-        "type": "attack",
-        "img": "icons/svg/explosion.svg",
-        "traits": [
-          "delay-3",
-          "danger-close",
-          "earthbound"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 5,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6,
-          "delay": 3
-        },
-        "variant": "aftershock",
-        "types": [
-          "ground"
-        ],
-        "category": "physical",
-        "power": 150,
-        "accuracy": 100,
-        "free": true,
-        "description": "<p>Effect: This attack may only be used if the target was hit with an [Earthbound] attack since the user's previous Activation.</p>"
       }
     ],
     "description": "<p>Trigger: The user is hit by a super effective Attack or by a Critical Hit.</p><p>Effect: Connection - Aftershock. The user freely uses Aftershock or Aftershock (Follow-Up) on an creature.</p>",
@@ -92,5 +36,78 @@
     }
   },
   "_id": "pI0Z1NiBcanHQKqP",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shear Fault",
+      "type": "passive",
+      "_id": "fkEtgmvIxecdy3hh",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.RuQs6by7zFAgsOhU",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.1.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737420346047,
+        "modifiedTime": 1737420392390,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/shell-shield.json
+++ b/packs/core-abilities/shell-shield.json
@@ -24,27 +24,6 @@
         },
         "description": "<p>Trigger: An adjacent ally creature targeted with a Physical or Special-Category Attack.</p><p>Effect: The user freely uses Withdraw and then Intercept, designating the triggering ally as their target.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "withdraw",
-        "name": "Withdraw",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 1
-        },
-        "category": "status",
-        "types": [
-          "water"
-        ],
-        "description": "<p>Effect: The user gains +1 DEF Stage for 5 activations.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: An adjacent ally creature targeted with a Physical or Special-Category Attack.</p><p>Effect: Connection - Withdraw. The user freely uses Withdraw and then Intercept, designating the triggering ally as their target.</p>",
@@ -59,5 +38,73 @@
     }
   },
   "_id": "UFd3V17cDGer1UQW",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shell Shield",
+      "type": "passive",
+      "_id": "YQ1Fn3HX0T8lywJL",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.PQBKLWDTfMtnglGy",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737420450840,
+        "modifiedTime": 1737420476606,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/singer.json
+++ b/packs/core-abilities/singer.json
@@ -22,31 +22,6 @@
         },
         "description": "<p>Trigger: A creature on the field (other than the user) uses a [Sonic] attack</p><p>Effect: The user uses the triggering attack as if it was on the user's Active List as a Free Action, selecting new targets as needed.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "sing",
-        "name": "Sing",
-        "type": "attack",
-        "traits": [
-          "sonic"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 2,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "status",
-        "accuracy": 55,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: On hit, all valid targets gain @Affliction[drowsy] 5.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: A creature on the field (other than the user) uses a [Sonic] attack</p><p>Effect: Connection - Sing. The user uses the triggering attack as if it was on the user's Active List as a Free Action, selecting new targets as needed.</p>",
@@ -60,5 +35,73 @@
     }
   },
   "_id": "NUI3hbwz9PJ65Znw",
-  "effects": []
+  "effects": [
+    {
+      "name": "Singer",
+      "type": "passive",
+      "_id": "iHW7xT2gudLUOy6e",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.ddcyCuH4t0mVmB7n",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737420519006,
+        "modifiedTime": 1737420546176,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/snow-warning.json
+++ b/packs/core-abilities/snow-warning.json
@@ -23,35 +23,13 @@
         },
         "description": "<p>Trigger: The user declares Snowscape.</p><p>Effect: The set Snowy Weather has its duration increased by +2 Rounds.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "snowscape",
-        "name": "Snowscape",
-        "type": "attack",
-        "traits": [
-          "weather"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "status",
-        "types": [
-          "ice"
-        ],
-        "description": "<p>Effect: The Weather becomes Snowy for 3 rounds.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares Snowscape.</p><p>Effect: Connection - Snowscape. The set Snowy Weather has its duration increased by +2 Rounds.</p>",
     "traits": [
       "connection",
-      "weather"
+      "weather",
+      "partial-automation"
     ],
     "slug": "snow-warning",
     "_migration": {
@@ -60,5 +38,73 @@
     }
   },
   "_id": "CNKfFD2LtrnuqHQB",
-  "effects": []
+  "effects": [
+    {
+      "name": "Snow Warning",
+      "type": "passive",
+      "_id": "3QxfKmjiaU4KXNbk",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.KQ8pNG4ebggQwd8k",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737420585643,
+        "modifiedTime": 1737420608211,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/solid-rock.json
+++ b/packs/core-abilities/solid-rock.json
@@ -22,31 +22,6 @@
         },
         "description": "<p>Trigger: The user is hit by a super effective attack.</p><p>Effect: The user freely uses Endure.",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "endure",
-        "name": "Endure",
-        "type": "attack",
-        "traits": [
-          "defensive",
-          "interrupt-4"
-        ],
-        "range": {
-          "target": "creature",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7,
-          "trigger": "<p>The user is hit by a Physical- or Special-Category Attack.</p>"
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Trigger: The user is hit by a Physical- or Special-Category Attack</p><p>Effect: The user resists the attack by 1 step and cannot fall below 1 HP from the attack. The user gains @Affliction[resolved] 5.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a super effective attack.</p><p>Effect: Connection - Endure. The user freely uses Endure. When under the effect of Endure, all incoming damage from attacks is reduced by 20%",
@@ -61,5 +36,73 @@
     }
   },
   "_id": "KgcLrZ8cl6dviEuW",
-  "effects": []
+  "effects": [
+    {
+      "name": "Solid Rock",
+      "type": "passive",
+      "_id": "a9sCkodLzRtJdPe5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.eEQiYEm2y7wkcKnx",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737420634451,
+        "modifiedTime": 1737420656405,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/special-delivery.json
+++ b/packs/core-abilities/special-delivery.json
@@ -20,121 +20,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "present",
-        "name": "Present",
-        "type": "attack",
-        "traits": [
-          "blast-1",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2,
-          "trigger": "<p>User rolls 1 thru 40 on the declaration roll.</p>"
-        },
-        "category": "physical",
-        "power": 40,
-        "accuracy": 90,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Trigger: User rolls 1 thru 40 on the declaration roll.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "present-2",
-        "name": "Present x2",
-        "type": "attack",
-        "traits": [
-          "blast-1",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2,
-          "trigger": "<p>User rolls 41 thru 60 on the declaration roll.</p>"
-        },
-        "category": "physical",
-        "power": 80,
-        "accuracy": 90,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Trigger: User rolls 41 thru 60 on the declaration roll.</p>",
-        "variant": "present",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "present-3",
-        "name": "Present x3",
-        "type": "attack",
-        "traits": [
-          "blast-1",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2,
-          "trigger": "<p>Trigger: User rolls 61 thru 70 on the declaration roll.</p>"
-        },
-        "category": "physical",
-        "power": 120,
-        "accuracy": 90,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Trigger: User rolls 61 thru 70 on the declaration roll.</p>",
-        "variant": "present",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "present-gift",
-        "name": "Present (Gift)",
-        "type": "attack",
-        "traits": [
-          "blast-1",
-          "healing",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 15,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2,
-          "trigger": "<p>Trigger: User rolls 71 thru 100 on the declaration roll.</p>"
-        },
-        "category": "status",
-        "accuracy": 90,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Trigger: User rolls 71 thru 100 on the declaration roll.</p><p>Effect: On hit, all valid targets recover 4 Ticks of HP.</p>",
-        "variant": "present",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
         "slug": "present-sp",
         "name": "Present (Special Delivery)",
         "type": "attack",
@@ -161,7 +46,8 @@
         "description": "<p>Trigger: User rolls 1 thru 60 on the declaration roll.</p>",
         "variant": "present",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "slug": "present-gift-sp",
@@ -190,7 +76,8 @@
         "description": "<p>Trigger: User rolls 61 thru 100 on the declaration roll.</p><p>Effect: On hit, all valid enemy targets recover 2 Ticks of HP, and all valid allied targets recover 8 Ticks of HP.</p>",
         "variant": "present",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Effect: Connection - Present. The user spends 3 extra PP, to use Present (Special Delivery) in place of Present.</p><p>Passive: The user's Fling Power for Gear is increased by 50%.</p>",
@@ -204,5 +91,88 @@
     }
   },
   "_id": "IY5l0838EgcytYTT",
-  "effects": []
+  "effects": [
+    {
+      "name": "Special Delivery",
+      "type": "passive",
+      "_id": "sSETsychl5pU9nwA",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.dTzHNqMNr83eSDwF",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.1.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.2.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.3.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737420787500,
+        "modifiedTime": 1737420845754,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/spider-lair.json
+++ b/packs/core-abilities/spider-lair.json
@@ -21,31 +21,6 @@
         },
         "description": "<p>Trigger: The user enters combat.</p><p>Effect: The user freely uses Sticky Web. Spider Web Hazards created by the user do not affect the user or their allies.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "sticky-web",
-        "name": "Sticky Web",
-        "type": "attack",
-        "traits": [
-          "hazard",
-          "blast-4"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "types": [
-          "bug"
-        ],
-        "description": "<p>Effect: A weave of webs covers all surfaces in the [Blast X] area, with squares that have two or more surfaces covered treating the whole space as having the Hazard, not just the surfaces. Each time an enemy creature moves through a space and touches the Hazard, they lose -1 SPD Stage for 5 activations. An enemy creature that starts their Activation touching the Hazard is @Affliction[slowed] 1.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user enters combat.</p><p>Effect: Connection - Sticky Web. The user freely uses Sticky Web. Spider Web Hazards created by the user do not affect the user or their allies.</p>",
@@ -60,5 +35,73 @@
     }
   },
   "_id": "iY9TDgK15i3JzWpq",
-  "effects": []
+  "effects": [
+    {
+      "name": "Spider Lair",
+      "type": "passive",
+      "_id": "TrdLexOXvavrAlU8",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.diUUeh3zVUhQBuoh",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737420878406,
+        "modifiedTime": 1737420898480,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/spinning-top.json
+++ b/packs/core-abilities/spinning-top.json
@@ -22,39 +22,12 @@
         },
         "description": "<p>Trigger: The user resolves a Fighting-Type attack.</p><p>Effect: The user gains +1 EVA Stage for 5 Activations, and freely uses Rapid Spin.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "rapid-spin",
-        "name": "Rapid Spin",
-        "type": "attack",
-        "traits": [
-          "basic",
-          "contact",
-          "pp-updated",
-          "partial-automation"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "physical",
-        "power": 50,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: The user gains +1 SPD Stage for 5 activations. The user also clears any [Hazards] within this attacks's range, and ends any [Trap] attack effects the user is affected by.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user resolves a Fighting-Type attack.</p><p>Effect: Connection - Rapid Spin. The user gains +1 EVA Stage for 5 Activations, and freely uses Rapid Spin.</p>",
-    "traits": [],
+    "traits": [
+      "partial-automation"
+    ],
     "slug": "spinning-top",
     "_migration": {
       "version": null,
@@ -64,22 +37,36 @@
   "_id": "TlSYPMlJ5cWHHpfQ",
   "effects": [
     {
-      "name": "Rapid Spin",
+      "name": "Spinning Top",
       "type": "affliction",
       "_id": "5hnnsJIol52RGqqz",
       "img": "systems/ptr2e/img/icons/effect_icon.webp",
       "system": {
         "changes": [
           {
-            "type": "roll-effect",
-            "key": "rapid-spin-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLM",
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.MCQGC0NYfdM72QBK",
             "predicate": [],
-            "chance": 100,
-            "affects": "target",
+            "alterations": [
+              {
+                "mode": 4,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
           }
         ],
         "slug": null,
@@ -109,14 +96,14 @@
       "sort": 0,
       "flags": {},
       "_stats": {
-        "compendiumSource": null,
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.TlSYPMlJ5cWHHpfQ.ActiveEffect.5hnnsJIol52RGqqz",
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.2.2.1",
+        "systemVersion": "0.10.0-alpha.5.1.5",
         "createdTime": 1726142564420,
-        "modifiedTime": 1726142585646,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+        "modifiedTime": 1737420983100,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }
   ]

--- a/packs/core-abilities/stance-change.json
+++ b/packs/core-abilities/stance-change.json
@@ -52,32 +52,11 @@
           "activation": "free"
         },
         "description": "<p>Passive: The user starts combat in Shield Forme.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "kings-shield",
-        "name": "King's Shield",
-        "type": "attack",
-        "traits": [
-          "shield",
-          "interrupt-4"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "self",
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7,
-          "trigger": "<p>The user is targeted by an Attack.</p>"
-        },
-        "category": "status",
-        "types": [
-          "steel"
-        ],
-        "description": "<p>Trigger: The user is targeted by an Attack.</p><p>Effect: The triggering attack fails to hit the user, and additional attacks also fail to hit until the user's next activation, or when the round ends, whichever is first. Attacks failing to hit this way do not activate their secondary effects. If the triggering Attack has [Contact], the attacker loses -2 ATK Stages for 5 Activations.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
+        }
       },
       {
         "slug": "kings-shield-supreme",
@@ -103,7 +82,8 @@
         "description": "<p>Trigger: The user is targeted by an Attack.</p><p>Effect: The triggering attack fails to hit the user, and additional attacks also fail to hit until the user's next activation, or when the round ends, whichever is first. Attacks failing to hit this way do not activate their secondary effects. If the triggering Attack has [Contact], the attacker loses -2 ATK Stages for 5 Activations. The user gains +1 DEF and SPDEF Stage for 5 Activations.</p>",
         "free": true,
         "variant": "kings-shield",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Effect: Connection - King's Shield. The user changes to Blade Forme when declaring a Physical- or Special-Category attack and changes to Shield Forme when declaring a Status-Category attack.  When using King's Shield, the user can spend an additional 4 AP to gains +1 DEF and SPDEF Stage for 5 Activations.</p><p>Passive: The user starts combat in Shield Forme.</p>",
@@ -119,5 +99,73 @@
     }
   },
   "_id": "cWgvYlEywzGnsOqG",
-  "effects": []
+  "effects": [
+    {
+      "name": "Stance Change",
+      "type": "passive",
+      "_id": "psMH6cgkpxjuWKhh",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.KgS6ulU2aIjf0vbo",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737421123127,
+        "modifiedTime": 1737421155826,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/stone-surge.json
+++ b/packs/core-abilities/stone-surge.json
@@ -36,31 +36,11 @@
           "activation": "free"
         },
         "description": "<p>Passive: When resolving Stealth Rock, the user can spend an additional 2 PP double the number of Hazards created.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "stealth-rock",
-        "name": "Stealth Rock",
-        "type": "attack",
-        "traits": [
-          "hazard",
-          "missile"
-        ],
+        "img": "icons/svg/explosion.svg",
         "range": {
-          "target": "emanation",
-          "distance": 8,
+          "target": "enemy",
           "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "types": [
-          "rock"
-        ],
-        "description": "<p>Effect: The user places 5 floating rock mine Hazards within Range. When a creature moves within 3m of a rock mine, it homes in on them and deals a Tick of Rock-Type damage.</p>",
-        "img": "icons/svg/explosion.svg"
+        }
       },
       {
         "slug": "stealth-rock-surge",
@@ -86,7 +66,8 @@
         "description": "<p>Effect: The user places 10 floating rock mine Hazards within Range. When a creature moves within 3m of a rock mine, it homes in on them and deals a Tick of Rock-Type damage.</p>",
         "variant": "stealth-rock",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "description": "<p>Trigger: The user is hit by an attack.</p><p>Effect: Connection - Stealth Rock. The user freely uses Stealth Rock. Passive: When resolving Stealth Rock, the user can spend an additional 3 PP double the number of Hazards created.</p>",
@@ -101,5 +82,73 @@
     }
   },
   "_id": "Fm6nZyEho5NddbtV",
-  "effects": []
+  "effects": [
+    {
+      "name": "Stone Surge",
+      "type": "passive",
+      "_id": "wREx29ri3TlSKJX7",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.JSSINn7yRN0wXMZ2",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": 0
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737421208876,
+        "modifiedTime": 1737421228560,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/stout-aerouant.json
+++ b/packs/core-abilities/stout-aerouant.json
@@ -22,35 +22,6 @@
         },
         "description": "<p>Trigger: The user resolves a Dragon-Type attack.</p><p>Effect: Negative [Stage Change] effects affecting the user are removed.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "dragon-energy",
-        "name": "Dragon Energy",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "pulse",
-          "drain-1/4",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 5,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 10
-        },
-        "category": "special",
-        "power": 150,
-        "accuracy": 100,
-        "types": [
-          "dragon"
-        ],
-        "description": "<p>Effect: This attack's Power ranges based on how healthy the user is, ranging from 1 to 150.</p><p><blockquote>Damage Formula: Power = max(1, 150 x UserCurrentHP/UserMaxHP)</blockquote>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user resolves a Dragon-Type attack.</p><p>Effect: Connection - Dragon Energy. Negative [Stage Change] effects affecting the user are removed. Passive: The user's Dragon Energy gains [Drain 1/4].</p>",
@@ -65,5 +36,73 @@
     }
   },
   "_id": "fgnUpZqSxSncHLqF",
-  "effects": []
+  "effects": [
+    {
+      "name": "Stout Aeronaut",
+      "type": "passive",
+      "_id": "yw1FfE7VzH6t42cu",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.xf2NuI372VOQGVIL",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737421256366,
+        "modifiedTime": 1737421304136,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/sword-of-ruin.json
+++ b/packs/core-abilities/sword-of-ruin.json
@@ -21,38 +21,14 @@
         },
         "description": "<p>Effect: All other creatures have their DEF stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "ruination",
-        "name": "Ruination",
-        "type": "attack",
-        "traits": [
-          "legendary"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "special",
-        "accuracy": 90,
-        "types": [
-          "dark"
-        ],
-        "description": "<p>Effect: On hit, all valid target's HP is cut in half. This attack always deals a minimum of 1 HP in damage.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Effect: Connection - Ruination. All other creatures have their DEF stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
     "traits": [
       "legendary",
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "sword-of-ruin",
     "_migration": {
@@ -61,5 +37,73 @@
     }
   },
   "_id": "mScBrZRMBkCr97fh",
-  "effects": []
+  "effects": [
+    {
+      "name": "Treasure of Ruin",
+      "type": "passive",
+      "_id": "YgWmBGhvm5CC56gf",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.6MiHI8QGhMknDms5",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.sWdQIvH00vsGkCYB.ActiveEffect.J2mZCtyIjIqYFGrQ",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392977380,
+        "modifiedTime": 1737392977380,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/tablets-of-ruin.json
+++ b/packs/core-abilities/tablets-of-ruin.json
@@ -21,38 +21,14 @@
         },
         "description": "<p>Effect: All other creatures have their ATK stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "ruination",
-        "name": "Ruination",
-        "type": "attack",
-        "traits": [
-          "legendary"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "special",
-        "accuracy": 90,
-        "types": [
-          "dark"
-        ],
-        "description": "<p>Effect: On hit, all valid target's HP is cut in half. This attack always deals a minimum of 1 HP in damage.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Effect: Connection - Ruination. All other creatures have their ATK stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
     "traits": [
       "legendary",
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "tablets-of-ruin",
     "_migration": {
@@ -61,5 +37,73 @@
     }
   },
   "_id": "5KUeoSGMw8YWNwDO",
-  "effects": []
+  "effects": [
+    {
+      "name": "Treasure of Ruin",
+      "type": "passive",
+      "_id": "gyzlusEjK4iMgITC",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.6MiHI8QGhMknDms5",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.sWdQIvH00vsGkCYB.ActiveEffect.J2mZCtyIjIqYFGrQ",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392939156,
+        "modifiedTime": 1737392939156,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/tera-shell.json
+++ b/packs/core-abilities/tera-shell.json
@@ -22,63 +22,6 @@
         },
         "description": "<p>Effect: While the user meets the [Intrepid 3/4] Condition, the user takes 50% less damage from Physical- and Special-Category Attacks. Upon leaving battle, the user returns to its Normal Forme.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "tera-starstorm",
-        "name": "Tera Starstorm",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "blast-2",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 20,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6
-        },
-        "category": "special",
-        "power": 120,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "tera-starstorm-stellar",
-        "name": "Tera Starstorm (Stellar)",
-        "type": "attack",
-        "traits": [
-          "legendary",
-          "blast-5",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 20,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6,
-          "trigger": "<p>The user is currently in their Stellar Forme.</p>"
-        },
-        "category": "special",
-        "power": 120,
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Tigger: The user is currently in their Stellar Forme.</p>",
-        "variant": "tera-starstorm",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Effect: Connection - Tera Starstorm. While the user meets the [Intrepid 3/4] Condition, the user takes 50% less damage from Physical- and Special-Category Attacks. Upon leaving battle, the user returns to its Normal Forme.</p>",
@@ -93,5 +36,90 @@
     }
   },
   "_id": "YTFTNio0VopMWf0s",
-  "effects": []
+  "effects": [
+    {
+      "name": "Tera Shell",
+      "type": "passive",
+      "_id": "8rPBDwrogEoSRHc5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.LNZi0GDKv5mYjS7F",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.1.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "damaging-attack-damage-percentile",
+            "value": -50,
+            "predicate": [
+              "self:state:intrepid-3-4"
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737421398604,
+        "modifiedTime": 1737421515833,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/toxic-chain.json
+++ b/packs/core-abilities/toxic-chain.json
@@ -20,59 +20,9 @@
         },
         "description": "<p>Effect: The user's attacks have a 30% chance to apply @Affliction[blight] 5.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "toxic",
-        "name": "Toxic",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "creature",
-          "distance": 6,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "status",
-        "accuracy": 90,
-        "types": [
-          "poison"
-        ],
-        "description": "<p>Effect: The target gains @Affliction[blight] 8. If Toxic is used by a Poison-Typed creature, this attack gains [Danger Close].</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "toxic-poison-type",
-        "name": "Toxic (Posion-Type)",
-        "type": "attack",
-        "traits": [
-          "danger-close"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 6,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7,
-          "trigger": "<p>The user has the Poison Type.</p>"
-        },
-        "category": "status",
-        "accuracy": 100,
-        "types": [
-          "poison"
-        ],
-        "description": "<p>Trigger: The user has the Poison Type.</p><p>Effect: The target gains @Affliction[blight] 8.</p>",
-        "variant": "toxic",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Effect: Connection - Toxic. The user's attacks have a 30% chance to apply @Affliction[blight] 5.</p>",
+    "description": "<p>Effect: Connection - Toxic. The user's attacks have a 30% chance to apply @Affliction[blight] 8.</p>",
     "traits": [
       "legendary",
       "connection"
@@ -84,5 +34,89 @@
     }
   },
   "_id": "l1yGOqKO6wB3AXyE",
-  "effects": []
+  "effects": [
+    {
+      "name": "Toxic Chain",
+      "type": "passive",
+      "_id": "x3SWoR6djlGuTccE",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.oTSFbF32HX101PTb",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.actions.1.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "roll-effect",
+            "key": "damaging-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.blightcondititem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737421607702,
+        "modifiedTime": 1737421670789,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/toxic-debris.json
+++ b/packs/core-abilities/toxic-debris.json
@@ -42,30 +42,6 @@
         },
         "description": "<p>Trigger: The user resolves Toxic Spikes.</p><p>Effect: All creatures occupying spaces shared by the triggering-attack's hazards gain @Affliction[poison] 1.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "toxic-spikes",
-        "name": "Toxic Spikes",
-        "type": "attack",
-        "traits": [
-          "hazard",
-          "blast-4"
-        ],
-        "range": {
-          "target": "blast",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "types": [
-          "poison"
-        ],
-        "description": "<p>Effect: Poison tipped spikes are spread over the [Blast X] area on standing surfaces. A creature that starts an Activation on a surface containing the Hazard gains @Affliction[poison] 1. A creature that moves through through a space touching a surface containing the Hazard gain @Affliction[poison] 1 for each square travelled. After gaining 4 Stacks of @Affliction[poison] this way during the same Round, the creature's @Affliction[poison] Affliction becomes @Affliction[blight].</p>",
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a Physical-Category Attack.</p><p>Effect: Connection - Toxic Spikes. The user freely uses Toxic Spikes. Passive: When using Toxic Spikes, the user can spend an additional 2 PP to have creatures occupying spaces shared by the triggering-attack's hazards gain @Affliction[poison] 1.</p>",
@@ -80,5 +56,73 @@
     }
   },
   "_id": "oOaKiFGlZvb15mXs",
-  "effects": []
+  "effects": [
+    {
+      "name": "Toxic Debris",
+      "type": "passive",
+      "_id": "RiqFLLZFPaCctz3h",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.ZPdwItj91QOBjAgC",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737421720524,
+        "modifiedTime": 1737421771750,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/trickster.json
+++ b/packs/core-abilities/trickster.json
@@ -23,32 +23,6 @@
         "img": "icons/svg/explosion.svg"
       },
       {
-        "slug": "disable",
-        "name": "Disable",
-        "type": "attack",
-        "traits": [
-          "interrupt-1"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 2,
-          "trigger": "<p>A foe uses an attack.</p>"
-        },
-        "category": "status",
-        "accuracy": 100,
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Trigger: A foe uses an attack.</p><p>Effect: The triggering attack becomes @Affliction[disabled] 5 after it resolves.</p>",
-        "img": "icons/svg/explosion.svg",
-        "free": true
-      },
-      {
         "slug": "disable-preemptive",
         "name": "Disable (Preemptive)",
         "type": "attack",
@@ -72,12 +46,14 @@
         "description": "<p>Trigger: Triggered by an Ability.</p><p>Effect: The target has the last Move it used this combat @Affliction[disabled] 5, else, a random Move is selected.</p>",
         "img": "icons/svg/explosion.svg",
         "variant": "disable",
-        "free": true
+        "free": true,
+        "predicate": []
       }
     ],
-    "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: Connection - Feint Attack. The user freely moves up to and using the Movement Score of their choice, and uses Feint Attack (Dastardly).</p>",
+    "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: Connection - Disable. The user freely moves up to and using the Movement Score of their choice, and uses Disable (Preemptive).</p>",
     "traits": [
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "trickster",
     "_migration": {
@@ -86,5 +62,73 @@
     }
   },
   "_id": "RCSnbau25ch2YFfz",
-  "effects": []
+  "effects": [
+    {
+      "name": "Trickster",
+      "type": "passive",
+      "_id": "a6fWEisVUu1V84NE",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.g2dBn6zaIVcZCIuM",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737421885411,
+        "modifiedTime": 1737421911170,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/vessel-of-ruin.json
+++ b/packs/core-abilities/vessel-of-ruin.json
@@ -21,38 +21,14 @@
         },
         "description": "<p>Effect: All other creatures have their SPATK stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "ruination",
-        "name": "Ruination",
-        "type": "attack",
-        "traits": [
-          "legendary"
-        ],
-        "range": {
-          "target": "emanation",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 7
-        },
-        "category": "special",
-        "accuracy": 90,
-        "types": [
-          "dark"
-        ],
-        "description": "<p>Effect: On hit, all valid target's HP is cut in half. This attack always deals a minimum of 1 HP in damage.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Effect: Connection - Ruination. All other creatures have their SPATK stat reduced by 25%. This reduction happens before any [Stage Change] effects.</p>",
     "traits": [
       "legendary",
       "aura",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "vessel-of-ruin",
     "_migration": {
@@ -61,5 +37,73 @@
     }
   },
   "_id": "97i4MiUWeQPLtv3G",
-  "effects": []
+  "effects": [
+    {
+      "name": "Treasure of Ruin",
+      "type": "passive",
+      "_id": "oSU2QsG2BuMUYQMc",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.6MiHI8QGhMknDms5",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.sWdQIvH00vsGkCYB.ActiveEffect.J2mZCtyIjIqYFGrQ",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737392957010,
+        "modifiedTime": 1737392957010,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/white-smoke.json
+++ b/packs/core-abilities/white-smoke.json
@@ -24,31 +24,6 @@
         },
         "description": "<p>Trigger: A negative [Stage Change] effect is applied to the user.</p><p>Effect: The user freely uses Smokescreen centered on itself. Then, the triggering effect is cured.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "smokescreen",
-        "name": "Smokescreen",
-        "type": "attack",
-        "traits": [
-          "hazard",
-          "blast-3"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 5
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "<p>Effect: An Obscurring Cloud is created in the [Blast X] area for 5 rounds. An enemy creature that starts their activation in or enters a space containing an Obscurring Cloud Hazard gains @Affliction[blinded] 2.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: A negative [Stage Change] effect is applied to the user</p><p>Effect: Connection - Smokescreen. The user freely uses Smokescreen centered on itself. Then, the triggering effect is cured.</p><p>Passive: Smokescreen Hazards created by the user do not affect the user or their allies.</p>",
@@ -64,5 +39,73 @@
     }
   },
   "_id": "1Tiu4yez4jm3cqu7",
-  "effects": []
+  "effects": [
+    {
+      "name": "White Smoke",
+      "type": "passive",
+      "_id": "bIPC4PLGYvMM5zmr",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.pYNVsTCmUw7oWhRg",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737421949545,
+        "modifiedTime": 1737421982805,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/windvane.json
+++ b/packs/core-abilities/windvane.json
@@ -23,35 +23,13 @@
         },
         "description": "<p>Trigger: The user declares Tailwind.</p><p>Effect: The set Windy Weather has its duration increased by +2 Rounds.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "tailwind",
-        "name": "Tailwind",
-        "type": "attack",
-        "traits": [
-          "weather"
-        ],
-        "range": {
-          "target": "field",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 4
-        },
-        "category": "status",
-        "types": [
-          "flying"
-        ],
-        "description": "<p>Effect: The weather becomes Windy for 3 rounds.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user declares Tailwind.</p><p>Effect: Connection - Tailwind. The set Windy Weather has its duration increased by +2 Rounds.</p>",
     "traits": [
       "connection",
-      "weather"
+      "weather",
+      "partial-automation"
     ],
     "slug": "windvane",
     "_migration": {
@@ -60,5 +38,73 @@
     }
   },
   "_id": "t8k9AGD2NcCxxW2f",
-  "effects": []
+  "effects": [
+    {
+      "name": "Windvane",
+      "type": "passive",
+      "_id": "MAgRjALWr8KOCtN6",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.u9S8zbICHVUBS1Gx",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737422014067,
+        "modifiedTime": 1737422043698,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/wishmaker.json
+++ b/packs/core-abilities/wishmaker.json
@@ -46,7 +46,8 @@
         ],
         "description": "<p>Effect: Set-Up: The user makes a wish, ending their current activation.</p><p>Resolution: On their next activation, they can select 1 creature on the field (which can be the user), to recover HP equal to 1/2 the Wish User's Max HP.</p>",
         "free": true,
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "traits": [
@@ -69,7 +70,8 @@
     "description": "<p>Trigger: The user resolves Wish.</p><p>Effect: Connection - Wish. The user selections to utilize one of the following effects to utilize in place of triggering attack's normal Resolution effect:<ul><li>The target is healed 12 Ticks of HP, and creatures allied to the target in a 5m Burst of the target are healed 4 Ticks of HP.</li><li>The target gains +3 Stages to a Stat of the target's choice, and creatures allied to the target in a 2m Burst of the target gain +1 Stage in that Stat, all for 7 Activations.</li><li>The target is cured of all its Status Afflictions (except @Affliction[weary]), and creatures allied to the target in a 4m Burst of the target are healed of 1 random Status Affliction they possess.</li><li>The target loses 1 @Affliction[weary] and regains 20% of its max PP, minimum 20, and creatures allied to the target in a Burst 3 of the target regain 10 PP.</li><li>The target loses 4 Ticks of HP, and creatures not allied to the target in a 5m Burst of the target lose 10 Ticks of HP.</li>This Action's Activation Cost is taken from the user's next Activation.</p><p>Passive: The user possesses the Comatose Ability.</p",
     "traits": [
       "legendary",
-      "connection"
+      "connection",
+      "partial-automation"
     ],
     "slug": "wishmaker",
     "_migration": {
@@ -78,5 +80,73 @@
     }
   },
   "_id": "UqcOktU7m7EH2znT",
-  "effects": []
+  "effects": [
+    {
+      "name": "Wishmaker",
+      "type": "passive",
+      "_id": "YLJVtSHHg1Y0g5cV",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.0mfq7wAjGYBPrmiN",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737422104879,
+        "modifiedTime": 1737422140142,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/zero-to-hero.json
+++ b/packs/core-abilities/zero-to-hero.json
@@ -59,62 +59,6 @@
         },
         "description": "<p>Effect: The user enters their Hero Forme for 5 Activations.</p>",
         "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "flip-turn",
-        "name": "Flip Turn",
-        "type": "attack",
-        "traits": [
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2
-        },
-        "category": "physical",
-        "power": 60,
-        "accuracy": 100,
-        "types": [
-          "water"
-        ],
-        "description": "<p>Effect: On hit, the user may freely move themselves up to half of the Movement Score of their choice away from the target. If the user is an owned Pokémon, they may then immediately be returned their Poké Ball and another Pokémon may immediately be sent out in their place.</p>",
-        "free": true,
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "jet-punch",
-        "name": "Jet Punch (Hero Only)",
-        "type": "attack",
-        "traits": [
-          "punch",
-          "priority-4",
-          "contact",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 1,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 2,
-          "priority": 4
-        },
-        "category": "physical",
-        "power": 60,
-        "accuracy": 100,
-        "types": [
-          "water"
-        ],
-        "free": true,
-        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user switches-out.</p><p>Effect: Connection - Flip Turn. The user transforms into their Hero Forme until the end of combat or when the user gains @Affliction[fainted]. The user can spend an 4 PP to transform into their Hero Forme for 5 Activations as a Complex Action. This effect costs 2 more PP and gains [Exhaust] if the user has @Affliction[weary].</p><p>Passive: While the user is in their Hero Forme, they gain Connection - Jet Punch.</p>",
@@ -130,5 +74,73 @@
     }
   },
   "_id": "gfJ5DPR5rW4LmiZA",
-  "effects": []
+  "effects": [
+    {
+      "name": "Zero To Hero",
+      "type": "passive",
+      "_id": "gfa3qdsK7eDfydYV",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.mQ7A5gRxvfUfZ8ew",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737422198535,
+        "modifiedTime": 1737422234674,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Fixed the rest of the abilities. Had to resubmit the treasures of ruin as had forgot something with them, so this needs done last of the fixes.
- Update Ability: Periodic Orbit
- Update Ability: Phantom Devicer
- Update Ability: Pickpocket
- Update Ability: Poison Puppeteer
- Update Ability: Pollution
- Update Ability: Powder Burst
- Update Ability: Power Construct
- Update Ability: Primordial Sea
- Update Ability: Psychic Surge
- Update Ability: Regression Field
- Update Ability: Rejection
- Update Ability: Relic Soloist
- Update Ability: Relic Variation
- Update Ability: Righteous Blade
- Update Ability: Sand Spit
- Update Ability: Sand Stream
- Update Ability: Seed Sower
- Update Ability: Shear Fault
- Update Ability: Shell Shield
- Update Ability: Singer
- Update Ability: Snow Warning
- Update Ability: Solid Rock
- Update Ability: Sword of Ruin
- Update Ability: Beads of Ruin
- Update Ability: Vessel of Ruin
- Update Ability: Tablets of Ruin
- Update Ability: Special Delivery
- Update Ability: Spider Lair
- Update Ability: Spinning Top
- Update Ability: Stance Change
- Update Ability: Stone Surge
- Update Ability: Stout Aerouant
- Update Ability: Tera Shell
- Update Ability: Toxic Chain
- Update Ability: Toxic Debris
- Update Ability: Trickster
- Update Ability: White Smoke
- Update Ability: Windvane
- Update Ability: Wishmaker
- Update Ability: Zero to Hero