### PR TITLE
Foundry Data Sync - Fox Move Automations 24/01/25 - Pack 1

### DIFF
--- a/packs/core-moves/bleakwind-storm.json
+++ b/packs/core-moves/bleakwind-storm.json
@@ -32,10 +32,8 @@
           "flying"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 60% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "slug": "bleakwind-storm-blowing",
@@ -67,16 +65,84 @@
           "flying"
         ],
         "description": "<pTrigger: Snowy or Windy Weather is present.</p><p>Effect: On hit, all valid targets have a 60% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
         "variant": "bleakwind-storm",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "4stUbCaYe9XkacsR",
-  "effects": []
+  "effects": [
+    {
+      "name": "Bleakwind Storm",
+      "type": "passive",
+      "_id": "iDzoKlg1FxuYIuAu",
+      "img": "icons/skills/movement/feet-winged-boots-brown.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "bleakwind-storm-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 60,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -50
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 50%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737718713006,
+        "modifiedTime": 1737718909961,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/blizzard.json
+++ b/packs/core-moves/blizzard.json
@@ -31,7 +31,8 @@
           "ice"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[frozen] 2.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "slug": "blizzard-snowy",
@@ -62,14 +63,16 @@
         ],
         "description": "<p>Snowy Weather is present.</p><p>Effect: On hit, the target has a 10% chance of gaining @Affliction[frozen] 3.</p>",
         "variant": "blizzard",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "grade": "B",
     "_migration": {
       "version": null,
       "previous": null
-    }
+    },
+    "traits": []
   },
   "_id": "pMSwY3ECWqqasF1a",
   "effects": [
@@ -87,6 +90,13 @@
             "predicate": [],
             "chance": 10,
             "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 2
+              }
+            ],
             "mode": 2,
             "priority": null,
             "ignored": false
@@ -98,6 +108,13 @@
             "predicate": [],
             "chance": 10,
             "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 2
+              }
+            ],
             "mode": 2,
             "priority": null,
             "ignored": false
@@ -131,9 +148,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.2.4.3",
+        "systemVersion": "0.10.0-alpha.5.2.1",
         "createdTime": 1729171571064,
-        "modifiedTime": 1729171594283,
+        "modifiedTime": 1737719121640,
         "lastModifiedBy": "Kc3DOunCh3ClAeHS"
       }
     }

--- a/packs/core-moves/block.json
+++ b/packs/core-moves/block.json
@@ -22,21 +22,94 @@
           "powerPoints": 3
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: The target is @Affliction[taunted] 5 and @Affliction[stuck] 9.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "bsgf6INiGdJJ90lm",
-  "effects": []
+  "effects": [
+    {
+      "name": "Block",
+      "type": "passive",
+      "_id": "lng7nVnmrHpBa4HR",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "block-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.tauntedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "block-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.stuckconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 9
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737719182056,
+        "modifiedTime": 1737719227183,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/bolt-strike.json
+++ b/packs/core-moves/bolt-strike.json
@@ -31,15 +31,78 @@
           "electric"
         ],
         "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[paralysis] 7.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "nVBR5wDXpMQkHpdT",
-  "effects": []
+  "effects": [
+    {
+      "name": "Bolt Strike",
+      "type": "passive",
+      "_id": "BrQrW82wgQpxxLOH",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "bolt-strike-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737719300246,
+        "modifiedTime": 1737719331034,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/bone-club.json
+++ b/packs/core-moves/bone-club.json
@@ -20,8 +20,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 0
+          "activation": "complex"
         },
         "category": "physical",
         "power": 65,
@@ -30,15 +29,83 @@
           "ground"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "iaEneHWmr71r7fP0",
-  "effects": []
+  "effects": [
+    {
+      "name": "Bone Club",
+      "type": "passive",
+      "_id": "Wbmj7GXM71FZtkEW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "bone-club-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -40
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 40%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737719361325,
+        "modifiedTime": 1737719434563,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/bunker-buster.json
+++ b/packs/core-moves/bunker-buster.json
@@ -4,7 +4,7 @@
   "_id": "NhuMc1zQyP4kM5QG",
   "img": "systems/ptr2e/img/svg/rock_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "bunker-buster",
     "actions": [
       {
         "name": "Bunker Buster",
@@ -24,8 +24,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "trigger": ""
+          "powerPoints": 5
         },
         "variant": "bunker-buster",
         "types": [
@@ -34,17 +33,13 @@
         "category": "physical",
         "power": 40,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": ""
+        "predicate": []
       },
       {
         "name": "Bunker Buster (Shield)",
         "slug": "bunker-buster-shield",
         "type": "attack",
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/rock_icon.svg",
         "traits": [
           "pierce",
           "explode",
@@ -66,33 +61,18 @@
           "rock"
         ],
         "category": "physical",
-        "power": 40,
+        "power": 120,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Trigger: The target has a [Shield] effect when this attack is declared.</p><p>Effect: This attack's Power is tripled, and on hit, the target is Flinched.</p>"
+        "description": "<p>Trigger: The target has a [Shield] effect when this attack is declared.</p><p>Effect: This attack's Power is tripled, and on hit, the target is Flinched.</p>",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721266070226,
-    "modifiedTime": 1721266974548,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/cold-snap.json
+++ b/packs/core-moves/cold-snap.json
@@ -31,10 +31,7 @@
         "category": "status",
         "accuracy": 85,
         "description": "<p>Effect: On hit, all valid targets gain @Affliction[frostbite] 7.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "predicate": []
       },
       {
         "name": "Cold Snap (Absolute Zero)",
@@ -60,18 +57,17 @@
         "category": "status",
         "accuracy": 85,
         "description": "<blockquote>Requirement: User must have Absolute Zero slotted as an Active Ability.</blockquote><p>Effect: On hit, all valid targets gain @Affliction[frostbite] 7, and have a 30% chance of gaining @Affliction[frozen] 3.</p>>",
-        "contestType": "",
-        "contestEffect": "",
         "variant": "cold-snap",
         "free": true,
-        "slot": null
+        "predicate": []
       }
     ],
     "grade": "C",
     "_migration": {
       "version": null,
       "previous": null
-    }
+    },
+    "traits": []
   },
   "effects": []
 }

--- a/packs/core-moves/coral-break.json
+++ b/packs/core-moves/coral-break.json
@@ -31,14 +31,45 @@
         ],
         "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF. Coral Break's Power is doubled against Swimming targets.</p>",
         "img": "systems/ptr2e/img/svg/water_icon.svg",
-        "defensiveStat": "def"
+        "defensiveStat": "def",
+        "predicate": []
+      },
+      {
+        "slug": "coral-break-swimming",
+        "name": "Coral Break Variant",
+        "type": "attack",
+        "traits": [
+          "crushing",
+          "pp-updated"
+        ],
+        "range": {
+          "target": "wide-line",
+          "distance": 4,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 7
+        },
+        "category": "special",
+        "power": 80,
+        "accuracy": 90,
+        "types": [
+          "water"
+        ],
+        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF. Coral Break's Power is doubled against Swimming targets.</p>",
+        "img": "systems/ptr2e/img/svg/water_icon.svg",
+        "defensiveStat": "def",
+        "variant": "coral-break",
+        "predicate": []
       }
     ],
     "grade": "A",
     "_migration": {
       "version": null,
       "previous": null
-    }
+    },
+    "traits": []
   },
   "_id": "a8tXijy7zx7TMFz2",
   "effects": []

--- a/packs/core-moves/core-enforcer.json
+++ b/packs/core-moves/core-enforcer.json
@@ -30,15 +30,78 @@
           "dragon"
         ],
         "description": "<p>Effect: On hit, all valid targets gain @Affliction[nullified] 7.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Dga2700B3ulU2Op0",
-  "effects": []
+  "effects": [
+    {
+      "name": "Core Enforcer",
+      "type": "passive",
+      "_id": "MuYepPVjNhkYB6rA",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "core-enforcer-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.nullifiedconitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737719970741,
+        "modifiedTime": 1737720032724,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/dark-pulse.json
+++ b/packs/core-moves/dark-pulse.json
@@ -31,15 +31,83 @@
           "dark"
         ],
         "description": "<p>Effect: On hit, the target has a 20% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "b0lJe38pFiac5Fo4",
-  "effects": []
+  "effects": [
+    {
+      "name": "Dark Pulse",
+      "type": "passive",
+      "_id": "PabtKRpEpevKy5UW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "dark-pulse-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -40
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 40%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737720152806,
+        "modifiedTime": 1737720204622,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/dark-void.json
+++ b/packs/core-moves/dark-void.json
@@ -24,21 +24,83 @@
           "powerPoints": 6
         },
         "category": "status",
-        "power": null,
         "accuracy": 80,
         "types": [
           "dark"
         ],
         "description": "<p>Effect: On hit, all valid targets gain @Affliction[drowsy] 7.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "1PokUazkRwGGoiG7",
-  "effects": []
+  "effects": [
+    {
+      "name": "Dark Void",
+      "type": "passive",
+      "_id": "34CDllWbs0JT2YGv",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "dark-void-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.nightmarescoitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737720413167,
+        "modifiedTime": 1737720449390,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/deke.json
+++ b/packs/core-moves/deke.json
@@ -4,7 +4,7 @@
   "_id": "xawzh01dPugjMv0F",
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "deke",
     "actions": [
       {
         "name": "Deke",
@@ -28,38 +28,88 @@
           "activation": "complex",
           "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "fighting"
         ],
         "category": "physical",
         "power": 30,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target has 30% chance of being Flinched.</p>"
+        "description": "<p>Effect: On hit, the target has 30% chance of being Flinched.</p>",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 2200000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1719587979129,
-    "modifiedTime": 1719971994938,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Deke",
+      "type": "passive",
+      "_id": "8NYIpa64VGcjbZG4",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "deke-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 30%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737720825611,
+        "modifiedTime": 1737720935925,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/destiny-bond.json
+++ b/packs/core-moves/destiny-bond.json
@@ -22,21 +22,82 @@
           "powerPoints": 4
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "ghost"
         ],
         "description": "<p>Effect: The target gains @Affliction[destined] 3.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "KtSSIe0Sc2Ucby1Q",
-  "effects": []
+  "effects": [
+    {
+      "name": "Destiny Bond",
+      "type": "passive",
+      "_id": "cGeUroA5bbgQQLxx",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "destiny-bond-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.destinedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737720970188,
+        "modifiedTime": 1737721009365,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/doom-scythe.json
+++ b/packs/core-moves/doom-scythe.json
@@ -4,7 +4,7 @@
   "_id": "pX8nkNhCfYldjbH8",
   "img": "systems/ptr2e/img/svg/ghost_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "doom-scythe",
     "actions": [
       {
         "name": "Doom Scythe",
@@ -23,38 +23,83 @@
           "activation": "complex",
           "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "ghost"
         ],
         "category": "physical",
         "power": 100,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, all valid targets have a 10% chance of gaining @Affliction[cursed] 3.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 10% chance of gaining @Affliction[cursed] 3.</p>",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720459801545,
-    "modifiedTime": 1720461538650,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Doom Scythe",
+      "type": "passive",
+      "_id": "MCH9JITFCyd7kCjg",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "doom-scythe-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.cursedcondititem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737721060690,
+        "modifiedTime": 1737721102382,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/double-iron-bash.json
+++ b/packs/core-moves/double-iron-bash.json
@@ -34,15 +34,83 @@
           "steel"
         ],
         "description": "<p>Effect: On hit, the target has a 30% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "nFd5TtfVgdTWk1Bp",
-  "effects": []
+  "effects": [
+    {
+      "name": "Double Iron Bash",
+      "type": "passive",
+      "_id": "H5cxpM0tp0xm3G8d",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "double-iron-bash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 30%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737721139727,
+        "modifiedTime": 1737721200021,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/dragon-cheer.json
+++ b/packs/core-moves/dragon-cheer.json
@@ -11,7 +11,8 @@
         "type": "attack",
         "traits": [
           "sonic",
-          "pp-updated"
+          "pp-updated",
+          "partial-automation"
         ],
         "range": {
           "target": "emanation",
@@ -28,10 +29,16 @@
         ],
         "description": "<p>Effect: The user and all allies in range gain +1 CRIT Stage for 5 Activations. Dragon-type creature instead gain +2 CRIT Stages for 5 Activations.</p>",
         "slot": 3,
-        "img": "systems/ptr2e/img/svg/dragon_icon.svg"
+        "img": "systems/ptr2e/img/svg/dragon_icon.svg",
+        "predicate": []
       }
     ],
-    "grade": "A"
+    "grade": "A",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "VoiUETAcuekeVO32",
   "effects": [
@@ -43,13 +50,16 @@
       "system": {
         "changes": [
           {
-            "type": "basic",
-            "key": "system.battleStats.critRate.Stage",
-            "value": 1,
+            "type": "roll-effect",
+            "key": "dragon-cheer-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.CEdcrWbb1KDTNIKl",
             "predicate": [],
+            "chance": 100,
+            "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,
@@ -81,66 +91,12 @@
       "_stats": {
         "compendiumSource": "Actor.7Oya3WGVjs2Pgx2h.Item.lvapVW6S8cvvw0BW.ActiveEffect.Ea5z2W4QPwWu8M0b",
         "duplicateSource": null,
-        "coreVersion": "12.327",
+        "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.1.0.2",
+        "systemVersion": "0.10.0-alpha.5.2.1",
         "createdTime": 1717881627901,
-        "modifiedTime": 1717881669389,
-        "lastModifiedBy": "01onCaJSVMVOgMDI"
-      }
-    },
-    {
-      "name": "Dragon Cheer (Dragon)",
-      "type": "affliction",
-      "_id": "NH3hV3bOesN1j19c",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
-      "system": {
-        "changes": [
-          {
-            "type": "basic",
-            "key": "system.battleStats.critRate.Stage",
-            "value": 2,
-            "predicate": [],
-            "mode": 2,
-            "priority": null,
-            "ignored": false
-          }
-        ],
-        "slug": null,
-        "traits": [],
-        "removeAfterCombat": true,
-        "removeOnRecall": false,
-        "stacks": 0,
-        "priority": 50,
-        "formula": "",
-        "type": "damage"
-      },
-      "disabled": false,
-      "duration": {
-        "startTime": null,
-        "seconds": null,
-        "combat": null,
-        "rounds": null,
-        "turns": 5,
-        "startRound": null,
-        "startTurn": null
-      },
-      "description": "<p>Temporary status condition to apply the effect of Dragon Cheer</p>",
-      "origin": null,
-      "tint": "#ffffff",
-      "transfer": false,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": "Actor.7Oya3WGVjs2Pgx2h.Item.lvapVW6S8cvvw0BW.ActiveEffect.NH3hV3bOesN1j19c",
-        "duplicateSource": null,
-        "coreVersion": "12.327",
-        "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.1.0.2",
-        "createdTime": 1717881701258,
-        "modifiedTime": 1717881725015,
-        "lastModifiedBy": "01onCaJSVMVOgMDI"
+        "modifiedTime": 1737721945458,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
       }
     }
   ]

--- a/packs/core-moves/dragon-rush.json
+++ b/packs/core-moves/dragon-rush.json
@@ -32,15 +32,83 @@
           "dragon"
         ],
         "description": "<p>Effect: On hit, the target has a 20% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "sBKrwPZi8gBdeIND",
-  "effects": []
+  "effects": [
+    {
+      "name": "Dragon Rush",
+      "type": "passive",
+      "_id": "AybBR8U5KZ1K5kcu",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "dragon-rush-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": 0
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 30%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737721988738,
+        "modifiedTime": 1737722028708,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/dynamic-punch.json
+++ b/packs/core-moves/dynamic-punch.json
@@ -30,15 +30,78 @@
           "fighting"
         ],
         "description": "<p>Effect: On hit, the target becomes @Affliction[confused] 7.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "CD4xTw6z9gp9tqmR",
-  "effects": []
+  "effects": [
+    {
+      "name": "Dynamic Punch",
+      "type": "passive",
+      "_id": "qbuE9ZyoQ38BIJZW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "dynamic-punch",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737722096227,
+        "modifiedTime": 1737722127181,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/encore.json
+++ b/packs/core-moves/encore.json
@@ -23,21 +23,83 @@
           "powerPoints": 3
         },
         "category": "status",
-        "power": null,
         "accuracy": 100,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: The target's last used attack is @Affliction[choice-locked] 4.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "ZxIubCcCNv3MnafK",
-  "effects": []
+  "effects": [
+    {
+      "name": "Encore",
+      "type": "passive",
+      "_id": "T7I1Sv3WNxP3ye2D",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "encore-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.choicelockeditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 4
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737722267517,
+        "modifiedTime": 1737722297217,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/extrasensory.json
+++ b/packs/core-moves/extrasensory.json
@@ -29,15 +29,83 @@
           "psychic"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "YtgyracqZOtm0zXZ",
-  "effects": []
+  "effects": [
+    {
+      "name": "Extrasensory",
+      "type": "passive",
+      "_id": "cqqlvALxMivGYi13",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "extrasensory-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 30%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737722430262,
+        "modifiedTime": 1737722471404,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/fiery-wrath.json
+++ b/packs/core-moves/fiery-wrath.json
@@ -32,15 +32,83 @@
           "fire"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 20% chance of being Flinched. This attack is considered to be both Dark- and Fire-Type.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "grade": "A",
     "_migration": {
       "version": null,
       "previous": null
-    }
+    },
+    "traits": []
   },
   "_id": "lqvZbIwEB8U1BDSY",
-  "effects": []
+  "effects": [
+    {
+      "name": "Fiery Wrath",
+      "type": "passive",
+      "_id": "yFsI1IBiJZMDLBoV",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fiery-wrath-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -40
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 40%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737722593737,
+        "modifiedTime": 1737722649933,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/fire-fang.json
+++ b/packs/core-moves/fire-fang.json
@@ -32,14 +32,16 @@
           "fire"
         ],
         "description": "<p>Effect: On hit, the target target has a 10% chance of gaining @Affliction[burn] 5, and a 10% chance of being Flinched.</p>",
-        "img": "systems/ptr2e/img/svg/fire_icon.svg"
+        "img": "systems/ptr2e/img/svg/fire_icon.svg",
+        "predicate": []
       }
     ],
     "grade": "E",
     "_migration": {
       "version": null,
       "previous": null
-    }
+    },
+    "traits": []
   },
   "_id": "pqZ5P3yI0bOu6Qni",
   "effects": [
@@ -57,6 +59,30 @@
             "predicate": [],
             "chance": 10,
             "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "fire-fang-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -40
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 40%"
+              }
+            ],
             "mode": 2,
             "priority": null,
             "ignored": false
@@ -90,9 +116,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "0.10.0-alpha.5.2.1",
         "createdTime": 1732966449975,
-        "modifiedTime": 1732966484551,
+        "modifiedTime": 1737723237069,
         "lastModifiedBy": "Kc3DOunCh3ClAeHS"
       }
     }

--- a/packs/core-moves/floaty-fall.json
+++ b/packs/core-moves/floaty-fall.json
@@ -32,15 +32,83 @@
           "flying"
         ],
         "description": "<p>Effect: On hit, the target has a 30% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "PNkHma7aKgEZYapq",
-  "effects": []
+  "effects": [
+    {
+      "name": "Floaty Fall",
+      "type": "passive",
+      "_id": "RLBApmtC99Jkm8VS",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "floaty-fall-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 30%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737723321975,
+        "modifiedTime": 1737723380969,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/flutter-jump.json
+++ b/packs/core-moves/flutter-jump.json
@@ -24,8 +24,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 0
+          "activation": "complex"
         },
         "types": [
           "fairy"
@@ -33,10 +32,82 @@
         "category": "physical",
         "description": "<p>Effect: On hit, the target has a 30% chance of being Flinched.</p>",
         "power": 30,
-        "accuracy": 100
+        "accuracy": 100,
+        "predicate": []
       }
     ],
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Flutter Jump",
+      "type": "passive",
+      "_id": "90s8v42SndrPsE6z",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "flutter-jump-attacl",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -20
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 20%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737723419902,
+        "modifiedTime": 1737723464440,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/flying-haymaker.json
+++ b/packs/core-moves/flying-haymaker.json
@@ -4,7 +4,7 @@
   "_id": "wqdSQ8Uh46vogd0K",
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "flying-haymaker",
     "actions": [
       {
         "name": "Flying Haymaker",
@@ -26,38 +26,88 @@
           "activation": "complex",
           "powerPoints": 5
         },
-        "variant": null,
         "types": [
           "fighting"
         ],
         "category": "physical",
         "power": 95,
         "accuracy": 85,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: The user is able to freely use up to half their Overland Score or their full Flight Score if available to jump towards their target upon declaring this attack. On hit, the target has a 10% chance of being Flinched.</p>"
+        "description": "<p>Effect: The user is able to freely use up to half their Overland Score or their full Flight Score if available to jump towards their target upon declaring this attack. On hit, the target has a 10% chance of being Flinched.</p>",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
-  "effects": [],
-  "sort": 3900000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1719588234792,
-    "modifiedTime": 1719972655032,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": [
+    {
+      "name": "Flying Haymaker",
+      "type": "passive",
+      "_id": "y7loieRbyALp8hPM",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "flying-haymaker-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -50
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 50%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737723502964,
+        "modifiedTime": 1737723551441,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/genesis-supernova.json
+++ b/packs/core-moves/genesis-supernova.json
@@ -21,7 +21,6 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 0,
           "trigger": "<p>User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p>"
         },
         "category": "special",
@@ -31,15 +30,79 @@
           "psychic"
         ],
         "description": "<p>Trigger: User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p><p>Effect: On hit, all valid targets have a 60% chance losing -1 SPDEF Stage for 7 Activations. Upon resolving this attack, the user freely uses Psychic Terrain.</p><p>Requirement: [Mew] Z-Power-Crystal as an Accessory Item and Psychic on the user's Active List.</p>",
-        "contestType": "",
-        "contestEffect": "",
         "free": true,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "QoaABhSyDya7Kyo4",
-  "effects": []
+  "effects": [
+    {
+      "name": "Genesis Supernova",
+      "type": "passive",
+      "_id": "sjkHcVk5b5pwKLs5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "genesis-supernova-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 60,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 7
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737723742881,
+        "modifiedTime": 1737723784573,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/grim-fangs.json
+++ b/packs/core-moves/grim-fangs.json
@@ -30,15 +30,78 @@
           "ghost"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance to gain @Affliction[cursed] 3.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "h92x7rnfOAptTYL6",
-  "effects": []
+  "effects": [
+    {
+      "name": "Grim Fangs",
+      "type": "passive",
+      "_id": "fQOPYeOwsW9JP7vF",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "grim-fangs-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.cursedcondititem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737723860394,
+        "modifiedTime": 1737723893442,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/headbutt.json
+++ b/packs/core-moves/headbutt.json
@@ -31,15 +31,83 @@
           "normal"
         ],
         "description": "<p>Effect: On hit, the target has a 30% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D"
+    "grade": "D",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "BzZjntvWTP1swwKG",
-  "effects": []
+  "effects": [
+    {
+      "name": "Headbutt",
+      "type": "passive",
+      "_id": "t3oglCufyQTa9mY7",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "headbutt-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -20
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 20%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737723987300,
+        "modifiedTime": 1737724033238,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/heart-stamp.json
+++ b/packs/core-moves/heart-stamp.json
@@ -30,15 +30,83 @@
           "psychic"
         ],
         "description": "<p>Effect: On hit, the target has a 30% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "GOMWacqt0eKWKfcd",
-  "effects": []
+  "effects": [
+    {
+      "name": "Heart Stamp",
+      "type": "passive",
+      "_id": "PAe1lY6cFl8WcZN9",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "heart-stamp-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 30%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737724126642,
+        "modifiedTime": 1737724179160,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/hyper-fang.json
+++ b/packs/core-moves/hyper-fang.json
@@ -31,15 +31,83 @@
           "normal"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E"
+    "grade": "E",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "mIp7WV1qNmFePStS",
-  "effects": []
+  "effects": [
+    {
+      "name": "Hyper Fang",
+      "type": "passive",
+      "_id": "LKNOCosobRAZZQAe",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "hyper-fang-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -50
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 50%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737724320882,
+        "modifiedTime": 1737724383136,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/ice-fang.json
+++ b/packs/core-moves/ice-fang.json
@@ -32,14 +32,16 @@
           "ice"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[frostbite] 5, and a 10% chance of being Flinched.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
     "grade": "E",
     "_migration": {
       "version": null,
       "previous": null
-    }
+    },
+    "traits": []
   },
   "_id": "WpolCDpAPNZl7wGS",
   "effects": [
@@ -57,6 +59,30 @@
             "predicate": [],
             "chance": 10,
             "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "ice-fang-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -40
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 40%"
+              }
+            ],
             "mode": 2,
             "priority": null,
             "ignored": false
@@ -86,14 +112,14 @@
       "sort": 0,
       "flags": {},
       "_stats": {
-        "compendiumSource": null,
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.WpolCDpAPNZl7wGS.ActiveEffect.hYXLFPR65C8bLB7S",
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "0.10.0-alpha.5.2.1",
         "createdTime": 1733419084497,
-        "modifiedTime": 1733419104740,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+        "modifiedTime": 1737724569214,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
       }
     }
   ]

--- a/packs/core-moves/icicle-crash.json
+++ b/packs/core-moves/icicle-crash.json
@@ -29,15 +29,95 @@
           "ice"
         ],
         "description": "<p>Effect: On hit, the target becomes @Affliction[grounded] 5. and has a 30% chance of being Flinched.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "cg9icfdvtuP3Jprn",
-  "effects": []
+  "effects": [
+    {
+      "name": "Icicle Crash",
+      "type": "passive",
+      "_id": "Agch6D496kZweOvI",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "icicle-crash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.groundedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "icicle-crash-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 30%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737724643648,
+        "modifiedTime": 1737724714324,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
32 new move automations
- Update Move: Bleakwind Storm
- Update Move: Blizzard
- Update Move: Block
- Update Move: Bolt Strike
- Update Move: Bone Club
- Update Move: Bunker Buster
- Create Move: Cold Snap
- Update Move: Coral Break
- Update Move: Core Enforcer
- Update Move: Dark Pulse
- Update Move: Dark Void
- Update Move: Deke
- Update Move: Destiny Bond
- Update Move: Doom Scythe
- Update Move: Double Iron Bash
- Update Move: Dragon Cheer
- Update Move: Dragon Rush
- Update Move: Dynamic Punch
- Update Move: Encore
- Update Move: Extrasensory
- Update Move: Fiery Wrath
- Update Move: Fire Fang
- Update Move: Floaty Fall
- Update Move: Flutter Jump
- Update Move: Flying Haymaker
- Update Move: Genesis Supernova
- Update Move: Grim Fangs
- Update Move: Headbutt
- Update Move: Heart Stamp
- Update Move: Hyper Fang
- Update Move: Ice Fang
- Update Move: Icicle Crash