### PR TITLE
Foundry Data Sync - Perk Archetype Data Fixes

### DIFF
--- a/packs/core-perks/acrobat.json
+++ b/packs/core-perks/acrobat.json
@@ -18,21 +18,15 @@
         "slug": "acrobat",
         "description": "<p>You gain a +10 to Acrobatics checks when benefitting from a running start.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "acrobat",
@@ -68,11 +62,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "athleticism"
+    }
   },
   "_id": "MDkJ0KhnAvqw0v3J",
   "img": "systems/ptr2e/img/perk-icons/Exploration.svg",

--- a/packs/core-perks/acute-affliction.json
+++ b/packs/core-perks/acute-affliction.json
@@ -9,27 +9,22 @@
       {
         "name": "Acute Affliction",
         "slug": "acute-affliction",
-        "description": "<p>Trigger: The target is afflicted with a [Major Affliction] the user caused.<p></p>Effect: The target's default DEF and SPDEF are reduced by -1.</p>",
+        "description": "<p>Trigger: The target is afflicted with a @Trait[major-affliction] the user caused.<p></p>Effect: The target's default DEF and SPDEF are reduced by -1.</p>",
         "traits": [],
         "type": "generic",
         "range": {
           "target": "creature",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "free",
-          "trigger": "The target is afflicted with a [Major Affliction] the user caused.",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "trigger": "The target is afflicted with a [Major Affliction] the user caused."
         },
-        "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
-        "variant": null
+        "img": "systems/ptr2e/img/perk-icons/Arcana.svg"
       }
     ],
     "slug": "acute-affliction",
-    "description": "<p>Trigger: The target is afflicted with a [Major Affliction] the user caused.<p></p>Effect: The target's default DEF and SPDEF are reduced by -1.</p>",
+    "description": "<p>Trigger: The target is afflicted with a @Trait[major-affliction] the user caused.<p></p>Effect: The target's default DEF and SPDEF are reduced by -1.</p>",
     "traits": [],
     "prerequisites": [
       "item:perk:potent-afflictions"
@@ -65,11 +60,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "power",
+      "archetype": "affliction"
+    }
   },
   "effects": []
 }

--- a/packs/core-perks/adrenaline-rush.json
+++ b/packs/core-perks/adrenaline-rush.json
@@ -19,9 +19,7 @@
         "description": "<p>Your fight or flight response is finely honed - able to get you out of the stickiest of situations. The user gains the Ability Adrenaline as a Tutored Ability, and once during battle, when the user crosses the [Desperation 1/2] threshold, they freely use either U-Turn or No Retreat, as if it was on their Active List.</p>",
         "cost": {
           "activation": "free",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
         "type": "generic",
         "traits": [
@@ -31,10 +29,8 @@
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null
+          "unit": "m"
+        }
       }
     ],
     "slug": "adrenaline-rush",
@@ -67,14 +63,97 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "berserker"
+    }
   },
   "_id": "1uzQwRPq1YMLDk8L",
   "img": "systems/ptr2e/img/perk-icons/Combat.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Adrenaline Rush",
+      "type": "passive",
+      "_id": "vTuNSDechlcqJw8F",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.kDYV4gKQkqKP04Mf",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.DTnhRJBYhTBapjIK",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934506228,
+        "modifiedTime": 1737934530202,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "zrVtKATNxzLNxTUa"
 }

--- a/packs/core-perks/all-seasonal.json
+++ b/packs/core-perks/all-seasonal.json
@@ -26,19 +26,15 @@
         "description": "<p>Until the start of the next Round, the user benefits from the active [Weather] and [Terrain] as if they were the beneficial Type or had the specific [Traits] of their choice.</p>",
         "cost": {
           "activation": "free",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null
+          "powerPoints": 4
         },
         "type": "generic",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null
+          "unit": "m"
+        }
       }
     ],
     "slug": "all-seasonal",
@@ -71,11 +67,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "exploration"
+    }
   },
   "_id": "c44mrEbFuTtSb747",
   "img": "systems/ptr2e/img/perk-icons/Exploration.svg",

--- a/packs/core-perks/belt-expansion-1.json
+++ b/packs/core-perks/belt-expansion-1.json
@@ -12,21 +12,15 @@
         "slug": "belt-expansion-1",
         "description": "<p>Add an additional Belt slot.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "belt-expansion-1",
@@ -39,12 +33,20 @@
     "mode": "coexist",
     "nodes": [
       {
+        "x": 181,
+        "y": 53,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "trained-wielder",
           "dress-to-impress",
           "out-of-options",
           "dual-wielder"
         ],
+        "tier": {
+          "rank": null,
+          "uuid": null
+        },
         "config": {
           "alpha": null,
           "backgroundColor": "#004080",
@@ -53,21 +55,18 @@
           "texture": "systems/ptr2e/img/perk-icons/Tactician.svg",
           "tint": null,
           "scale": null
-        },
-        "hidden": false,
-        "type": "normal",
-        "x": 181,
-        "y": 53,
-        "tier": null
+        }
       },
       {
+        "x": null,
+        "y": null,
+        "hidden": false,
+        "type": "normal",
+        "connected": [],
         "tier": {
           "rank": 2,
           "uuid": "Compendium.ptr2e.core-perks.Item.sJ1B6djHXWc4F5Ez"
         },
-        "x": null,
-        "y": null,
-        "connected": [],
         "config": {
           "alpha": null,
           "backgroundColor": null,
@@ -76,18 +75,18 @@
           "texture": null,
           "tint": null,
           "scale": null
-        },
-        "hidden": false,
-        "type": "normal"
+        }
       },
       {
+        "x": null,
+        "y": null,
+        "hidden": false,
+        "type": "normal",
+        "connected": [],
         "tier": {
           "rank": 3,
           "uuid": "Compendium.ptr2e.core-perks.Item.wWAAPsxfOC8nGPGm"
         },
-        "x": null,
-        "y": null,
-        "connected": [],
         "config": {
           "alpha": null,
           "backgroundColor": null,
@@ -96,17 +95,71 @@
           "texture": null,
           "tint": null,
           "scale": null
-        },
-        "hidden": false,
-        "type": "normal"
+        }
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "backpacker"
+    }
   },
   "_id": "zAKTLdBrA5eeGCsX",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Belt Expansion",
+      "type": "passive",
+      "_id": "lVg2p1y5m9hhxAjN",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.inventory.belt.max",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934804061,
+        "modifiedTime": 1737934814111,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/belt-expansion-2.json
+++ b/packs/core-perks/belt-expansion-2.json
@@ -15,21 +15,15 @@
         "slug": "belt-expansion-2",
         "description": "<p>Add an additional Belt slot.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "belt-expansion-2",
@@ -61,13 +55,67 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "backpacker"
+    }
   },
   "_id": "sJ1B6djHXWc4F5Ez",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Belt Expansion",
+      "type": "passive",
+      "_id": "mTdlefRuy8oqZ58J",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.inventory.belt.max",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.zAKTLdBrA5eeGCsX.ActiveEffect.lVg2p1y5m9hhxAjN",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934839620,
+        "modifiedTime": 1737934839620,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/belt-expansion-3.json
+++ b/packs/core-perks/belt-expansion-3.json
@@ -15,21 +15,15 @@
         "slug": "belt-expansion-3",
         "description": "<p>Add an additional Belt slot.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "belt-expansion-3",
@@ -60,13 +54,67 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "backpacker"
+    }
   },
   "_id": "wWAAPsxfOC8nGPGm",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Belt Expansion",
+      "type": "passive",
+      "_id": "0ivPfvgd3bL9oEif",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.inventory.belt.max",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.zAKTLdBrA5eeGCsX.ActiveEffect.lVg2p1y5m9hhxAjN",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934847677,
+        "modifiedTime": 1737934847677,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/cautious-healer.json
+++ b/packs/core-perks/cautious-healer.json
@@ -46,11 +46,74 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "healer"
+    }
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Cautious Healer",
+      "type": "passive",
+      "_id": "HtkzCrH7tO9RaQZP",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "healing-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.resolvedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934950597,
+        "modifiedTime": 1737934990638,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/chansey-medicine.json
+++ b/packs/core-perks/chansey-medicine.json
@@ -85,7 +85,12 @@
     ],
     "originSlug": "chansey-medicine",
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "healer"
+    }
   },
   "effects": [
     {
@@ -114,7 +119,14 @@
             "onDeleteActions": {
               "grantee": "detach",
               "granter": "cascade"
-            }
+            },
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "alterations": [],
+            "track": false
           },
           {
             "type": "grant-item",
@@ -126,7 +138,14 @@
             "onDeleteActions": {
               "grantee": "detach",
               "granter": "cascade"
-            }
+            },
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "alterations": [],
+            "track": false
           }
         ],
         "slug": null,

--- a/packs/core-perks/cultivate-weakness.json
+++ b/packs/core-perks/cultivate-weakness.json
@@ -19,12 +19,9 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "slug": "cultivate-weakness",
@@ -72,11 +69,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "affliction"
+    }
   },
   "effects": []
 }

--- a/packs/core-perks/cyclist.json
+++ b/packs/core-perks/cyclist.json
@@ -18,21 +18,15 @@
         "slug": "cyclist",
         "description": "<p>When riding a [Cycle], your Overland Movement Allowance increases by +3, and you may use Take Down as if it were on your Active List. When riding a [Rotom Device] [Cycle] you get access to Wild Charge instead of Take Down.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "cyclist",
@@ -68,11 +62,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "cavalier"
+    }
   },
   "_id": "AFU1teCNRoIixS3n",
   "img": "systems/ptr2e/img/item-icons/acro%20bike.webp",

--- a/packs/core-perks/dead-eye.json
+++ b/packs/core-perks/dead-eye.json
@@ -12,19 +12,15 @@
         "description": "<p>Trigger: You hit with a damaging, non-Critical, non-[Contact] Attack. The attack becomes a Critical Hit.</p>",
         "cost": {
           "activation": "free",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 5
         },
         "type": "generic",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null
+          "unit": "m"
+        }
       }
     ],
     "slug": "dead-eye",
@@ -57,11 +53,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "hunter"
+    }
   },
   "_id": "XwBEo0SPEQ5UtA0l",
   "img": "systems/ptr2e/img/perk-icons/Combat.svg",

--- a/packs/core-perks/dead-to-rights.json
+++ b/packs/core-perks/dead-to-rights.json
@@ -12,19 +12,15 @@
         "description": "<p>The next time you declare a non-[Contact] Attack against a foe without Cover, you gain +3 ACC and +2 CRIT Stages for 1 Activation.</p>",
         "cost": {
           "activation": "free",
-          "powerPoints": 10,
-          "delay": null,
-          "priority": null
+          "powerPoints": 10
         },
         "type": "generic",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null
+          "unit": "m"
+        }
       }
     ],
     "slug": "dead-to-rights",
@@ -58,11 +54,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "hunter"
+    }
   },
   "_id": "7Uhx4SiJFnFrbhB6",
   "img": "systems/ptr2e/img/perk-icons/Combat.svg",

--- a/packs/core-perks/desperate-strike.json
+++ b/packs/core-perks/desperate-strike.json
@@ -16,17 +16,12 @@
         "type": "generic",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "simple",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "simple"
         },
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "slug": "desperate-strike",
@@ -65,11 +60,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "berserker"
+    }
   },
   "effects": [
     {

--- a/packs/core-perks/dizzy-daft.json
+++ b/packs/core-perks/dizzy-daft.json
@@ -4,16 +4,20 @@
   "folder": "e9XnhZdjIE7hroYs",
   "system": {
     "_migration": {
-      "version": 0.109,
-      "previous": null
+      "version": 0.11,
+      "previous": {
+        "schema": 0.109,
+        "foundry": "12.331",
+        "system": "0.10.0-alpha.5.1.5"
+      }
     },
     "actions": [
       {
-        "name": "Dizzy Daft (Active)",
-        "slug": "dizzy-daft-action-1",
+        "name": "Dizzy Daft",
+        "slug": "dizzy-daft",
         "description": "<p>You inflict @Affliction[confused] 5 on yourself.</p>",
         "traits": [],
-        "type": "generic",
+        "type": "attack",
         "img": "modules/ptr2e-pkmn-sprites/sprites/327.webp",
         "range": {
           "target": "self",
@@ -22,23 +26,13 @@
         "cost": {
           "activation": "simple",
           "powerPoints": 2
-        }
-      },
-      {
-        "name": "Dizzy Daft (Passive)",
-        "slug": "dizzy-daft-action-2",
-        "description": "<p>You are immune to the negative effects of the Confused condition, and never Fumble as a result of it.</p>",
-        "traits": [],
-        "type": "passive",
-        "img": "modules/ptr2e-pkmn-sprites/sprites/327.webp",
-        "range": {
-          "target": "self",
-          "unit": "m"
         },
-        "cost": {
-          "activation": "free"
-        },
-        "hidden": true
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": []
       }
     ],
     "description": "<p>You can confuse yourself, and avoid the ill-effects.</p>",
@@ -47,8 +41,8 @@
     "cost": 2,
     "nodes": [
       {
-        "x": 15,
-        "y": 13,
+        "x": 26,
+        "y": 24,
         "connected": [
           "evolution-spinda"
         ],
@@ -69,11 +63,82 @@
     "webs": [
       "Compendium.ptr2e.core-species.Item.DN39HBQfR7lFM73H"
     ],
-    "global": false,
     "slug": "dizzy-daft",
-    "autoUnlock": []
+    "autoUnlock": [],
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "species"
+    }
   },
   "img": "systems/ptr2e/img/perk-icons/Breeder.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Dizzy Daft",
+      "type": "passive",
+      "_id": "03AB6rXnGwbeK2kJ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "dizzy-daft-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-option",
+            "value": "damage:affliction:confused",
+            "domain": "immunities",
+            "key": "",
+            "mode": 2,
+            "priority": null,
+            "predicate": [],
+            "ignored": false,
+            "suboptions": [],
+            "state": true
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>You can confuse yourself, and avoid the ill-effects.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.6",
+        "createdTime": 1737565815439,
+        "modifiedTime": 1737565838382,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ],
   "_id": "y3aSWoyIMrXrn0l1"
 }

--- a/packs/core-perks/down-the-sights.json
+++ b/packs/core-perks/down-the-sights.json
@@ -13,19 +13,15 @@
         "description": "<p>Your next non-[Contact] gains [Crit 1] or [Crit X+1] until it resolves.</p>",
         "cost": {
           "activation": "simple",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
         "type": "generic",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null
+          "unit": "m"
+        }
       }
     ],
     "slug": "down-the-sights",
@@ -59,11 +55,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "hunter"
+    }
   },
   "_id": "eHdFNdcyllxflfNA",
   "img": "systems/ptr2e/img/perk-icons/Combat.svg",

--- a/packs/core-perks/dress-to-impress.json
+++ b/packs/core-perks/dress-to-impress.json
@@ -37,14 +37,68 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "backpacker"
+    }
   },
   "img": "systems/ptr2e/img/icons/equipment_icon.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Dress To Impress",
+      "type": "passive",
+      "_id": "6vToOC0fhANYGmEB",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.inventory.accessory.max",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.2.1",
+        "createdTime": 1737934863150,
+        "modifiedTime": 1737934882767,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "_id": "AgjtqgC1JxsZPjSp",
   "folder": "oMMIXyKwOCIxMHrK"
 }

--- a/packs/core-perks/dual-wielder.json
+++ b/packs/core-perks/dual-wielder.json
@@ -3,31 +3,25 @@
   "type": "perk",
   "system": {
     "prerequisites": [
-      "#Have a Wielded Item Slot"
+      "trait:wielder"
     ],
     "cost": 4,
-    "description": "<p>Gain a second Wielded Item Slot.</p>",
+    "description": "<p>Gain a second Held Item slot.</p>",
     "actions": [
       {
         "name": "Dual Wielder",
         "slug": "dual-wielder",
         "description": "<p>Gain a second Wielded Item Slot.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "dual-wielder",
@@ -60,14 +54,68 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "weapon"
+    }
   },
   "_id": "QioUEl6UBFclZvzG",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Dual Wielder",
+      "type": "passive",
+      "_id": "KS2tYC5yodOQrCN2",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.inventory.held.max",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>Gain a second Held Item slot.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737566059443,
+        "modifiedTime": 1737566090456,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
+      }
+    }
+  ],
   "folder": "oMMIXyKwOCIxMHrK"
 }

--- a/packs/core-perks/freeclimber.json
+++ b/packs/core-perks/freeclimber.json
@@ -18,21 +18,15 @@
         "slug": "freeclimber",
         "description": "<p>You are able to climb without suffering penalties due to lack of equipment.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "freeclimber",
@@ -69,11 +63,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "exploration"
+    }
   },
   "_id": "sAukVqClITEpjQE3",
   "img": "systems/ptr2e/img/perk-icons/Exploration.svg",

--- a/packs/core-perks/glutton-for-punishment.json
+++ b/packs/core-perks/glutton-for-punishment.json
@@ -16,18 +16,12 @@
         "type": "passive",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "simple",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "simple"
         },
-        "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "hidden": false
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "slug": "glutton-for-punishment",
@@ -66,11 +60,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "berserker"
+    }
   },
   "effects": [
     {

--- a/packs/core-perks/gut-punch.json
+++ b/packs/core-perks/gut-punch.json
@@ -34,11 +34,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "berserker"
+    }
   },
   "img": "systems/ptr2e/img/perk-icons/Combat.svg",
   "effects": [],

--- a/packs/core-perks/hardy-trekker.json
+++ b/packs/core-perks/hardy-trekker.json
@@ -28,18 +28,14 @@
         ],
         "cost": {
           "activation": "free",
-          "powerPoints": 4,
-          "delay": null,
-          "priority": null
+          "powerPoints": 4
         },
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "description": "<p>Until the start of the next Round, the user is immune to effect damage and negative effects of active Terrains and Weathers.</p>",
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "slug": "hardy-trekker",
@@ -77,11 +73,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "exploration"
+    }
   },
   "_id": "iOlwna5vtQnrFxtc",
   "img": "systems/ptr2e/img/perk-icons/Exploration.svg",

--- a/packs/core-perks/healing-hands.json
+++ b/packs/core-perks/healing-hands.json
@@ -44,11 +44,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "healer"
+    }
   },
   "effects": []
 }

--- a/packs/core-perks/hear-no-bell.json
+++ b/packs/core-perks/hear-no-bell.json
@@ -63,7 +63,12 @@
     ],
     "autoUnlock": [],
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "berserker"
+    }
   },
   "effects": [
     {

--- a/packs/core-perks/heroic-mobility.json
+++ b/packs/core-perks/heroic-mobility.json
@@ -36,11 +36,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "hero"
+    }
   },
   "img": "icons/magic/control/silhouette-grow-shrink-blue.webp",
   "effects": [],

--- a/packs/core-perks/heroic-rush.json
+++ b/packs/core-perks/heroic-rush.json
@@ -36,11 +36,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "hero"
+    }
   },
   "img": "icons/magic/control/silhouette-grow-shrink-blue.webp",
   "effects": [],

--- a/packs/core-perks/heroic-senses.json
+++ b/packs/core-perks/heroic-senses.json
@@ -36,11 +36,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "hero"
+    }
   },
   "img": "icons/magic/control/silhouette-grow-shrink-blue.webp",
   "effects": [],

--- a/packs/core-perks/heroic-transformation.json
+++ b/packs/core-perks/heroic-transformation.json
@@ -49,11 +49,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "hero"
+    }
   },
   "img": "icons/magic/control/silhouette-grow-shrink-blue.webp",
   "effects": [],

--- a/packs/core-perks/hit-run.json
+++ b/packs/core-perks/hit-run.json
@@ -12,21 +12,15 @@
         "slug": "hit-run",
         "description": "<p>After resolving an Attack, the user cannot be targeted with [Interrupt X] Actions until the end of their Activation.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "creature",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "hit-run",
@@ -63,11 +57,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "hunter"
+    }
   },
   "_id": "1SjUYN4180BTBYCk",
   "img": "systems/ptr2e/img/perk-icons/Combat.svg",

--- a/packs/core-perks/holistic-care.json
+++ b/packs/core-perks/holistic-care.json
@@ -45,11 +45,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "healer"
+    }
   },
   "effects": []
 }

--- a/packs/core-perks/i-get-knocked-down.json
+++ b/packs/core-perks/i-get-knocked-down.json
@@ -18,18 +18,14 @@
         "type": "generic",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "free",
           "powerPoints": 2,
-          "trigger": "The user takes damage and crosses the threshold to meet the [Desperation 1/3] Condition.",
-          "delay": null,
-          "priority": null
+          "trigger": "The user takes damage and crosses the threshold to meet the [Desperation 1/3] Condition."
         },
-        "img": "systems/ptr2e/img/perk-icons/Taskmaster.svg",
-        "variant": null
+        "img": "systems/ptr2e/img/perk-icons/Taskmaster.svg"
       }
     ],
     "description": "<p>Trigger: The user takes damage and crosses the threshold to meet the [Desperation 1/3] Condition.</p><p>Effect: The user gains 4 Ticks of Shields.</p>",
@@ -69,11 +65,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "berserker"
+    }
   },
   "effects": []
 }

--- a/packs/core-perks/invigorate.json
+++ b/packs/core-perks/invigorate.json
@@ -45,11 +45,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "social",
+      "approach": "resilience",
+      "archetype": "healer"
+    }
   },
   "effects": []
 }

--- a/packs/core-perks/logicians-wisdom.json
+++ b/packs/core-perks/logicians-wisdom.json
@@ -18,14 +18,9 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
-        "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-        "variant": null,
-        "hidden": false
+        "img": "systems/ptr2e/img/perk-icons/Tactician.svg"
       }
     ],
     "slug": "logicians-wisdom",
@@ -65,9 +60,11 @@
     "autoUnlock": [],
     "global": true,
     "webs": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "tactician"
+    }
   },
   "effects": []
 }

--- a/packs/core-perks/muse.json
+++ b/packs/core-perks/muse.json
@@ -16,16 +16,11 @@
         "img": "systems/ptr2e/img/conditions/cheered.svg",
         "range": {
           "target": "ally",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "simple",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
-        },
-        "variant": null
+          "activation": "simple"
+        }
       }
     ],
     "description": "<p>As a Simple Action, designate an ally as your Muse and set a Muse Clock for 6 Spans. When that ally ends an Activation, tick one Span on the Muse Clock. When the Clock fills, your next Attack has its Power doubled.</p>",
@@ -60,11 +55,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "pack-mon"
+    }
   },
   "img": "systems/ptr2e/img/conditions/cheered.svg",
   "effects": [],

--- a/packs/core-perks/mutual-aid.json
+++ b/packs/core-perks/mutual-aid.json
@@ -45,11 +45,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "healer"
+    }
   },
   "effects": []
 }

--- a/packs/core-perks/offering.json
+++ b/packs/core-perks/offering.json
@@ -35,11 +35,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "berserker"
+    }
   },
   "img": "systems/ptr2e/img/icons/capability_icon.webp",
   "effects": [],

--- a/packs/core-perks/overbooster.json
+++ b/packs/core-perks/overbooster.json
@@ -14,17 +14,13 @@
         "type": "generic",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
-          "delay": null,
-          "priority": null
+          "powerPoints": 1
         },
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "slug": "overbooster",
@@ -62,11 +58,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "berserker"
+    }
   },
   "effects": []
 }

--- a/packs/core-perks/parkour.json
+++ b/packs/core-perks/parkour.json
@@ -18,21 +18,15 @@
         "slug": "parkour",
         "description": "<p>When your Movement would take you into an obstacle that could reasonably be traversed within your Overland Movement Allowance, you may make a Hard (-20) Acrobatics check to temporarily grant yourself [Wallclimber] during that movement. If you have not returned to stable ground before your activation ends, you immediately fall.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "parkour",
@@ -68,11 +62,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "exploration"
+    }
   },
   "_id": "95OUHWV4eEI4I3Fe",
   "img": "systems/ptr2e/img/perk-icons/Exploration.svg",

--- a/packs/core-perks/plus-ultra.json
+++ b/packs/core-perks/plus-ultra.json
@@ -13,22 +13,18 @@
         "cost": {
           "activation": "free",
           "powerPoints": 5,
-          "trigger": "The user takes damage and crosses the threshold to meet the [Desperation 1/3] Condition.",
-          "delay": null,
-          "priority": null
+          "trigger": "The user takes damage and crosses the threshold to meet the [Desperation 1/3] Condition."
         },
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "traits": [
           "desperation-1-3",
           "interrupt-2"
         ],
         "type": "generic",
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "slug": "plus-ultra",
@@ -67,11 +63,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "berserker"
+    }
   },
   "effects": []
 }

--- a/packs/core-perks/powerlifter.json
+++ b/packs/core-perks/powerlifter.json
@@ -18,21 +18,15 @@
         "slug": "powerlifter",
         "description": "<p>You have trained your muscles for great weights, and gain +10 on skill checks made with the Lift against targets larger than yourself.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "powerlifter",
@@ -67,11 +61,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "exploration"
+    }
   },
   "_id": "bSM1oq0xt7kx6hLX",
   "img": "systems/ptr2e/img/svg/fighting_icon.svg",

--- a/packs/core-perks/sprint.json
+++ b/packs/core-perks/sprint.json
@@ -42,20 +42,15 @@
         "cost": {
           "activation": "free",
           "powerPoints": 2,
-          "trigger": "The user declares Rush.",
-          "delay": null,
-          "priority": null
+          "trigger": "The user declares Rush."
         },
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "type": "passive",
         "traits": [],
-        "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "hidden": false
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "slug": "sprint",
@@ -91,11 +86,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "exploration"
+    }
   },
   "_id": "vxp5hyhlVJozIaNR",
   "img": "systems/ptr2e/img/perk-icons/Exploration.svg",

--- a/packs/core-perks/strong-swimmer.json
+++ b/packs/core-perks/strong-swimmer.json
@@ -18,21 +18,15 @@
         "slug": "strong-swimmer",
         "description": "<p>You are able to hold your breath for longer, and manage your air more carefully while diving. Increase the size of your Breath clock while swimming by 2 Spans.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "strong-swimmer",
@@ -66,11 +60,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "exploration"
+    }
   },
   "_id": "8biTrHnT6nNeO3in",
   "img": "systems/ptr2e/img/svg/water_icon.svg",

--- a/packs/core-perks/swimming-lessons.json
+++ b/packs/core-perks/swimming-lessons.json
@@ -18,21 +18,15 @@
         "slug": "swimming-lessons",
         "description": "<p>If you previously lacked a Swim Movement Allowance, you gain a Swim Movement Allowance of 3. If you already possessed a Swim Movement Allowance, increase that Movement Allowance by 2.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "swimming-lessons",
@@ -68,11 +62,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "exploration"
+    }
   },
   "_id": "xr7XdAhvvd8T08IC",
   "img": "systems/ptr2e/img/svg/water_icon.svg",

--- a/packs/core-perks/thug.json
+++ b/packs/core-perks/thug.json
@@ -20,19 +20,15 @@
         "cost": {
           "activation": "free",
           "powerPoints": 2,
-          "trigger": "You hit a creature with an attack.",
-          "delay": null,
-          "priority": null
+          "trigger": "You hit a creature with an attack."
         },
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "type": "generic",
         "traits": [],
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "slug": "thug",
@@ -71,11 +67,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "affliction"
+    }
   },
   "_id": "1iAaHzCp7bW9108k",
   "img": "systems/ptr2e/img/perk-icons/Combat.svg",

--- a/packs/core-perks/trained-wielder.json
+++ b/packs/core-perks/trained-wielder.json
@@ -2,28 +2,10 @@
   "name": "Trained Wielder",
   "type": "perk",
   "system": {
-    "prerequisites": [
-      "#Lack a Wielding slot."
-    ],
+    "prerequisites": [],
     "cost": 2,
-    "description": "<p>Gain a Wielded Item Slot.</p>",
-    "actions": [
-      {
-        "name": "Trained Wielder",
-        "slug": "trained-wielder",
-        "description": "<p>Gain a Wielded Item Slot.</p>",
-        "cost": {
-          "activation": "free"
-        },
-        "type": "passive",
-        "traits": [],
-        "img": "icons/svg/explosion.svg",
-        "range": {
-          "target": "enemy",
-          "unit": "m"
-        }
-      }
-    ],
+    "description": "<p>You gain the @Trait[wielder] Trait</p>",
+    "actions": [],
     "slug": "trained-wielder",
     "traits": [],
     "_migration": {
@@ -61,10 +43,67 @@
       "trait:wielder"
     ],
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "weapon"
+    }
   },
   "_id": "Noilrz4vhlRIcrO3",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Trained Wielder",
+      "type": "passive",
+      "_id": "bpQjAA2XFel5zc8B",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "wielder",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>You gain the @Trait[wielder] Trait.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.5.1.5",
+        "createdTime": 1737565954035,
+        "modifiedTime": 1737566017540,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
+      }
+    }
+  ],
   "folder": "oMMIXyKwOCIxMHrK"
 }

--- a/packs/core-perks/transformation-ability.json
+++ b/packs/core-perks/transformation-ability.json
@@ -36,11 +36,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "power",
+      "archetype": "hero"
+    }
   },
   "img": "icons/magic/control/silhouette-grow-shrink-blue.webp",
   "effects": [],

--- a/packs/core-perks/tubthumping.json
+++ b/packs/core-perks/tubthumping.json
@@ -16,18 +16,14 @@
         "cost": {
           "activation": "free",
           "powerPoints": 5,
-          "trigger": "The user gains @Affliction[fainted].",
-          "delay": null,
-          "priority": null
+          "trigger": "The user gains @Affliction[fainted]."
         },
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "description": "Effect: You heal 6 Ticks of HP, accruing a Stack of @Affliction[weary] as normal. If done on your own turn, this becomes a Complex Action.",
-        "img": "icons/svg/explosion.svg",
-        "variant": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The user gains @Affliction[fainted].<br><br>Effect: You heal 6 Ticks of HP, accruing a Stack of @Affliction[weary] as normal. If done on your own turn, this becomes a Complex Action.</p>",
@@ -66,11 +62,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "berserker"
+    }
   },
   "effects": []
 }

--- a/packs/core-perks/type-hunter.json
+++ b/packs/core-perks/type-hunter.json
@@ -17,16 +17,11 @@
         "img": "systems/ptr2e/img/perk-icons/Touched.svg",
         "range": {
           "target": "creature",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
-        },
-        "variant": null
+          "activation": "free"
+        }
       }
     ],
     "description": "<p>You can tutor abilities with the [Hunter] trait. This can be applied to self or owned [Pokemon]. Follows the normal restrictions for tutored abilities.</p>",
@@ -61,11 +56,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "hunter"
+    }
   },
   "img": "systems/ptr2e/img/perk-icons/Touched.svg",
   "effects": [],

--- a/packs/core-perks/typed-transform.json
+++ b/packs/core-perks/typed-transform.json
@@ -36,11 +36,13 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
-    "webs": []
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "power",
+      "archetype": "hero"
+    }
   },
   "img": "icons/magic/control/silhouette-grow-shrink-blue.webp",
   "effects": [],

--- a/packs/core-perks/venomous-stinger.json
+++ b/packs/core-perks/venomous-stinger.json
@@ -42,7 +42,12 @@
         "tier": null
       }
     ],
-    "slug": "venomous-stinger"
+    "slug": "venomous-stinger",
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "species"
+    }
   },
   "img": "systems/ptr2e/img/perk-icons/Breeder.svg",
   "effects": [
@@ -62,7 +67,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,


### PR DESCRIPTION
Did in bulk down A-S but got bored, so...that was that, I guess.
- Update Perk: Acute Affliction
- Update Perk: Cultivate Weakness
- Update Perk: Logician's Wisdom
- Update Perk: Thug
- Update Perk: Adrenaline Rush
- Update Perk: Desperate Strike
- Update Perk: Glutton For Punishment
- Update Perk: Gut Punch
- Update Perk: Hear No Bell
- Update Perk: I Get Knocked Down
- Update Perk: Offering
- Update Perk: Overbooster
- Update Perk: Plus Ultra
- Update Perk: Tubthumping
- Update Perk: Acrobat
- Update Perk: All-Seasonal
- Update Perk: Cyclist
- Update Perk: Freeclimber
- Update Perk: Hardy Trekker
- Update Perk: Parkour
- Update Perk: Powerlifter
- Update Perk: Sprint
- Update Perk: Strong Swimmer
- Update Perk: Swimming Lessons
- Update Perk: Belt Expansion 1
- Update Perk: Belt Expansion 2
- Update Perk: Belt Expansion 3
- Update Perk: Dress To Impress
- Update Perk: Dual Wielder
- Update Perk: Trained Wielder
- Update Perk: Cautious Healer
- Update Perk: Chansey Medicine
- Update Perk: Healing Hands
- Update Perk: Holistic Care
- Update Perk: Invigorate
- Update Perk: Mutual Aid
- Update Perk: Heroic Mobility
- Update Perk: Heroic Rush
- Update Perk: Heroic Senses
- Update Perk: Heroic Transformation
- Update Perk: Transformation Ability
- Update Perk: Typed Transform
- Update Perk: <Type> Hunter
- Update Perk: Dead Eye
- Update Perk: Dead To Rights
- Update Perk: Down The Sights
- Update Perk: Hit & Run
- Update Perk: Muse
- Update Perk: Dizzy Daft
- Update Perk: Venomous Stinger