### PR TITLE
Foundry Data Sync - Meaning of Haste Action Fix

### DIFF
--- a/packs/core-perks/the-meaning-of-haste.json
+++ b/packs/core-perks/the-meaning-of-haste.json
@@ -25,7 +25,8 @@
           "untyped"
         ],
         "category": "status",
-        "predicate": []
+        "predicate": [],
+        "free": true
       }
     ],
     "slug": "the-meaning-of-haste",
@@ -72,7 +73,7 @@
     "design": {
       "arena": "social",
       "approach": "power",
-      "archetype": "Tactician"
+      "archetype": "tactician"
     }
   },
   "effects": [
@@ -92,7 +93,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,


### PR DESCRIPTION
Sets action as free so it doesn't end up hidden in Known Attacks.
- Update Perk: The Meaning of Haste