### PR TITLE
Foundry Data Sync - Automate Atlas Crash

### DIFF
--- a/packs/core-moves/atlas-crash.json
+++ b/packs/core-moves/atlas-crash.json
@@ -4,15 +4,6 @@
   "img": "systems/ptr2e/img/svg/rock_icon.svg",
   "system": {
     "slug": "atlas-crash",
-    "description": "",
-    "traits": [
-      "recoil-1-2",
-      "crushing",
-      "dash",
-      "legendary",
-      "flinch-5",
-      "pp-updated"
-    ],
     "actions": [
       {
         "slug": "atlas-crash",
@@ -33,10 +24,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null,
-          "trigger": null
+          "powerPoints": 6
         },
         "category": "physical",
         "power": 130,
@@ -45,15 +33,78 @@
           "rock"
         ],
         "description": "<p>Effect: On hit, the target becomes Flinched and gains @Affliction[confused] 7.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "nGNLKSSBn9QOTUn6",
-  "effects": []
+  "effects": [
+    {
+      "name": "Atlas Crash",
+      "type": "passive",
+      "_id": "JpFohoAHTlxkzYG9",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "atlas-crash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ]
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>Effect: On hit, the target becomes Flinched and gains @Affliction[confused] 7.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737571491768,
+        "modifiedTime": 1737571649330,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Example of non-standard Duration Effect Roll
- Update Move: Atlas Crash