### PR TITLE
Foundry Data Sync - Evo Items part 2

### DIFF
--- a/packs/core-gear/electirizer.json
+++ b/packs/core-gear/electirizer.json
@@ -1,0 +1,120 @@
+{
+  "folder": "V4skAU6G3OH5fXad",
+  "name": "Electirizer",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "slug": "electirizer",
+    "traits": [
+      "combat",
+      "type",
+      "dragon",
+      "evolution",
+      "elekid",
+      "electabuzz",
+      "electivire"
+    ],
+    "actions": [],
+    "description": "<p><span style=\"font-family: bp_gender, sans-serif\">A box packed with a tremendous amount of electric energy that boosts the power of Electric-type moves. It's loved by a certain Pokémon.</span></p><p></p><p><span style=\"font-family: Signika, sans-serif\">Effect: Increases the Power and Accuracy of attacks by 10%</span></p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "accessory"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "electric",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [
+    {
+      "name": "Type Booster (Dragon)",
+      "type": "passive",
+      "_id": "Q6zn9sod4O2yqmp1",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "dragon-attack-power",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Dragon) Power",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "dragon-attack-accuracy",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Dragon)",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "zQRQn1X9bw5xOApv"
+}

--- a/packs/core-gear/kings-rock.json
+++ b/packs/core-gear/kings-rock.json
@@ -1,0 +1,118 @@
+{
+  "folder": "V4skAU6G3OH5fXad",
+  "name": "King's Rock",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "slug": "kings-rock",
+    "traits": [
+      "combat",
+      "evolution",
+      "slowpoke",
+      "slowking"
+    ],
+    "actions": [],
+    "description": "<p><span style=\"font-family: bp_gender, sans-serif\">An item to be held by a Pokémon. It may cause the target to flinch whenever the holder successfully inflicts damage on them with an attack.<br><br>Effect: 10% Flinch chance with contact moves, 40% Flinch</span></p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "accessory"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "rock",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [
+    {
+      "name": "Flinch Chance",
+      "type": "passive",
+      "_id": "BJ3qkYo6TQo4dnDw",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "contact-traits-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -40
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinched 40%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.3KCZGRV9lMmb44FC.ActiveEffect.uM9lEbJS6Ee0AHd9",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "gczzcqNALLAAN5wi"
+}

--- a/packs/core-gear/magmarizer.json
+++ b/packs/core-gear/magmarizer.json
@@ -1,0 +1,120 @@
+{
+  "folder": "V4skAU6G3OH5fXad",
+  "name": "Magmarizer",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "slug": "magmarizer",
+    "traits": [
+      "combat",
+      "type",
+      "fire",
+      "evolution",
+      "magbi",
+      "magmar",
+      "magmortor"
+    ],
+    "actions": [],
+    "description": "<p>A box packed with a tremendous amount of magma energy that boosts the power of Fire-type moves. It's loved by a certain Pokémon.<br><br><span style=\"font-family: Signika, sans-serif\">Effect: Increases the Power and Accuracy of attacks by 10%.</span></p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "accessory"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "fire",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [
+    {
+      "name": "Type Booster (Fire)",
+      "type": "passive",
+      "_id": "VyowOF7JzAYbZCSP",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "fire-attack-power",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Fire) Power",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "fire-attack-accuracy",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Fire)",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "z2tpg5PbD7FYa9BD"
+}

--- a/packs/core-gear/metal-coat.json
+++ b/packs/core-gear/metal-coat.json
@@ -1,0 +1,117 @@
+{
+  "folder": "V4skAU6G3OH5fXad",
+  "name": "Metal Coat",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "slug": "metal-coat",
+    "traits": [
+      "combat",
+      "type",
+      "steel",
+      "evolution"
+    ],
+    "actions": [],
+    "description": "<p><span style=\"font-family: bp_gender, sans-serif\">An item to be held by a Pokémon. It's a special metallic coating that boosts the power of the holder's Steel-type moves.</span></p><p></p><p>Effect: <span style=\"font-family: Signika, sans-serif\">Increases the Power and Accuracy of attacks by 10%.</span></p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "accessory"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "steel",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [
+    {
+      "name": "Type Booster (Steel)",
+      "type": "passive",
+      "_id": "vKlTSnMarPKjXCOW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "steel-attack-power",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Steel) Power",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "steel-attack-accuracy",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Steel)",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "YMXWN09sEo9uEsAi"
+}

--- a/packs/core-gear/oval-stone.json
+++ b/packs/core-gear/oval-stone.json
@@ -1,0 +1,120 @@
+{
+  "folder": "V4skAU6G3OH5fXad",
+  "name": "Oval Stone",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "slug": "oval-stone",
+    "traits": [
+      "combat",
+      "type",
+      "normal",
+      "evolution",
+      "happiny",
+      "chancey",
+      "blissey"
+    ],
+    "actions": [],
+    "description": "<p><span style=\"font-family: bp_gender, sans-serif\">A peculiar stone that can make a certain species of Pokémon evolve. It is round and smooth, boosting the power of Normal-type moves.</span></p><p></p><p><span style=\"font-family: Signika, sans-serif\">Effect: Increases the Power and Accuracy of attacks by 10%</span></p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "accessory"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [
+    {
+      "name": "Type Booster (Normal)",
+      "type": "passive",
+      "_id": "G6DCgSb3io2sh1fO",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "normal-attack-power",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Normal) Power",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "normal-attack-accuracy",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Normal)",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "7Z3vDgjEyOCWlrlX"
+}

--- a/packs/core-gear/prism-scale.json
+++ b/packs/core-gear/prism-scale.json
@@ -1,0 +1,119 @@
+{
+  "folder": "V4skAU6G3OH5fXad",
+  "name": "Prism Scale",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "slug": "prism-scale",
+    "traits": [
+      "combat",
+      "type",
+      "water",
+      "evolution",
+      "feebas",
+      "milotic"
+    ],
+    "actions": [],
+    "description": "<p><span style=\"font-family: bp_gender, sans-serif\">A mysterious scale that causes a certain Pokémon to evolve. It shines in rainbow colors that boosts the power of Water-Type Moves.</span></p><p></p><p><span style=\"font-family: Signika, sans-serif\">Effect: Increases the Power and Accuracy of attacks by 10%.</span></p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "accessory"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "water",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [
+    {
+      "name": "Type Booster (Water)",
+      "type": "passive",
+      "_id": "9U95e4Y9D4XkQT5N",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "water-attack-power",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Water) Power",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "water-attack-accuracy",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Water)",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "LrsTWZAslsQeuiJb"
+}

--- a/packs/core-gear/protector.json
+++ b/packs/core-gear/protector.json
@@ -1,0 +1,119 @@
+{
+  "folder": "V4skAU6G3OH5fXad",
+  "name": "Protector",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "slug": "protector",
+    "traits": [
+      "combat",
+      "type",
+      "rock",
+      "evolution",
+      "rhyhorn",
+      "rhyperior"
+    ],
+    "actions": [],
+    "description": "<p><span style=\"font-family: bp_gender, sans-serif\">A protective item of some sort. It is extremely stiff and heavy that boosts the power of Rock-Type moves. It's loved by a certain Pokémon.</span></p><p></p><p><span style=\"font-family: Signika, sans-serif\">Effect: Increases the Power and Accuracy of attacks by 10%.</span></p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "accessory"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "rock",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [
+    {
+      "name": "Type Booster (Rock)",
+      "type": "passive",
+      "_id": "ZDRTTaPk89qWotn5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "rock-attack-power",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Rock) Power",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "rock-attack-accuracy",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Rock)",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "HCte0tv6rdpKecWM"
+}

--- a/packs/core-gear/reaper-cloth.json
+++ b/packs/core-gear/reaper-cloth.json
@@ -1,0 +1,120 @@
+{
+  "folder": "V4skAU6G3OH5fXad",
+  "name": "Reaper Cloth",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "slug": "reaper-cloth",
+    "traits": [
+      "combat",
+      "type",
+      "ghost",
+      "evolution",
+      "duskull",
+      "dusclops",
+      "dusknoir"
+    ],
+    "actions": [],
+    "description": "<p><span style=\"font-family: bp_gender, sans-serif\">A cloth imbued with horrifyingly strong spiritual energy that boosts the power of Ghost-type moves. It's loved by a certain Pokémon.<br><br></span><span style=\"font-family: Signika, sans-serif\">Effect: Increases the Power and Accuracy of attacks by 10%.</span></p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "accessory"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "ghost",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [
+    {
+      "name": "Type Booster (Ghost)",
+      "type": "passive",
+      "_id": "1SH2PhGFeK52Umuv",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "ghost-attack-power",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Ghost) Power",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "ghost-attack-accuracy",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Ghost)",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "L0OlExGenlDjF0Ft"
+}

--- a/packs/core-gear/sachet.json
+++ b/packs/core-gear/sachet.json
@@ -1,0 +1,119 @@
+{
+  "folder": "V4skAU6G3OH5fXad",
+  "name": "Sachet",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "slug": "sachet",
+    "traits": [
+      "combat",
+      "type",
+      "fairy",
+      "evolution",
+      "spritzee",
+      "aromatisse"
+    ],
+    "actions": [],
+    "description": "<p><span style=\"font-family: bp_gender, sans-serif\">A sachet filled with fragrant perfumes that are just slightly overwhelming That boosts the power of Fairy-type moves. Yet it's loved by a certain Pokémon.</span></p><p></p><p><span style=\"font-family: Signika, sans-serif\">Effect: Increases the Power and Accuracy of attacks by 10%</span></p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "accessory"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "fairy",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [
+    {
+      "name": "Type Booster (Fairy)",
+      "type": "passive",
+      "_id": "TGoTjawzLutdvVCF",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "fairy-attack-power",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Fairy) Power",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "fairy-attack-accuracy",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Fairy)",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "AddZ0pPHBStJ19Qb"
+}

--- a/packs/core-gear/whipped-dream.json
+++ b/packs/core-gear/whipped-dream.json
@@ -1,0 +1,112 @@
+{
+  "folder": "V4skAU6G3OH5fXad",
+  "name": "Whipped Dream",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "slug": "whipped-dream",
+    "traits": [],
+    "actions": [],
+    "description": "<p><span style=\"font-family: bp_gender, sans-serif\">A soft and sweet treat made of fluffy, puffy, whipped, and whirled cream that boosts the power of Fairy-type moves. It's loved by a certain Pokémon.</span></p><p></p><p><span style=\"font-family: Signika, sans-serif\">Effect: Increases the Power and Accuracy of attacks by 10%.</span></p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "accessory"
+    },
+    "grade": "C",
+    "fling": {
+      "type": "fairy",
+      "power": 70,
+      "accuracy": 100,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [
+    {
+      "name": "Type Booster (Fairy)",
+      "type": "passive",
+      "_id": "TxXTntfh3SMv8nsi",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "fairy-attack-power",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Fairy) Power",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "fairy-attack-accuracy",
+            "value": 10,
+            "predicate": [],
+            "label": "Type Booster (Fairy)",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.3.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "PAp00fGGTK3wL303"
+}


### PR DESCRIPTION
The later half of the Evo items.
- Update Equipment: Electirizer
- Update Equipment: King's Rock
- Update Equipment: Magmarizer
- Update Equipment: Metal Coat
- Update Equipment: Oval Stone
- Update Equipment: Prism Scale
- Update Equipment: Protector
- Update Equipment: Reaper Cloth
- Update Equipment: Sachet
- Update Equipment: Whipped Dream