### PR TITLE
Foundry Data Sync - Calyrex Rework (Partial)

### DIFF
--- a/packs/core-abilities/as-one.json
+++ b/packs/core-abilities/as-one.json
@@ -37,5 +37,75 @@
     }
   },
   "_id": "d9KdCsnQsW8pZrJS",
-  "effects": []
+  "effects": [
+    {
+      "name": "As One (Extra Ability)",
+      "type": "passive",
+      "_id": "otfKaCGxMWBKDLDg",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.tETlM9WcIzcdJPG3",
+            "predicate": [
+              "item:ability:as-one:active"
+            ],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "reevaluateOnUpdate": true,
+            "allowDuplicate": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Item.NBmCkMbE24J7xDD3.ActiveEffect.YmxvbMk38NztOIAT",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.6.beta",
+        "createdTime": 1739813558192,
+        "modifiedTime": 1739813558192,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/chilling-neigh.json
+++ b/packs/core-abilities/chilling-neigh.json
@@ -24,7 +24,6 @@
         "description": "<p>Trigger: The user causes at least one creature to gain @Affliction[fainted].</p><p>Effect: The user's ATK Stage is increased by +1 for 7 Activations.</p>",
         "img": "icons/svg/explosion.svg"
       },
-      
       {
         "traits": [
           "legendary"
@@ -34,7 +33,6 @@
         "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 0,
           "trigger": "<p>The user possesses the effect Calyrex Rider.</p>"
         },
         "range": {
@@ -45,7 +43,7 @@
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Trigger: The user causes at least one creature to gain @Affliction[fainted]</p><p>Effect: The user's ATK Stage is increased by +1 for 5 Activations.</p><p>Passive: If the user has the effect Calyrex Rider, the user gains Connection - Glacial Lance and takes 33% less damage from Special-Category Attacks.</p>",
+    "description": "<p>Trigger: The user causes at least one creature to gain @Affliction[fainted]</p><p>Effect: The user's ATK Stage is increased by +1 for 7 Activations.</p><p>Passive: If the user has the effect Calyrex Rider, the user gains Connection - Glacial Lance and takes 33% less damage from Special-Category Attacks.</p>",
     "traits": [
       "legendary"
     ],
@@ -56,5 +54,73 @@
     }
   },
   "_id": "Y6uBelrwgxzHQMkY",
-  "effects": []
+  "effects": [
+    {
+      "name": "Glacial Lance",
+      "type": "passive",
+      "_id": "sNNhUcJIjygHHBiF",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.VWtxhdUlCpAZ7pvr",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Item.5TPjCjAsFMgdFVSR.ActiveEffect.X2J9s78aixergPau",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.6.beta",
+        "createdTime": 1739813701982,
+        "modifiedTime": 1739813701982,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/grim-neigh.json
+++ b/packs/core-abilities/grim-neigh.json
@@ -33,7 +33,6 @@
         "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 0,
           "trigger": "<p>The user possesses the effect Calyrex Rider.</p>"
         },
         "range": {
@@ -44,7 +43,7 @@
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Trigger: The user causes at least one creature to gain @Affliction[fainted]</p><p>Effect: The user's SPATK Stage is increased by +1 for 5 Activations.</p><p>Passive: If the user has the effect Calyrex Rider, the user gains Connection - Astral Barrage and takes 33% less damage from Physical-Category Attacks.</p>",
+    "description": "<p>Trigger: The user causes at least one creature to gain @Affliction[fainted]</p><p>Effect: The user's SPATK Stage is increased by +1 for 7 Activations.</p><p>Passive: If the user has the effect Calyrex Rider, the user gains Connection - Astral Barrage and takes 33% less damage from Physical-Category Attacks.</p>",
     "traits": [
       "legendary"
     ],
@@ -55,5 +54,75 @@
     }
   },
   "_id": "jTIQ6TM0ukEdbOn2",
-  "effects": []
+  "effects": [
+    {
+      "name": "Astral Barrage",
+      "type": "passive",
+      "_id": "uts4EMxaExNca14Z",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.DtnkomrT8bTf6rJD",
+            "predicate": [
+              "item:ability:grim-neigh:active"
+            ],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Item.TJP3L7FaIQ6vn30B.ActiveEffect.xj4dxM2LBRZi87fo",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.6.beta",
+        "createdTime": 1739813895724,
+        "modifiedTime": 1739813895724,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-effects/calyrex-rider.json
+++ b/packs/core-effects/calyrex-rider.json
@@ -1,0 +1,90 @@
+{
+  "name": "Calyrex Rider",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": null
+    },
+    "description": "<p>+20 Base ATK, DEF, SPATK, SPDEF, SPD</p><p>+40% to all Movements (minimum +2).</p><p>+15 to Skill Rolls.</p><p>Effect: The user gains Defend as One, Fight as One, and Intercept (Noble Steed).</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Cavalier.svg",
+  "effects": [
+    {
+      "name": "Calyrex Rider",
+      "type": "passive",
+      "_id": "6bXSWgYQgYizNH0O",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "stats-alteration",
+            "key": "",
+            "value": 0,
+            "predicate": [],
+            "hp": null,
+            "atk": 20,
+            "def": 20,
+            "spa": 20,
+            "spd": 20,
+            "spe": 20,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-option",
+            "key": "",
+            "value": "Ridden by Calyrex",
+            "predicate": [],
+            "domain": "all",
+            "label": "SKILL ROLLS",
+            "toggleable": true,
+            "count": false,
+            "alwaysActive": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "state": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.6.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "W27Z0zdJ3apwYcxv"
+}

--- a/packs/core-species/calyrex.json
+++ b/packs/core-species/calyrex.json
@@ -328,7 +328,13 @@
     "evolutions": {
       "name": "calyrex",
       "details": null,
-      "evolutions": []
+      "evolutions": [],
+      "uuid": null,
+      "methods": [],
+      "perk": {
+        "x": 26,
+        "y": 26
+      }
     },
     "number": 898,
     "slug": "calyrex",
@@ -388,8 +394,7 @@
           "value": 8
         }
       ],
-      "secondary": [
-      ]
+      "secondary": []
     },
     "skills": [
       {
@@ -570,10 +575,155 @@
       }
     ],
     "habitats": [],
-    "description": "",
-    "form": null
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "sBexkWdVdVfEWzQZ",
-  "effects": [],
-  "folder": null
+  "effects": [
+    {
+      "name": "Calyrex Rider",
+      "type": "form",
+      "_id": "VHxm9kTjAlTM7RCP",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:calyrex-rider:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Calyrex Rider Forme",
+            "predicate": [],
+            "alwaysActive": false,
+            "count": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "state": false
+          },
+          {
+            "type": "stats-alteration",
+            "predicate": [
+              "forme:calyrex-rider:active"
+            ],
+            "key": "",
+            "value": 0,
+            "hp": null,
+            "atk": 20,
+            "def": 20,
+            "spa": 20,
+            "spd": 20,
+            "spe": 20,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "predicate": [
+              "forme:calyrex-rider:active"
+            ],
+            "key": "system.skills.conversation.value",
+            "value": 30,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "predicate": [
+              "forme:calyrex-rider:active"
+            ],
+            "key": "system.skills.fast-talk.value",
+            "value": 30,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "predicate": [
+              "forme:calyrex-rider:active"
+            ],
+            "key": "system.skills.intimidation.value",
+            "value": 30,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "predicate": [
+              "forme:calyrex-rider:active"
+            ],
+            "key": "system.skills.leadership.value",
+            "value": 30,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "predicate": [
+              "forme:calyrex-rider:active"
+            ],
+            "key": "system.skills.negotiation.value",
+            "value": 30,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "predicate": [
+              "forme:calyrex-rider:active"
+            ],
+            "key": "system.skills.psychology.value",
+            "value": 30,
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Item.J3bH6UQ17HWilihs.ActiveEffect.ssmMqSbTuW7zlilk",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.6.beta",
+        "createdTime": 1739813576036,
+        "modifiedTime": 1739813614723,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Needs Defend As One, Fight As One, Intercept (Crowned King) and Intercept (Noble Steed) added after polish.
- Update Ability: As One
- Update Species: calyrex
- Update Effect: Calyrex Rider
- Update Ability: Chilling Neigh
- Update Ability: Grim Neigh