### PR TITLE
Foundry Data Sync - Further Weather and Freeze-Dry Automation

### DIFF
--- a/packs/core-moves/freeze-dry.json
+++ b/packs/core-moves/freeze-dry.json
@@ -28,14 +28,16 @@
           "ice"
         ],
         "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[frostbite] 5. This attack is super effective against the Water Type.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "C"
+    "grade": "C",
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "y5H4C8WkE4feSmwt",
   "effects": [
@@ -47,6 +49,19 @@
       "system": {
         "changes": [
           {
+            "type": "percentile-modifier",
+            "key": "freeze-dry-attack-damage-percentile",
+            "value": 300,
+            "predicate": [
+              "target:trait:water"
+            ],
+            "label": "Super Effective vs Water",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
             "type": "roll-effect",
             "key": "freeze-dry-attack",
             "value": "Compendium.ptr2e.core-effects.Item.frostbiteconitem",
@@ -55,7 +70,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,
@@ -86,10 +102,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.0.0",
+        "systemVersion": "1.0.3.beta",
         "createdTime": 1729547235568,
-        "modifiedTime": 1729547257083,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+        "modifiedTime": 1739584461375,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
       }
     }
   ]

--- a/packs/core-summons/intense-downpour-weather.json
+++ b/packs/core-summons/intense-downpour-weather.json
@@ -1,0 +1,102 @@
+{
+  "name": "Intense Downpour Weather",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "traits": [
+      "partial-automation",
+      "weather"
+    ],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "img": "systems/ptr2e/img/svg/water_icon.svg",
+  "effects": [
+    {
+      "name": "Intense Downpour",
+      "type": "summon",
+      "_id": "IxXhdscv2UYxFaqO",
+      "img": "systems/ptr2e/img/svg/water_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "water-attack-damage",
+            "value": 60,
+            "predicate": [],
+            "label": "Water Damage Boost",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "fire-attack-damage-percentile",
+            "value": -100,
+            "predicate": [],
+            "label": "Fire Failure",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "explode-trait-attack-damage-percentile",
+            "value": -100,
+            "predicate": [],
+            "label": "Explode Failure",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage",
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "05v6WQHLOzcIKXPS"
+}

--- a/packs/core-summons/intense-heat-weather.json
+++ b/packs/core-summons/intense-heat-weather.json
@@ -1,0 +1,183 @@
+{
+  "name": "Intense Heat Weather",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "traits": [
+      "partial-automation",
+      "weather"
+    ],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "img": "systems/ptr2e/img/svg/fire_icon.svg",
+  "effects": [
+    {
+      "name": "Intense Heat",
+      "type": "summon",
+      "_id": "LenoUR3rUsjmFRqO",
+      "img": "systems/ptr2e/img/svg/fire_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "fire-attack-damage",
+            "value": 60,
+            "predicate": [],
+            "label": "Fire Damage Boost",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "water-attack-damage",
+            "value": -100,
+            "predicate": [],
+            "label": "Water Damage Nullification",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "basic",
+            "key": "system.attributes.spe.value",
+            "value": 1.3,
+            "mode": 1,
+            "predicate": [],
+            "label": "Grass Speed Boost",
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "fire-attack-damage-percentile",
+            "value": 100,
+            "predicate": [
+              {
+                "not": "target:trait:water"
+              }
+            ],
+            "label": "Fire Effectiveness Boost",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "fire-attack-damage-percentile",
+            "value": 300,
+            "predicate": [
+              "target:trait:water"
+            ],
+            "label": "Water Type Fire Weakness",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-option",
+            "key": "",
+            "value": "afflication:frozen",
+            "predicate": [],
+            "domain": "immunities",
+            "toggleable": false,
+            "count": false,
+            "label": "Frozen Immunity",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "state": true
+          },
+          {
+            "type": "roll-effect",
+            "key": "attack-effect-chance",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "label": "Burn Chance Increase",
+            "chance": 25,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "fire-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 25,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "physical-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [
+              "item:trait:steel"
+            ],
+            "chance": 25,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage",
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": 1739583772199,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "CoRSw7YDim16e6P4"
+}

--- a/packs/core-summons/rainy-weather.json
+++ b/packs/core-summons/rainy-weather.json
@@ -11,7 +11,8 @@
     ],
     "actions": [],
     "baseAV": 150,
-    "duration": 3
+    "duration": 3,
+    "slug": "rainy-weather"
   },
   "img": "icons/magic/air/weather-clouds-rain.webp",
   "effects": [
@@ -86,13 +87,12 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "1.0.3.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1739583806615,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
       }
     }
   ],
-  "flags": {},
   "_id": "IkeVGMx2xjpkphtA"
 }

--- a/packs/core-summons/sunny-weather.json
+++ b/packs/core-summons/sunny-weather.json
@@ -11,7 +11,8 @@
     ],
     "actions": [],
     "baseAV": 150,
-    "duration": 3
+    "duration": 3,
+    "slug": "sunny-weather"
   },
   "img": "icons/magic/air/weather-sunlight-sky.webp",
   "effects": [
@@ -27,6 +28,7 @@
             "key": "fire-attack-damage",
             "value": 30,
             "predicate": [],
+            "label": "Fire Damage Boost",
             "mode": 2,
             "priority": null,
             "ignored": false,
@@ -37,6 +39,20 @@
             "key": "water-attack-damage",
             "value": -30,
             "predicate": [],
+            "label": "Water Damage Reduction",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "fire-attack-damage-percentage",
+            "value": 100,
+            "predicate": [
+              "traget:trait:water"
+            ],
+            "label": "Neutral Fire Damage to Water",
             "mode": 2,
             "priority": null,
             "ignored": false,
@@ -50,20 +66,9 @@
               "actor:trait:grass"
             ],
             "mode": 1,
+            "label": "Grass Speed Boost",
             "priority": null,
             "ignored": false
-          },
-          {
-            "type": "flat-modifier",
-            "key": "fire-attack-effectiveness-stage",
-            "value": 100,
-            "predicate": [
-              "target:trait:water"
-            ],
-            "mode": 2,
-            "priority": null,
-            "ignored": false,
-            "hideIfDisabled": true
           },
           {
             "type": "roll-option",
@@ -88,7 +93,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           },
           {
             "type": "roll-effect",
@@ -99,7 +105,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           },
           {
             "type": "roll-effect",
@@ -112,7 +119,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,
@@ -148,13 +156,12 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "1.0.3.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "modifiedTime": 1739583368751,
+        "lastModifiedBy": "OCI1vTFsIMTEwU21"
       }
     }
   ],
-  "flags": {},
   "_id": "9cgLo9qwotwZUqPT"
 }


### PR DESCRIPTION
Sunny ( Sunny Day )

Replaced Effectiveness Modifier with a 100% percentile modifier as previous effectiveness modifier caused move to fail to execute (Not roll) instead

Intense Heat

Added 60% Fire Damage Boost

Added a -100% Modifier to water damage until a better alternative is available for the weather to fully negate water moves

Added 100% Percentage boost to Fire Moves to replicate Weaknesses for other types

Added 300% Percentage boost to Fire Moves vs Water Types to replicate Fire Weakness Effect

Added Immunity to Freeze Condition ( Does not Currently Cleanse )

Added Non Functional Burn Chance/Bonus for Fire Moves and Physical Moves

Rainy ( Rain Dance )

Changed Rainy Explode Trait damage reduction into a -50% modifier as previous effectiveness modifier caused move to fail to execute (Not roll) instead

Intense Downpour

Added 60% Water Damage Boost

Added -100% Fire Damage and Explode Trait Damage Reduction until a better alternative is available for the weather to fully negate fire and explode moves

freeze-dry

300% damage boost vs Water Types to simulate Ice Weakness
- Update Summon: Intense Heat Weather
- Update Summon: Sunny Weather
- Update Summon: Rainy Weather
- Update Summon: Intense Downpour Weather
- Update Move: Freeze-Dry