### PR TITLE
Foundry Data Sync - Fox Fixes 23/01/2025 - Species Tweaks, Xernean Longbow Fixes, Automation for Priority/Flinch perks and moves

### DIFF
--- a/packs/core-abilities/quick-draw.json
+++ b/packs/core-abilities/quick-draw.json
@@ -29,5 +29,71 @@
     }
   },
   "_id": "3gU77YvsknBgWXat",
-  "effects": []
+  "effects": [
+    {
+      "name": "Quick Draw",
+      "type": "passive",
+      "_id": "jjXpN1kBOnwlXqwm",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "missile-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": 20
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Advance 20"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Actor.XMvKhKU2wT1KaqEG.Item.JLLXjz8iXmJXERiZ.ActiveEffect.GoqKyTjXpVMAzHXR",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737665297412,
+        "modifiedTime": 1737665297412,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-gear/xernean-longbow.json
+++ b/packs/core-gear/xernean-longbow.json
@@ -17,15 +17,20 @@
         "name": "Light Arrow",
         "slug": "xernean-longbow-action-1",
         "description": "<p>A bow crafted from the shedding of the Horns of Xerneas. It has a faint pearl sheen that becomes a soft glow in the light of the moon.<br><br>The Light Arrow targets the victim's Special Defense.</p>",
-        "traits": [],
+        "traits": [
+          "weapon",
+          "missile"
+        ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "range": {
           "target": "enemy",
-          "unit": "m"
+          "unit": "m",
+          "distance": 30
         },
         "cost": {
-          "activation": "complex"
+          "activation": "complex",
+          "powerPoints": 2
         },
         "types": [
           "fairy"
@@ -41,15 +46,20 @@
         "name": "Wyrmslayer Arrow",
         "slug": "xernean-longbow-action-2",
         "description": "<p>A bow crafted from the shedding of the Horns of Xerneas. It has a faint pearl sheen that becomes a soft glow in the light of the moon.</p>",
-        "traits": [],
+        "traits": [
+          "weapon",
+          "missile"
+        ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "range": {
           "target": "enemy",
-          "unit": "m"
+          "unit": "m",
+          "distance": 30
         },
         "cost": {
-          "activation": "simple"
+          "activation": "simple",
+          "powerPoints": 5
         },
         "types": [
           "fairy"
@@ -58,7 +68,8 @@
         "power": 120,
         "accuracy": 80,
         "defensiveStat": "spd",
-        "predicate": []
+        "predicate": [],
+        "free": true
       }
     ],
     "description": "<p>A bow crafted from the shedding of the Horns of Xerneas. It has a faint pearl sheen that becomes a soft glow in the light of the moon.</p>",
@@ -68,7 +79,7 @@
       "materials": []
     },
     "equipped": {
-      "carryType": "stowed",
+      "carryType": "equipped",
       "handsHeld": null,
       "slot": "held"
     },
@@ -89,7 +100,8 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "slug": "xernean-longbow"
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -146,6 +158,5 @@
     }
   ],
   "folder": "V4skAU6G3OH5fXaf",
-  "flags": {},
   "_id": "3DcwGXX9YCxh72T6"
 }

--- a/packs/core-moves/after-you.json
+++ b/packs/core-moves/after-you.json
@@ -22,21 +22,87 @@
           "powerPoints": 4
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: Target takes their Activation immediately after the user's Activation ends.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "qzWBfWEqTPCaQdhz",
-  "effects": []
+  "effects": [
+    {
+      "name": "After You",
+      "type": "passive",
+      "_id": "onaNwS1d5Oh7Vem0",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "after-you-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": 100
+              },
+              {
+                "mode": 5,
+                "property": "Advance 100%",
+                "value": 0
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737678343853,
+        "modifiedTime": 1737678407352,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/air-slash.json
+++ b/packs/core-moves/air-slash.json
@@ -30,15 +30,79 @@
           "flying"
         ],
         "description": "<p>Effect: On hit, the target has a 30% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "lxpXiXqapEF8GFPC",
-  "effects": []
+  "effects": [
+    {
+      "name": "Air Slash",
+      "type": "advancement",
+      "_id": "VrxettEItzXCeva9",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "air-slash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "amount": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737651928799,
+        "modifiedTime": 1737676628954,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/aqua-fang.json
+++ b/packs/core-moves/aqua-fang.json
@@ -32,14 +32,16 @@
           "water"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of being Flinched, and a 10% chance to lose -1 SPD for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "grade": "E",
     "_migration": {
       "version": null,
       "previous": null
-    }
+    },
+    "traits": []
   },
   "_id": "UJk9BTkjOZh8WeaX",
   "effects": [
@@ -57,6 +59,25 @@
             "predicate": [],
             "chance": 10,
             "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "aqua-fang-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -40
+              }
+            ],
             "mode": 2,
             "priority": null,
             "ignored": false
@@ -90,10 +111,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.2.4.3",
+        "systemVersion": "0.10.0-alpha.5.2.1",
         "createdTime": 1729165852859,
-        "modifiedTime": 1729166081106,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+        "modifiedTime": 1737676726884,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
       }
     }
   ]

--- a/packs/core-moves/astonish.json
+++ b/packs/core-moves/astonish.json
@@ -23,8 +23,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 0
+          "activation": "complex"
         },
         "category": "physical",
         "power": 30,
@@ -33,15 +32,83 @@
           "ghost"
         ],
         "description": "<p>Effect: On hit, the target has a 30% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "05gTyZzErLsW9RtE",
-  "effects": []
+  "effects": [
+    {
+      "name": "Astonish",
+      "type": "passive",
+      "_id": "dStoecgRLGTkIVx9",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "astonish-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 30%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737678446356,
+        "modifiedTime": 1737678577654,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/aura-wheel.json
+++ b/packs/core-moves/aura-wheel.json
@@ -31,15 +31,90 @@
           "electric"
         ],
         "description": "<p>Effect: On hit, the user gains +1 SPD Stage for 5 Activations and gains Curl 3. Aura Wheel's damage Type changes to match the user's Forme.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "rN234RofhiJa4Le2",
-  "effects": []
+  "effects": [
+    {
+      "name": "Aura Wheel",
+      "type": "passive",
+      "_id": "t8wavS5rCNcjiqGv",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "aura-wheel-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLM",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "aura-wheel-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.curledcondititem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737678637698,
+        "modifiedTime": 1737678718577,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/bark.json
+++ b/packs/core-moves/bark.json
@@ -4,7 +4,7 @@
   "_id": "h2xOusyckAvQlQtf",
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "bark",
     "actions": [
       {
         "name": "Bark",
@@ -26,38 +26,88 @@
           "activation": "complex",
           "powerPoints": 1
         },
-        "variant": null,
         "types": [
           "normal"
         ],
         "category": "special",
         "power": 40,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has a 10% chance of being Flinched.</p>"
+        "description": "<p>Effect: On hit, the target has a 10% chance of being Flinched.</p>",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720813254885,
-    "modifiedTime": 1720813458366,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Bark",
+      "type": "passive",
+      "_id": "Tisd5aDrTFStL0bm",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "bark-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -20
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 20%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737678877781,
+        "modifiedTime": 1737678932191,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/bite.json
+++ b/packs/core-moves/bite.json
@@ -31,15 +31,83 @@
           "dark"
         ],
         "description": "<p>Effect: On hit, the target has a 30% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "3KCZGRV9lMmb44FC",
-  "effects": []
+  "effects": [
+    {
+      "name": "Bite",
+      "type": "passive",
+      "_id": "uM9lEbJS6Ee0AHd9",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "bite-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinched 30%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737678983033,
+        "modifiedTime": 1737679041699,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/black-hole-eclipse.json
+++ b/packs/core-moves/black-hole-eclipse.json
@@ -21,7 +21,6 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 0,
           "trigger": "<p>User's partner uses Z-Pose! and triggers the appropriate Z-Crystal.</p>"
         },
         "category": "physical",
@@ -31,15 +30,84 @@
           "dark"
         ],
         "description": "<p>Trigger: User's partner uses Z-Pose! and triggers the appropriate Z-Crystal.</p><p>Effect: On hit, all valid targets have a 50% chance of being Flinched.</p><p>Requirement: [Dark] Z-Crystal as an Accessory Item and a Dark-Type attack on the user's Active List.</p>",
-        "contestType": "",
-        "contestEffect": "",
         "free": true,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "xSlpc2zrEMwrb4oZ",
-  "effects": []
+  "effects": [
+    {
+      "name": "Black Hole Eclipse",
+      "type": "passive",
+      "_id": "V40us5heVtwKSOvd",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "black-hole-eclipse",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 30%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737679088801,
+        "modifiedTime": 1737679205723,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/blue-flare.json
+++ b/packs/core-moves/blue-flare.json
@@ -31,15 +31,78 @@
           "fire"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 20% chance of gaining @Affliction[burn] 9.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "s9hHSCryL6AuXfbG",
-  "effects": []
+  "effects": [
+    {
+      "name": "Blue Flare",
+      "type": "passive",
+      "_id": "GRC2CWQ1gQDGnHW6",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "blue-flare-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 9
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737679265806,
+        "modifiedTime": 1737679391796,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/engulf.json
+++ b/packs/core-moves/engulf.json
@@ -10,7 +10,6 @@
         "name": "Engulf",
         "type": "attack",
         "traits": [
-          "move-locked",
           "exhaust",
           "pp-updated"
         ],
@@ -30,14 +29,16 @@
           "ghost"
         ],
         "description": "<p>Effect: All [Hazard] and [Shield] attack effects in Range are cleared, as are the @Affliction[leech] and @Affliction[bound] conditions.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "v7DeY7cPLe5xLE9Y",
   "effects": []

--- a/packs/core-moves/ice-beam.json
+++ b/packs/core-moves/ice-beam.json
@@ -29,15 +29,78 @@
           "ice"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[frozen] 2.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "vyh3c4td7WZqIt5O",
-  "effects": []
+  "effects": [
+    {
+      "name": "Ice Beam",
+      "type": "passive",
+      "_id": "qoyjhqejccsuv9q4",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "ice-beam-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.frozencondititem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 2
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737665793454,
+        "modifiedTime": 1737665891587,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/quick-and-the-dead.json
+++ b/packs/core-perks/quick-and-the-dead.json
@@ -58,5 +58,60 @@
     "global": true,
     "webs": []
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Quick And The Dead",
+      "type": "passive",
+      "_id": "z7y1zzA2z4Rf7Nwm",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737661825098,
+        "modifiedTime": 1737661874073,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-species/feraligatr.json
+++ b/packs/core-species/feraligatr.json
@@ -721,6 +721,10 @@
                 "item": null,
                 "level": null,
                 "knownMove": null
+              },
+              "perk": {
+                "x": 15,
+                "y": 15
               }
             }
           ],
@@ -729,18 +733,30 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.7cPNHVaVom6J7rAT"
+      "uuid": "Compendium.ptr2e.core-species.Item.7cPNHVaVom6J7rAT",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "lake",
       "river",
       "swamp"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "IdeCj7OGKWQfNSwz",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/pincurchin.json
+++ b/packs/core-species/pincurchin.json
@@ -289,7 +289,13 @@
     "evolutions": {
       "name": "pincurchin",
       "details": null,
-      "evolutions": []
+      "evolutions": [],
+      "uuid": null,
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "number": 871,
     "traits": [
@@ -423,9 +429,12 @@
       "polar",
       "abyss"
     ],
-    "slug": "pincurchin"
+    "slug": "pincurchin",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "wb0Ro2ZSYlKng0pT",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/poipole.json
+++ b/packs/core-species/poipole.json
@@ -213,10 +213,19 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.A16SczAsH6QDzUjL"
+      "uuid": "Compendium.ptr2e.core-species.Item.A16SczAsH6QDzUjL",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "number": 803,
     "traits": [
@@ -374,9 +383,12 @@
       }
     ],
     "habitats": [],
-    "slug": "poipole"
+    "slug": "poipole",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "A16SczAsH6QDzUjL",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/rayquaza.json
+++ b/packs/core-species/rayquaza.json
@@ -667,13 +667,22 @@
     "evolutions": {
       "name": "rayquaza",
       "details": null,
-      "evolutions": []
+      "evolutions": [],
+      "uuid": null,
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "genderRatio": -1,
     "habitats": [],
-    "slug": "rayquaza"
+    "slug": "rayquaza",
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "sNc45Kp3GYTWr6OZ",
-  "effects": [],
-  "folder": null
+  "effects": []
 }


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Ability: Quick Draw
- Update Perk: Quick And The Dead
- Update Move: Ice Beam
- Update Weapon: Xernean Longbow
- Create Species: poipole
- Create Species: pincurchin
- Create Species: rayquaza
- Update Move: Engulf
- Create Species: feraligatr
- Update Move: Air Slash
- Update Move: Aqua Fang
- Update Move: After You
- Update Move: Astonish
- Update Move: Aura Wheel
- Update Move: Bark
- Update Move: Bite
- Update Move: Black Hole Eclipse
- Update Move: Blue Flare