### PR TITLE
Foundry Data Sync - Added Partial/Full Automation for Certain Weather and Sludge Bomb

### DIFF
--- a/packs/core-moves/acid-rain.json
+++ b/packs/core-moves/acid-rain.json
@@ -15,7 +15,6 @@
         ],
         "range": {
           "target": "field",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
@@ -23,20 +22,21 @@
           "powerPoints": 4
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "poison"
         ],
         "description": "<p>Effect: The weather becomes Smoggy for 3 rounds.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/poison_icon.svg",
+        "summon": "Compendium.ptr2e.core-summons.Item.AUpYPhcmwB7BsQ8I",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "ufutclHyzVOmKmdi",
   "effects": []

--- a/packs/core-moves/electric-terrain.json
+++ b/packs/core-moves/electric-terrain.json
@@ -15,7 +15,6 @@
         ],
         "range": {
           "target": "field",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
@@ -23,20 +22,21 @@
           "powerPoints": 3
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "electric"
         ],
         "description": "<p>Effect: The Terrain type is set to Electric Terrain for 3 rounds.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/electric_icon.svg",
+        "summon": "Compendium.ptr2e.core-summons.Item.dinLBMHBNUshV0Og",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "dPSChKwDs2PiIA7p",
   "effects": []

--- a/packs/core-moves/fallout.json
+++ b/packs/core-moves/fallout.json
@@ -11,11 +11,11 @@
         "type": "attack",
         "traits": [
           "weather",
-          "pp-updated"
+          "pp-updated",
+          "partial-automation"
         ],
         "range": {
           "target": "field",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
@@ -23,20 +23,21 @@
           "powerPoints": 4
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "nuclear"
         ],
         "description": "<p>Effect: The Weather becomes Glowy for 3 rounds.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/nuclear_icon.svg",
+        "summon": "Compendium.ptr2e.core-summons.Item.9a5RrO9eF0kzt9Xn",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "tvJruA8VQvYfNvaV",
   "folder": "EpCOePz8omfXbp35",

--- a/packs/core-moves/foghorn.json
+++ b/packs/core-moves/foghorn.json
@@ -15,7 +15,6 @@
         ],
         "range": {
           "target": "field",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
@@ -23,20 +22,21 @@
           "powerPoints": 4
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
         "description": "<p>Effect: The Weather becomes Foggy for 3 rounds.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/normal_icon.svg",
+        "summon": "Compendium.ptr2e.core-summons.Item.Kv1r7REyDbd8rJua",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B"
+    "grade": "B",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "9w7Zluo37ewy3NaQ",
   "effects": []

--- a/packs/core-moves/sludge-bomb.json
+++ b/packs/core-moves/sludge-bomb.json
@@ -43,5 +43,64 @@
     }
   },
   "_id": "3NZj02Fbw14aWuTa",
-  "effects": []
+  "effects": [
+    {
+      "name": "Sludge Bomb",
+      "type": "affliction",
+      "_id": "dmXgQCjv6Eg6FkSj",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sludge-bomb-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "label": "SludgeBomb",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Item.rAeOK7nRumOYcWbN.ActiveEffect.0f6g5ojIJK5z8gao",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": 1739417742407,
+        "modifiedTime": 1739483387604,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
+      }
+    }
+  ]
 }

--- a/packs/core-moves/sludge-bomb.json
+++ b/packs/core-moves/sludge-bomb.json
@@ -58,7 +58,7 @@
             "predicate": [],
             "chance": 30,
             "affects": "target",
-            "label": "SludgeBomb",
+            "label": "Sludge Bomb",
             "mode": 2,
             "priority": null,
             "ignored": false,

--- a/packs/core-summons/electric-terrain.json
+++ b/packs/core-summons/electric-terrain.json
@@ -1,0 +1,107 @@
+{
+  "name": "Electric Terrain",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "traits": [],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "img": "systems/ptr2e/img/svg/electric_icon.svg",
+  "effects": [
+    {
+      "name": "Electric Terrain",
+      "type": "summon",
+      "_id": "DOFLoEK0rFAWyi3C",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "electric-attack-power",
+            "value": 30,
+            "predicate": [],
+            "label": "Electric Terrain Damage Boost",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-option",
+            "key": "",
+            "value": "affliction:drowsy",
+            "predicate": [],
+            "domain": "immunities",
+            "toggleable": false,
+            "count": false,
+            "label": "Drowsy Immunity",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "state": true
+          },
+          {
+            "type": "roll-option",
+            "key": "",
+            "value": "affliction:nightmares",
+            "predicate": [],
+            "domain": "immunities",
+            "toggleable": false,
+            "count": false,
+            "label": "Nightmares Immunity",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "state": true
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage",
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": 1739485677501,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "dinLBMHBNUshV0Og"
+}

--- a/packs/core-summons/foggy-weather.json
+++ b/packs/core-summons/foggy-weather.json
@@ -1,0 +1,89 @@
+{
+  "name": "Foggy Weather",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "traits": [],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "img": "systems/ptr2e/img/svg/normal_icon.svg",
+  "effects": [
+    {
+      "name": "Foggy Weather",
+      "type": "summon",
+      "_id": "2P73uDiEOQttMM0O",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "electric-attack-damage",
+            "value": -30,
+            "predicate": [],
+            "label": "Electric Fog Modifier",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "basic",
+            "key": "system.attributes.spe.value",
+            "value": 1.25,
+            "mode": 1,
+            "predicate": [
+              "actor:trait:bug"
+            ],
+            "label": "Bug SpeedBoost",
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage",
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": 1739484782488,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "Kv1r7REyDbd8rJua"
+}

--- a/packs/core-summons/glowy-weather.json
+++ b/packs/core-summons/glowy-weather.json
@@ -1,0 +1,81 @@
+{
+  "name": "Glowy Weather",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "traits": [
+      "partial-automation",
+      "weather"
+    ],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "img": "systems/ptr2e/img/svg/nuclear_icon.svg",
+  "effects": [
+    {
+      "name": "Glowy Weather",
+      "type": "summon",
+      "_id": "CI0kHPoSIikPh7Ky",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.attributes.spe.value",
+            "value": 1.3,
+            "predicate": [
+              "actor:trait:nuclear"
+            ],
+            "mode": 1,
+            "label": "Nuclear SpeedBoost",
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/16",
+        "type": "damage",
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": 1739484412012,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "9a5RrO9eF0kzt9Xn"
+}

--- a/packs/core-summons/intense-acid-rain-weather.json
+++ b/packs/core-summons/intense-acid-rain-weather.json
@@ -1,0 +1,139 @@
+{
+  "name": "Intense Acid Rain Weather",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "traits": [
+      "partial-automation",
+      "weather"
+    ],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "img": "systems/ptr2e/img/svg/poison_icon.svg",
+  "effects": [
+    {
+      "name": "Intense Acid Raid Weather",
+      "type": "summon",
+      "_id": "2DcCkbzRFhJkLU9n",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "poison-attack-damage",
+            "value": 40,
+            "predicate": [],
+            "label": "Poison Damage Boost",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "physical-attack-damage-percentile",
+            "value": 25,
+            "predicate": [
+              {
+                "not": "target:trait:poison"
+              }
+            ],
+            "label": "NonPoison Damage Taken Increase",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "physical-attack-damage-percentile",
+            "value": -25,
+            "predicate": [
+              {
+                "not": "actor:trait:poison"
+              }
+            ],
+            "label": "NonPoison Damage Decrease",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "poison-attack-effect-chance",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 25,
+            "affects": "target",
+            "label": "Poison Chance",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "poison-attack-effect-chance",
+            "value": "Compendium.ptr2e.core-effects.Item.blightcondititem",
+            "predicate": [],
+            "chance": 25,
+            "affects": "target",
+            "label": "Blight Chance",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [
+          "partial-automation",
+          "weather"
+        ],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/16",
+        "type": "damage",
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-summons.Item.nXGTvwoiQ7Cr3kPZ.ActiveEffect.RnUBhAHQxzG4FotL",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": 1739486061357,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "QJK3V4l4ZeQd4t6U"
+}

--- a/packs/core-summons/intense-fog-weather.json
+++ b/packs/core-summons/intense-fog-weather.json
@@ -1,0 +1,92 @@
+{
+  "name": "Intense Fog Weather",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "traits": [],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "img": "systems/ptr2e/img/svg/normal_icon.svg",
+  "effects": [
+    {
+      "name": "Intense Fog Weather",
+      "type": "summon",
+      "_id": "2P73uDiEOQttMM0O",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "electric-attack-damage",
+            "value": -60,
+            "predicate": [],
+            "label": "Electric Fog Modifier",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "basic",
+            "key": "system.attributes.spe.value",
+            "value": 1.5,
+            "mode": 1,
+            "predicate": [
+              "actor:trait:bug"
+            ],
+            "label": "Bug SpeedBoost",
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [
+          "partial-automation",
+          "weather"
+        ],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage",
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": 1739484795007,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "Krb1BRo2XyhMNZ3G"
+}

--- a/packs/core-summons/intense-radstorm-weather.json
+++ b/packs/core-summons/intense-radstorm-weather.json
@@ -1,0 +1,84 @@
+{
+  "name": "Intense Radstorm Weather",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "traits": [
+      "partial-automation",
+      "weather"
+    ],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "img": "systems/ptr2e/img/svg/nuclear_icon.svg",
+  "effects": [
+    {
+      "name": "Intense Radstorm Weather",
+      "type": "summon",
+      "_id": "3EYv9rOpoutevHH5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.attributes.spe.value",
+            "value": 1.5,
+            "predicate": [
+              "actor:trait:nuclear"
+            ],
+            "label": "Nuclear SpeedBoost",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [
+          "partial-automation",
+          "weather"
+        ],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/16",
+        "type": "damage",
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": 1739484439130,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "IZfUOgGn8H1XJ5GS"
+}

--- a/packs/core-summons/intense-winds-weather.json
+++ b/packs/core-summons/intense-winds-weather.json
@@ -1,0 +1,95 @@
+{
+  "name": "Intense Winds Weather",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "traits": [
+      "partial-automation",
+      "weather"
+    ],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "img": "systems/ptr2e/img/svg/flying_icon.svg",
+  "effects": [
+    {
+      "name": "Intense Winds Weather",
+      "type": "summon",
+      "_id": "sXN4OmKfzYgrtbSg",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.attributes.spe.value",
+            "value": 1.6,
+            "predicate": [
+              "actor:trait:flying"
+            ],
+            "mode": 1,
+            "label": "Flying SpeedBoost",
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "wind-trait-attack-damage",
+            "value": 80,
+            "predicate": [],
+            "label": "Wind Damage Modifier",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [
+          "partial-automation",
+          "weather"
+        ],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage",
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-summons.Item.OeB2hndOSCLzlbcp.ActiveEffect.btSZQSeig8xrmoQ4",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": 1739485374046,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "Uq4WJydMueMJij91"
+}

--- a/packs/core-summons/smoggy-weather.json
+++ b/packs/core-summons/smoggy-weather.json
@@ -38,10 +38,8 @@
             "value": 25,
             "predicate": [
               {
-                "not": "target:trait:poison"
-              },
-              {
-                "nor": [
+                "nand": [
+                  "target:trait:poison",
                   "target:trait:steel"
                 ]
               }

--- a/packs/core-summons/smoggy-weather.json
+++ b/packs/core-summons/smoggy-weather.json
@@ -6,12 +6,11 @@
       "version": 0.11,
       "previous": null
     },
-    "traits": [
-      "partial-automation"
-    ],
+    "traits": [],
     "actions": [],
     "baseAV": 150,
-    "duration": 3
+    "duration": 3,
+    "slug": "smoggy-weather"
   },
   "img": "icons/magic/death/skeleton-skull-soul-blue.webp",
   "effects": [
@@ -27,6 +26,27 @@
             "key": "poison-attack-damage",
             "value": 20,
             "predicate": [],
+            "label": "Poison Damage Increase",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "physical-attack-damage-percentile",
+            "value": 25,
+            "predicate": [
+              {
+                "not": "target:trait:poison"
+              },
+              {
+                "nor": [
+                  "target:trait:steel"
+                ]
+              }
+            ],
+            "label": "Physical Damage Increase",
             "mode": 2,
             "priority": null,
             "ignored": false,
@@ -92,13 +112,12 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.2.1",
+        "systemVersion": "1.0.3.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1739484678261,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
       }
     }
   ],
-  "flags": {},
   "_id": "AUpYPhcmwB7BsQ8I"
 }


### PR DESCRIPTION
Partially Automated Weathers:

Foggy ( Fog Horn )

30% Electric Damage Reduction

25% Bug Speed Boost

Intense Fog

60% Electric Damage Reduction

50% Bug Speed Boost

Smoggy ( Acid Rain )

Damage Over Time - Not complete, affects all

20% Poison Damage Boost

25% Physical Damage Boost ( Inactive against Poison and Steel )

non-functional but written 10% Poison and Blight Chance

Intense Acid Rain

Tick Damage Over Time - Not complete, Effects all types

40% Poison Damage Boost

25% Physical Damage Boost ( Inactive against Poison types )

25% Damage Reduction ( Inactive for Poison types )

non-functional but written 25% Poison and Blight Chance

Windy ( Tailwind ) ( Already Sent Upstream )

30% Flying Speed Boost

40% Wind Attack Damage Boost

Intense Wind

60% Flying Speed Boost

80% Wind Attack Damage Boost

Glowy ( Fallout )

30% Nuclear Speed Boost

Tick Damage Over Time - Not Complete, Effects all types

Intense Radstorm

50% Nuclear Speed Boost

Tick Damage Over Time - Not Complete, Effects all types

Electric Terrain ( Electric Terrain )

30% Electric Damage Boost

Immunity to Nightmare and Drowsy ( No Cleanse yet )

Fully Automated:

Sludge Bomb

30% Chance to Poison
- Update Move: Electric Terrain
- Update Summon: Electric Terrain
- Update Move: Foghorn
- Update Summon: Foggy Weather
- Update Move: Fallout
- Update Summon: Glowy Weather
- Update Move: Acid Rain
- Update Summon: Smoggy Weather
- Update Summon: Intense Acid Rain Weather
- Update Summon: Intense Radstorm Weather
- Update Summon: Intense Winds Weather
- Update Summon: Intense Fog Weather
- Update Move: Sludge Bomb