### PR TITLE
Foundry Data Sync - Rotom Form Changes + Foretold Connection Fix + Heavy Metal Automation

### DIFF
--- a/packs/core-abilities/foretold.json
+++ b/packs/core-abilities/foretold.json
@@ -71,7 +71,9 @@
             "type": "grant-item",
             "key": "Compendium.ptr2e.core-moves.Item.mFTIJjM1A7Ty1vBb",
             "value": "Compendium.ptr2e.core-moves.Item.mFTIJjM1A7Ty1vBb",
-            "predicate": [],
+            "predicate": [
+              "item:ability:foretold:active"
+            ],
             "alterations": [
               {
                 "mode": 5,
@@ -79,12 +81,12 @@
                 "value": "true"
               }
             ],
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
             "mode": 2,
             "priority": null,
             "ignored": false,
-            "reevaluateOnUpdate": false,
             "inMemoryOnly": false,
-            "allowDuplicate": true,
             "track": false,
             "replaceSelf": false,
             "onDeleteActions": {
@@ -121,9 +123,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.5",
+        "systemVersion": "1.0.3.beta",
         "createdTime": 1722259246709,
-        "modifiedTime": 1737398514469,
+        "modifiedTime": 1739625122139,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }

--- a/packs/core-abilities/heavy-metal.json
+++ b/packs/core-abilities/heavy-metal.json
@@ -29,5 +29,57 @@
     }
   },
   "_id": "gKHCt0SSuaws2ZN3",
-  "effects": []
+  "effects": [
+    {
+      "name": "Heavy Metal",
+      "type": "passive",
+      "_id": "DJWYDI3MnyUqca3A",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.modifiers.weightClass",
+            "value": 3,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-abilities.Item.gKHCt0SSuaws2ZN3.ActiveEffect.DJWYDI3MnyUqca3A",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": 1739625327869,
+        "modifiedTime": 1739625403883,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/phantom-devicer.json
+++ b/packs/core-abilities/phantom-devicer.json
@@ -69,7 +69,9 @@
             "type": "grant-item",
             "key": "",
             "value": "Compendium.ptr2e.core-moves.Item.g0tf8DHabi55oj5C",
-            "predicate": [],
+            "predicate": [
+              "item:ability:phantom-devicer:active"
+            ],
             "alterations": [
               {
                 "mode": 5,
@@ -77,12 +79,12 @@
                 "value": "true"
               }
             ],
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
             "mode": 2,
             "priority": null,
             "ignored": false,
-            "reevaluateOnUpdate": false,
             "inMemoryOnly": false,
-            "allowDuplicate": true,
             "track": false,
             "replaceSelf": false,
             "onDeleteActions": {
@@ -94,7 +96,9 @@
             "type": "grant-item",
             "key": "",
             "value": "Compendium.ptr2e.core-abilities.Item.WNpGnjZkiWLOta0C",
-            "predicate": [],
+            "predicate": [
+              "item:ability:phantom-devicer:active"
+            ],
             "alterations": [
               {
                 "mode": 5,
@@ -102,12 +106,12 @@
                 "value": "true"
               }
             ],
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
             "mode": 2,
             "priority": null,
             "ignored": false,
-            "reevaluateOnUpdate": false,
             "inMemoryOnly": false,
-            "allowDuplicate": true,
             "track": false,
             "replaceSelf": false,
             "onDeleteActions": {
@@ -144,9 +148,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.5",
+        "systemVersion": "1.0.3.beta",
         "createdTime": 1737417652483,
-        "modifiedTime": 1737417721437,
+        "modifiedTime": 1739634064601,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }

--- a/packs/core-species/rotom.json
+++ b/packs/core-species/rotom.json
@@ -462,7 +462,11 @@
       "details": null,
       "evolutions": [],
       "uuid": null,
-      "methods": []
+      "methods": [],
+      "perk": {
+        "x": 26,
+        "y": 26
+      }
     },
     "slug": "rotom",
     "_migration": {
@@ -471,5 +475,710 @@
     }
   },
   "_id": "gptW2VMUw2eUT7LX",
-  "effects": []
+  "effects": [
+    {
+      "name": "Frost",
+      "type": "form",
+      "_id": "L9o9IqAscCfj83Fz",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:frost:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Frost Forme",
+            "predicate": [],
+            "alwaysActive": false,
+            "count": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "state": false
+          },
+          {
+            "type": "stats-alteration",
+            "predicate": [
+              "forme:frost:active"
+            ],
+            "key": "",
+            "value": 0,
+            "hp": null,
+            "atk": 15,
+            "def": 30,
+            "spa": 10,
+            "spd": 30,
+            "spe": -5,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "suppress-ability",
+            "predicate": [
+              "forme:frost:active"
+            ],
+            "key": "phantom-devicer",
+            "value": 0,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "predicate": [
+              "forme:frost:active"
+            ],
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.pMSwY3ECWqqasF1a",
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "predicate": [
+              "forme:frost:active"
+            ],
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.vXvFp7PqPkhPr0zX",
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-species.Item.gptW2VMUw2eUT7LX.ActiveEffect.L9o9IqAscCfj83Fz",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": 1739630481930,
+        "modifiedTime": 1739634486188,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    },
+    {
+      "name": "Fan",
+      "type": "form",
+      "_id": "1gbbXBF0mOzsVyjn",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:fan:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Fan Forme",
+            "predicate": [],
+            "alwaysActive": false,
+            "count": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "state": false
+          },
+          {
+            "type": "stats-alteration",
+            "predicate": [
+              "forme:fan:active"
+            ],
+            "key": "",
+            "value": 0,
+            "hp": null,
+            "atk": 15,
+            "def": 30,
+            "spa": 10,
+            "spd": 30,
+            "spe": -5,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "suppress-ability",
+            "predicate": [
+              "forme:fan:active"
+            ],
+            "key": "phantom-devicer",
+            "value": 0,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "predicate": [
+              "forme:fan:active"
+            ],
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.vXvFp7PqPkhPr0zX",
+            "reevaluateOnUpdate": true,
+            "allowDuplicate": false,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "predicate": [
+              "forme:fan:active"
+            ],
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.dcZCfNmzzkDymeBa",
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": 1739630491982,
+        "modifiedTime": 1739634632538,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    },
+    {
+      "name": "Wash",
+      "type": "form",
+      "_id": "IysB8fpGpr6VmGwE",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:wash:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Wash Forme",
+            "predicate": [],
+            "alwaysActive": false,
+            "count": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "state": false
+          },
+          {
+            "type": "stats-alteration",
+            "predicate": [
+              "forme:wash:active"
+            ],
+            "key": "",
+            "value": 0,
+            "hp": null,
+            "atk": 15,
+            "def": 30,
+            "spa": 10,
+            "spd": 30,
+            "spe": -5,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "predicate": [
+              "forme:wash:active"
+            ],
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.fK1Auf8fdnd5qLCw",
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "predicate": [
+              "forme:wash:active"
+            ],
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.vXvFp7PqPkhPr0zX",
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "suppress-ability",
+            "predicate": [
+              "forme:wash:active"
+            ],
+            "key": "phantom-devicer",
+            "value": 0,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-species.Item.gptW2VMUw2eUT7LX.ActiveEffect.IysB8fpGpr6VmGwE",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": 1739630505039,
+        "modifiedTime": 1739634808747,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    },
+    {
+      "name": "Mow",
+      "type": "form",
+      "_id": "bZ4HSfCMx6yX3zus",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mow:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mow Forme",
+            "predicate": [],
+            "alwaysActive": false,
+            "count": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "state": false
+          },
+          {
+            "type": "stats-alteration",
+            "predicate": [
+              "forme:mow:active"
+            ],
+            "key": "",
+            "value": 0,
+            "hp": null,
+            "atk": 15,
+            "def": 30,
+            "spa": 10,
+            "spd": 30,
+            "spe": -5,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "suppress-ability",
+            "predicate": [
+              "forme:mow:active"
+            ],
+            "key": "phantom-devicer",
+            "value": 0,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "predicate": [
+              "forme:mow:active"
+            ],
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.vXvFp7PqPkhPr0zX",
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "predicate": [
+              "forme:mow:active"
+            ],
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.KAJo4ac23wQ6dkac",
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": 1739630514422,
+        "modifiedTime": 1739634910754,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    },
+    {
+      "name": "Heat",
+      "type": "form",
+      "_id": "W3GdrCAUOVjG8Hfn",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:heat:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Heat Forme",
+            "predicate": [],
+            "alwaysActive": false,
+            "count": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "state": false
+          },
+          {
+            "type": "stats-alteration",
+            "predicate": [
+              "forme:heat:active"
+            ],
+            "key": "",
+            "value": 0,
+            "hp": null,
+            "atk": 15,
+            "def": 30,
+            "spa": 10,
+            "spd": 30,
+            "spe": -5,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "suppress-ability",
+            "predicate": [
+              "forme:heat:active"
+            ],
+            "key": "phantom-devicer",
+            "value": 0,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "predicate": [
+              "forme:heat:active"
+            ],
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.1YuSHdlx3r8g5RJ3",
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "predicate": [
+              "forme:heat:active"
+            ],
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.vXvFp7PqPkhPr0zX",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": 1739630523926,
+        "modifiedTime": 1739635089921,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
We should be able to delete the surplus Rotom dex entries now.
- Update Ability: Foretold
- Update Ability: Heavy Metal
- Update Ability: Phantom Devicer
- Update Species: rotom