### PR TITLE
Foundry Data Sync - Fantasy Species Average Height & Weight Updoot

### DIFF
--- a/packs/core-species/catrazzan-birdfolk.json
+++ b/packs/core-species/catrazzan-birdfolk.json
@@ -6,7 +6,6 @@
     "slug": "catrazzan-birdfolk",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -254,8 +253,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.5,
+      "weight": 50
     },
     "abilities": {
       "starting": [
@@ -275,6 +274,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApa"
 }

--- a/packs/core-species/cavern-dwarf.json
+++ b/packs/core-species/cavern-dwarf.json
@@ -6,7 +6,6 @@
     "slug": "cavern-dwarf",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -259,8 +258,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.3,
+      "weight": 70
     },
     "abilities": {
       "starting": [
@@ -280,6 +279,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApb"
 }

--- a/packs/core-species/dark-elf.json
+++ b/packs/core-species/dark-elf.json
@@ -6,7 +6,6 @@
     "slug": "dark-elf",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -275,8 +274,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.6,
+      "weight": 65
     },
     "abilities": {
       "starting": [
@@ -296,6 +295,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApc"
 }

--- a/packs/core-species/halfling.json
+++ b/packs/core-species/halfling.json
@@ -6,7 +6,6 @@
     "slug": "halfling",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -249,8 +248,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 0.8,
+      "weight": 50
     },
     "abilities": {
       "starting": [
@@ -270,6 +269,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApd"
 }

--- a/packs/core-species/haunted.json
+++ b/packs/core-species/haunted.json
@@ -6,7 +6,6 @@
     "slug": "haunted",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -259,8 +258,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.7,
+      "weight": 80
     },
     "abilities": {
       "starting": [
@@ -280,6 +279,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApe"
 }

--- a/packs/core-species/high-elf.json
+++ b/packs/core-species/high-elf.json
@@ -6,7 +6,6 @@
     "slug": "high-elf",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -282,8 +281,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 2.2,
+      "weight": 95
     },
     "abilities": {
       "starting": [
@@ -303,6 +302,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApf"
 }

--- a/packs/core-species/human-fantasy.json
+++ b/packs/core-species/human-fantasy.json
@@ -6,7 +6,6 @@
     "slug": "human-fantasy",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -257,8 +256,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.7,
+      "weight": 80
     },
     "abilities": {
       "starting": [
@@ -278,6 +277,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApg"
 }

--- a/packs/core-species/kitsune.json
+++ b/packs/core-species/kitsune.json
@@ -6,7 +6,6 @@
     "slug": "kitsune",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -252,8 +251,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.6,
+      "weight": 70
     },
     "abilities": {
       "starting": [
@@ -273,6 +272,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApz"
 }

--- a/packs/core-species/kobold.json
+++ b/packs/core-species/kobold.json
@@ -6,7 +6,6 @@
     "slug": "kobold",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -259,8 +258,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 0.65,
+      "weight": 18
     },
     "abilities": {
       "starting": [
@@ -280,6 +279,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApi"
 }

--- a/packs/core-species/lizardfolk.json
+++ b/packs/core-species/lizardfolk.json
@@ -6,7 +6,6 @@
     "slug": "lizardfolk",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -241,8 +240,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 2.4,
+      "weight": 120
     },
     "abilities": {
       "starting": [
@@ -262,6 +261,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApj"
 }

--- a/packs/core-species/mindrats.json
+++ b/packs/core-species/mindrats.json
@@ -6,7 +6,6 @@
     "slug": "mindrats",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -250,8 +249,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.6,
+      "weight": 45
     },
     "abilities": {
       "starting": [
@@ -271,6 +270,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApk"
 }

--- a/packs/core-species/mountain-dwarf.json
+++ b/packs/core-species/mountain-dwarf.json
@@ -6,7 +6,6 @@
     "slug": "mountain-dwarf",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -258,8 +257,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.4,
+      "weight": 75
     },
     "abilities": {
       "starting": [
@@ -279,6 +278,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApl"
 }

--- a/packs/core-species/orc.json
+++ b/packs/core-species/orc.json
@@ -6,7 +6,6 @@
     "slug": "orc",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -259,8 +258,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 2.1,
+      "weight": 100
     },
     "abilities": {
       "starting": [
@@ -280,6 +279,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApm"
 }

--- a/packs/core-species/shade.json
+++ b/packs/core-species/shade.json
@@ -6,7 +6,6 @@
     "slug": "shade",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -250,8 +249,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.7,
+      "weight": 80
     },
     "abilities": {
       "starting": [
@@ -271,6 +270,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApn"
 }

--- a/packs/core-species/shield-dwarf.json
+++ b/packs/core-species/shield-dwarf.json
@@ -6,7 +6,6 @@
     "slug": "shield-dwarf",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -258,8 +257,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.4,
+      "weight": 90
     },
     "abilities": {
       "starting": [
@@ -279,6 +278,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApo"
 }

--- a/packs/core-species/slime.json
+++ b/packs/core-species/slime.json
@@ -6,7 +6,6 @@
     "slug": "slime",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -251,8 +250,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.5,
+      "weight": 30
     },
     "abilities": {
       "starting": [
@@ -272,6 +271,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApp"
 }

--- a/packs/core-species/wood-elf.json
+++ b/packs/core-species/wood-elf.json
@@ -6,7 +6,6 @@
     "slug": "wood-elf",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -267,8 +266,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 1.5,
+      "weight": 60
     },
     "abilities": {
       "starting": [
@@ -288,6 +287,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApq"
 }

--- a/packs/core-species/yeti.json
+++ b/packs/core-species/yeti.json
@@ -6,7 +6,6 @@
     "slug": "yeti",
     "traits": [
       "humanoid",
-      "underdog",
       "unique-egg-group",
       "bipedal",
       "speech",
@@ -249,8 +248,8 @@
     "size": {
       "category": "medium",
       "type": "height",
-      "height": 0,
-      "weight": 0
+      "height": 2.6,
+      "weight": 130
     },
     "abilities": {
       "starting": [
@@ -270,6 +269,5 @@
   },
   "effects": [],
   "folder": "CNpRUvGI08ofZosB",
-  "flags": {},
   "_id": "1RFDzRQhOBK0dApr"
 }


### PR DESCRIPTION
To make creating characters with these flow smoother as they are generated in the same way as Pokemon are initially.
- Update Species: Catrazzan Birdfolk
- Update Species: Cavern Dwarf
- Update Species: Mountain Dwarf
- Update Species: Shield Dwarf
- Update Species: Dark Elf
- Update Species: High Elf
- Update Species: Wood Elf
- Update Species: Halfling
- Update Species: Haunted
- Update Species: Human (Fantasy)
- Update Species: Kitsune
- Update Species: Kobold
- Update Species: Lizardfolk
- Update Species: Mindrats
- Update Species: Orc
- Update Species: Shade
- Update Species: Slime
- Update Species: Yeti