### PR TITLE
Foundry Data Sync - Fox Fixes 26/01/25

### DIFF
--- a/packs/core-gear/assault-jacket.json
+++ b/packs/core-gear/assault-jacket.json
@@ -17,7 +17,8 @@
     "fling": {
       "type": "untyped",
       "power": null,
-      "accuracy": 100
+      "accuracy": 100,
+      "hide": null
     },
     "rarity": "uncommon",
     "traits": [
@@ -36,21 +37,16 @@
         ],
         "range": {
           "target": "creature",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "complex"
         },
-        "variant": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "Effect: Increases the user's Defense stat by 50%. All of the user's Status-Category Attacks have triple PP cost.",
-    "slug": null,
-    "container": null,
+    "slug": "assault-jacket",
     "quantity": 1,
     "identification": {
       "misidentified": null,
@@ -60,26 +56,65 @@
         "img": "systems/ptu/css/images/icons/item_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "sVCEjkvugrCRkH60",
-  "effects": [],
-  "folder": "V4skAU6G3OH5fXad",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!sVCEjkvugrCRkH60"
+  "effects": [
+    {
+      "name": "Assault Jacket",
+      "type": "passive",
+      "_id": "G4SlhAM3HFZTjz6I",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.modifiers.defMultiplier",
+            "value": 1.5,
+            "mode": 1,
+            "predicate": [],
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934680878,
+        "modifiedTime": 1737934689641,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
+  "folder": "V4skAU6G3OH5fXad"
 }

--- a/packs/core-gear/devon-corp-exo-rig.json
+++ b/packs/core-gear/devon-corp-exo-rig.json
@@ -70,6 +70,16 @@
             "mode": 2,
             "priority": null,
             "ignored": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "electric-attack-damage-percentile",
+            "value": 25,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
           }
         ],
         "slug": null,
@@ -100,10 +110,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.4.1",
+        "systemVersion": "0.10.0-alpha.5.2.1",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1737931019370,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }
   ],

--- a/packs/core-moves/sandstorm.json
+++ b/packs/core-moves/sandstorm.json
@@ -15,7 +15,6 @@
         ],
         "range": {
           "target": "field",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
@@ -23,20 +22,21 @@
           "powerPoints": 4
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "rock"
         ],
         "description": "<p>Effect: The weather becomes Sandy for 3 rounds.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/rock_icon.svg",
+        "summon": "Compendium.ptr2e.core-summons.Item.2pDL6hkh4fjFIEAe",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "CUj5LvNodz0DfdaJ",
   "effects": []

--- a/packs/core-perks/adrenaline-rush.json
+++ b/packs/core-perks/adrenaline-rush.json
@@ -19,9 +19,7 @@
         "description": "<p>Your fight or flight response is finely honed - able to get you out of the stickiest of situations. The user gains the Ability Adrenaline as a Tutored Ability, and once during battle, when the user crosses the [Desperation 1/2] threshold, they freely use either U-Turn or No Retreat, as if it was on their Active List.</p>",
         "cost": {
           "activation": "free",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
         "type": "generic",
         "traits": [
@@ -31,10 +29,8 @@
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null
+          "unit": "m"
+        }
       }
     ],
     "slug": "adrenaline-rush",
@@ -67,14 +63,92 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "_id": "1uzQwRPq1YMLDk8L",
   "img": "systems/ptr2e/img/perk-icons/Combat.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Adrenaline Rush",
+      "type": "passive",
+      "_id": "vTuNSDechlcqJw8F",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.kDYV4gKQkqKP04Mf",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.DTnhRJBYhTBapjIK",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934506228,
+        "modifiedTime": 1737934530202,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "zrVtKATNxzLNxTUa"
 }

--- a/packs/core-perks/belt-expansion-1.json
+++ b/packs/core-perks/belt-expansion-1.json
@@ -12,21 +12,15 @@
         "slug": "belt-expansion-1",
         "description": "<p>Add an additional Belt slot.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "belt-expansion-1",
@@ -102,11 +96,62 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
     "global": true,
     "webs": []
   },
   "_id": "zAKTLdBrA5eeGCsX",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Belt Expansion",
+      "type": "passive",
+      "_id": "lVg2p1y5m9hhxAjN",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.inventory.belt.max",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934804061,
+        "modifiedTime": 1737934814111,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/belt-expansion-2.json
+++ b/packs/core-perks/belt-expansion-2.json
@@ -15,21 +15,15 @@
         "slug": "belt-expansion-2",
         "description": "<p>Add an additional Belt slot.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "belt-expansion-2",
@@ -61,13 +55,62 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "_id": "sJ1B6djHXWc4F5Ez",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Belt Expansion",
+      "type": "passive",
+      "_id": "mTdlefRuy8oqZ58J",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.inventory.belt.max",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.zAKTLdBrA5eeGCsX.ActiveEffect.lVg2p1y5m9hhxAjN",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934839620,
+        "modifiedTime": 1737934839620,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/belt-expansion-3.json
+++ b/packs/core-perks/belt-expansion-3.json
@@ -15,21 +15,15 @@
         "slug": "belt-expansion-3",
         "description": "<p>Add an additional Belt slot.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "belt-expansion-3",
@@ -60,13 +54,62 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "_id": "wWAAPsxfOC8nGPGm",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Belt Expansion",
+      "type": "passive",
+      "_id": "0ivPfvgd3bL9oEif",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.inventory.belt.max",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.zAKTLdBrA5eeGCsX.ActiveEffect.lVg2p1y5m9hhxAjN",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934847677,
+        "modifiedTime": 1737934847677,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/cautious-healer.json
+++ b/packs/core-perks/cautious-healer.json
@@ -46,11 +46,69 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Cautious Healer",
+      "type": "passive",
+      "_id": "HtkzCrH7tO9RaQZP",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "healing-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.resolvedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934950597,
+        "modifiedTime": 1737934990638,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/condemn.json
+++ b/packs/core-perks/condemn.json
@@ -21,9 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
         "img": "systems/ptr2e/img/perk-icons/Socialite.svg",
         "types": [
@@ -32,16 +30,7 @@
         "category": "status",
         "accuracy": 100,
         "free": true,
-        "variant": null,
-        "power": null,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
+        "predicate": []
       }
     ],
     "slug": "condemn",
@@ -91,11 +80,87 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Condemn",
+      "type": "passive",
+      "_id": "KcLbfoRAIs98wJ72",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "condemn-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "condemn-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737935473142,
+        "modifiedTime": 1737935537139,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/dress-to-impress.json
+++ b/packs/core-perks/dress-to-impress.json
@@ -37,14 +37,63 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "img": "systems/ptr2e/img/icons/equipment_icon.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Dress To Impress",
+      "type": "passive",
+      "_id": "6vToOC0fhANYGmEB",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.inventory.accessory.max",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934863150,
+        "modifiedTime": 1737934882767,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "_id": "AgjtqgC1JxsZPjSp",
   "folder": "oMMIXyKwOCIxMHrK"
 }

--- a/packs/core-perks/high-noon.json
+++ b/packs/core-perks/high-noon.json
@@ -5,30 +5,9 @@
   "_id": "9sYLADeHfdZRQtgZ",
   "img": "systems/ptr2e/img/perk-icons/Hunting.svg",
   "system": {
-    "actions": [
-      {
-        "name": "High Noon",
-        "slug": "high-noon",
-        "description": "<p>The user and the target gain @Affliction[duel] 5, and the user gains 4 Ticks of Shields.</p>",
-        "traits": [],
-        "type": "generic",
-        "range": {
-          "target": "self",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "free",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null
-        },
-        "img": "icons/svg/explosion.svg",
-        "variant": null
-      }
-    ],
+    "actions": [],
     "slug": "high-noon",
-    "description": "<p>The user and the target gain @Affliction[duel] 5, and the user gains 4 Ticks of Shields.</p>",
+    "description": "<p>Connection: Stand Off<br><br>When using Stand Off, the user gains 4 ticks of shields.</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 3,
@@ -62,11 +41,76 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "High Noon",
+      "type": "passive",
+      "_id": "SOrQSrQB8xtD9KZj",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.MBgMy5w6O5j5Ux9Q",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737935167337,
+        "modifiedTime": 1737935200437,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/run-down.json
+++ b/packs/core-perks/run-down.json
@@ -11,15 +11,22 @@
         "slug": "run-down",
         "description": "<p>Trigger: You successfully hit an opponent with an attack.<br><br>May spend 4 PP to gain +1 SPD stage for 5 activations as a Free Action at [Interrupt 2].</p>",
         "traits": [],
-        "type": "generic",
+        "type": "attack",
         "range": {
-          "target": "creature",
+          "target": "self",
           "unit": "m"
         },
         "cost": {
-          "activation": "free"
+          "activation": "free",
+          "powerPoints": 4
         },
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/perk-icons/Cavalier.svg",
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": []
       }
     ],
     "slug": "run-down",
@@ -59,5 +66,60 @@
     "global": true,
     "webs": []
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Run Down",
+      "type": "passive",
+      "_id": "fD0IX4eexKRd9laq",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "run-down-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLM",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737935246436,
+        "modifiedTime": 1737935273361,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/shielding-aura.json
+++ b/packs/core-perks/shielding-aura.json
@@ -19,19 +19,21 @@
         "description": "<p>You harden your Aura about yourself. You gain @Affliction[resolved] 5.</p>",
         "cost": {
           "activation": "complex",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null
+          "powerPoints": 4
         },
-        "type": "generic",
+        "type": "attack",
         "traits": [],
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/perk-icons/Aura.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
-        "variant": null
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": []
       }
     ],
     "slug": "shielding-aura",
@@ -64,14 +66,72 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "_id": "D4mh3LuuSy0DDBj0",
   "img": "systems/ptr2e/img/perk-icons/Aura.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Shielding Aura",
+      "type": "passive",
+      "_id": "ic5iLopjjgfGT61E",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shielding-aura-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.resolvedconditem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 5
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934380177,
+        "modifiedTime": 1737934406711,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "I7ocNlZvZjyhwUcw"
 }

--- a/packs/core-perks/unbending-steel.json
+++ b/packs/core-perks/unbending-steel.json
@@ -7,43 +7,7 @@
       "version": 0.109,
       "previous": null
     },
-    "actions": [
-      {
-        "slug": "iron-defense",
-        "name": "Iron Defense",
-        "type": "attack",
-        "traits": [],
-        "range": {
-          "target": "self",
-          "unit": "m",
-          "distance": 0
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 6,
-          "delay": null,
-          "priority": null
-        },
-        "category": "status",
-        "types": [
-          "steel"
-        ],
-        "description": "<p>Effect: The user increases their WC by 3 Stages (max WC 16) for 5 activations and increases their DEF Stage by +2 for 5 activations.</p>",
-        "free": true,
-        "img": "systems/ptr2e/img/svg/steel_icon.svg",
-        "variant": null,
-        "power": null,
-        "accuracy": null,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": null,
-        "offensiveStat": null,
-        "defensiveStat": null
-      }
-    ],
+    "actions": [],
     "slug": "unbending-steel",
     "description": "<p>You gain Iron Defense as a Connected Move, and may spend an additional 2PP when using Iron Defense to gain 2 ticks of Shields.</p>",
     "traits": [],
@@ -77,13 +41,78 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": []
   },
   "_id": "Gxv0teWTcPT64AJu",
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Unbending Steel",
+      "type": "passive",
+      "_id": "LGmdT3NOqO6wZK6j",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.qSWTxI39iL7ivEVw",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737922877806,
+        "modifiedTime": 1737922913974,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/weak-spot.json
+++ b/packs/core-perks/weak-spot.json
@@ -5,70 +5,7 @@
   "_id": "1eZASTA0wlCgvJ9v",
   "img": "systems/ptr2e/img/perk-icons/Hunting.svg",
   "system": {
-    "actions": [
-      {
-        "name": "Weak Spot",
-        "slug": "weak-spot",
-        "description": "<p>Connection - Focus Energy. The user learns Laser Focus.</p>",
-        "traits": [],
-        "type": "passive",
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "free"
-        },
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "focus-energy",
-        "name": "Focus Energy",
-        "type": "attack",
-        "traits": [
-          "aura"
-        ],
-        "range": {
-          "target": "creature",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 3
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "Effect: The user's gain +1 CRIT stage for 5 activations.",
-        "free": true,
-        "img": "icons/svg/explosion.svg",
-        "predicate": []
-      },
-      {
-        "slug": "laser-focus",
-        "name": "Laser Focus",
-        "type": "attack",
-        "traits": [
-          "aura"
-        ],
-        "range": {
-          "target": "self",
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "simple",
-          "powerPoints": 3
-        },
-        "category": "status",
-        "types": [
-          "normal"
-        ],
-        "description": "Effect: The user gains +4 CRIT stages for 2 activations.",
-        "img": "icons/svg/explosion.svg",
-        "predicate": []
-      }
-    ],
+    "actions": [],
     "slug": "weak-spot",
     "description": "<p>Connection - Focus Energy. The user learns Laser Focus.</p>",
     "traits": [],

--- a/packs/core-species/raticate-alolan.json
+++ b/packs/core-species/raticate-alolan.json
@@ -7,7 +7,7 @@
     "form": "alolan",
     "size": {
       "category": "small",
-      "type": "height",
+      "type": "quad",
       "height": 0.7,
       "weight": 25.5
     },
@@ -31,7 +31,6 @@
     "traits": [
       "pokemon",
       "quadrupedal",
-      "underdog",
       "darkvision-15",
       "pack-mon",
       "lumbering",
@@ -530,11 +529,19 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          }
         }
       ],
       "uuid": "Compendium.ptr2e.core-species.Item.s4wgoxXjXIrhTSrM",
-      "methods": []
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [],
     "slug": "raticate",

--- a/packs/core-species/raticate.json
+++ b/packs/core-species/raticate.json
@@ -596,11 +596,19 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
       "uuid": "Compendium.ptr2e.core-species.Item.s1cHLN4dQBQE7Y96",
-      "methods": []
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "_migration": {
       "version": null,

--- a/packs/core-species/scolipede.json
+++ b/packs/core-species/scolipede.json
@@ -529,6 +529,10 @@
                 "item": null,
                 "level": null,
                 "knownMove": null
+              },
+              "perk": {
+                "x": 15,
+                "y": 15
               }
             }
           ],
@@ -537,13 +541,25 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 15,
+            "y": 15
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.dNt6z45d0K3reNSu"
+      "uuid": "Compendium.ptr2e.core-species.Item.dNt6z45d0K3reNSu",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "wwExCkoJXLvdO33x",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/sneasel-hisuian.json
+++ b/packs/core-species/sneasel-hisuian.json
@@ -33,8 +33,7 @@
       "bipedal",
       "wallclimber",
       "darkvision-15",
-      "venomous",
-      "underdog"
+      "venomous"
     ],
     "abilities": {
       "starting": [
@@ -216,182 +215,74 @@
     "moves": {
       "levelUp": [
         {
-          "name": "scratch",
-          "level": 1,
-          "gen": "scarlet-violet"
-        },
-        {
           "name": "leer",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "rock-smash",
-          "level": 1,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 1
+        },
+        {
+          "name": "scratch",
+          "gen": "scarlet-violet",
+          "level": 1
         },
         {
           "name": "taunt",
-          "level": 6,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 6
         },
         {
           "name": "quick-attack",
-          "level": 12,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 12
         },
         {
           "name": "metal-claw",
-          "level": 18,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 18
         },
         {
           "name": "poison-jab",
-          "level": 24,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 24
         },
         {
           "name": "brick-break",
-          "level": 30,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 30
         },
         {
           "name": "hone-claws",
-          "level": 36,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 36
         },
         {
           "name": "slash",
-          "level": 42,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 42
         },
         {
           "name": "agility",
-          "level": 48,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 48
         },
         {
           "name": "screech",
-          "level": 54,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 54
         },
         {
           "name": "close-combat",
-          "level": 60,
-          "gen": "scarlet-violet"
+          "gen": "scarlet-violet",
+          "level": 60
         }
       ],
       "tutor": [
         {
-          "name": "counter",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "fake-out",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "feint",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "night-slash",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "switcheroo",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "double-hit",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "quick-guard",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "swords-dance",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "take-down",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "low-kick",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "dig",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "toxic",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "swift",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rest",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "substitute",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "thief",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "reversal",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "spite",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "protect",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sludge-bomb",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "endure",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "false-swipe",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sleep-talk",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "rain-dance",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sunny-day",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "shadow-ball",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "facade",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "focus-punch",
+          "name": "acid-spray",
           "gen": "scarlet-violet"
         },
         {
@@ -403,71 +294,7 @@
           "gen": "scarlet-violet"
         },
         {
-          "name": "poison-tail",
-          "gen": "scarlet-violet"
-        },
-        {
           "name": "calm-mind",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "toxic-spikes",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "x-scissor",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "vacuum-wave",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "focus-blast",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "giga-impact",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "nasty-plot",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "shadow-claw",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "gunk-shot",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "grass-knot",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "venoshock",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "sludge-wave",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "low-sweep",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "acid-spray",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "throat-chop",
-          "gen": "scarlet-violet"
-        },
-        {
-          "name": "lash-out",
           "gen": "scarlet-violet"
         },
         {
@@ -475,11 +302,183 @@
           "gen": "scarlet-violet"
         },
         {
+          "name": "counter",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "dig",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "double-hit",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "endure",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "facade",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "fake-out",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "false-swipe",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "feint",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "focus-blast",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "focus-punch",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "giga-impact",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "grass-knot",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "gunk-shot",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "lash-out",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "low-kick",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "low-sweep",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "nasty-plot",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "night-slash",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "poison-tail",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "protect",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "quick-guard",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rain-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "rest",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "reversal",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "shadow-ball",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "shadow-claw",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sleep-talk",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sludge-bomb",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sludge-wave",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "spite",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "substitute",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "sunny-day",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "swift",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "switcheroo",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "swords-dance",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "take-down",
+          "gen": "scarlet-violet"
+        },
+        {
           "name": "tera-blast",
           "gen": "scarlet-violet"
         },
         {
+          "name": "thief",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "throat-chop",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "toxic",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "toxic-spikes",
+          "gen": "scarlet-violet"
+        },
+        {
           "name": "trailblaze",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "vacuum-wave",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "venoshock",
+          "gen": "scarlet-violet"
+        },
+        {
+          "name": "x-scissor",
           "gen": "scarlet-violet"
         }
       ]
@@ -502,26 +501,43 @@
               "item": "razor-claw",
               "operand": "or",
               "held": false
+            },
+            {
+              "type": "level",
+              "level": 32,
+              "operand": "and"
             }
           ],
-          "evolutions": [],
+          "perk": {
+            "x": 15,
+            "y": 15
+          },
           "details": {
             "gender": null,
             "item": null,
             "level": null,
             "knownMove": null
-          }
+          },
+          "evolutions": []
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.AtnvFdQhkSnoY8GC"
+      "uuid": "Compendium.ptr2e.core-species.Item.AtnvFdQhkSnoY8GC",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "mountain",
       "ice",
       "tundra"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "AtnvFdQhkSnoY8GC",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/sneasler.json
+++ b/packs/core-species/sneasler.json
@@ -510,6 +510,11 @@
               "item": "razor-claw",
               "operand": "or",
               "held": false
+            },
+            {
+              "type": "level",
+              "level": 32,
+              "operand": "or"
             }
           ],
           "details": {
@@ -518,18 +523,30 @@
             "level": null,
             "knownMove": null
           },
+          "perk": {
+            "x": 15,
+            "y": 15
+          },
           "evolutions": []
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.AtnvFdQhkSnoY8GC"
+      "uuid": "Compendium.ptr2e.core-species.Item.AtnvFdQhkSnoY8GC",
+      "methods": [],
+      "perk": {
+        "x": 15,
+        "y": 15
+      }
     },
     "habitats": [
       "mountain",
       "ice",
       "tundra"
-    ]
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "7FQufFN5EZOn5sxs",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-summons/dusty-weather.json
+++ b/packs/core-summons/dusty-weather.json
@@ -1,0 +1,90 @@
+{
+  "name": "Dusty Weather",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "traits": [
+      "partial-automation"
+    ],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "img": "icons/magic/air/fog-gas-smoke-brown.webp",
+  "effects": [
+    {
+      "name": "Dusty Weather",
+      "type": "summon",
+      "_id": "iGyrLq3vr5uJN5fZ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.modifiers.spdMultiplier",
+            "value": 1.5,
+            "predicate": [
+              "self:trait:rock"
+            ],
+            "mode": 1,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.modifiers.spdMultiplier",
+            "value": 1.5,
+            "predicate": [
+              "self:trait:ground"
+            ],
+            "mode": 1,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/16",
+        "type": "damage",
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "2pDL6hkh4fjFIEAe"
+}


### PR DESCRIPTION
Assorted fixes, plus a handful of perk automations.
- Update Perk: Unbending Steel
- Create Species: raticate
- Update Species: raticate-alolan
- Update Species: sneasel-hisuian
- Update Species: sneasler
- Update Summon: Dusty Weather
- Update Move: Sandstorm
- Create Species: scolipede
- Update Equipment: DevonCorp Exo-Rig
- Update Perk: Shielding Aura
- Update Perk: Adrenaline Rush
- Update Equipment: Assault Jacket
- Update Perk: Belt Expansion 1
- Update Perk: Belt Expansion 2
- Update Perk: Belt Expansion 3
- Update Perk: Dress To Impress
- Update Perk: Cautious Healer
- Update Perk: High Noon
- Update Perk: Run Down
- Update Perk: Weak Spot
- Update Perk: Condemn