### PR TITLE
Foundry Data Sync - "Berries": Oran Berry

### DIFF
--- a/packs/core-gear/aguav-berry.json
+++ b/packs/core-gear/aguav-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The target gains 6 Ticks of HP. Confuses if the user dislikes Bitter flavors. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "aguav-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "jIWE3Y0JmtmQPUyf",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!jIWE3Y0JmtmQPUyf"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/apicot-berry.json
+++ b/packs/core-gear/apicot-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The user gains +1 SPDE Stage for 5 activations. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "apicot-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "8u2icZ5YVJB4DFiA",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!8u2icZ5YVJB4DFiA"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/aspear-berry.json
+++ b/packs/core-gear/aspear-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "Cures the user of @Affliction[frostbite] or @Affliction[frozen]. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "aspear-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "nzlMqzUk6Afe9Ssk",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!nzlMqzUk6Afe9Ssk"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/babiri-berry.json
+++ b/packs/core-gear/babiri-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "babiri-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "XlP1DiwMfrzTNIr4",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!XlP1DiwMfrzTNIr4"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/belue-berry.json
+++ b/packs/core-gear/belue-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 5 Ticks of HP, 3 Ticks of PP, and their Catch Rate increases by x16/5 / x5/16 for 5 Activations if they like/dislike Sour flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "belue-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "40z0yGMLiijLoaYJ",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!40z0yGMLiijLoaYJ"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/bluk-berry.json
+++ b/packs/core-gear/bluk-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain a Tick of HP, and their Catch Rate increases by x6/5 / x5/6 for 5 Activations if they like/dislike Dry flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "bluk-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "LnnGW1fEEVJxsw5c",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!LnnGW1fEEVJxsw5c"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/charti-berry.json
+++ b/packs/core-gear/charti-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "charti-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "T6uLY6UIPjrGkqav",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!T6uLY6UIPjrGkqav"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/cheri-berry.json
+++ b/packs/core-gear/cheri-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "Cures the user of @Affliction[paralysis]. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "cheri-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "q2DQxMFnIFAh0XpN",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!q2DQxMFnIFAh0XpN"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/chesto-berry.json
+++ b/packs/core-gear/chesto-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "Cures the user of @Affliction[drowsy] and @Affliction[nightmares]. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "chesto-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "2uospWDh632eLqr7",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!2uospWDh632eLqr7"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/chilan-berry.json
+++ b/packs/core-gear/chilan-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "chilan-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "xlotcdvvTK3uEs3I",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!xlotcdvvTK3uEs3I"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/chople-berry.json
+++ b/packs/core-gear/chople-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "chople-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "yiWwoOkFpSrpIGL0",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!yiWwoOkFpSrpIGL0"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/coba-berry.json
+++ b/packs/core-gear/coba-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "coba-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "P6I8qCYVvy55axUJ",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!P6I8qCYVvy55axUJ"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/colbur-berry.json
+++ b/packs/core-gear/colbur-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "colbur-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "NtPgbAmnn4ZcDpzD",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!NtPgbAmnn4ZcDpzD"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/cornn-berry.json
+++ b/packs/core-gear/cornn-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 3 Ticks of HP, 2 Ticks of PP, and their Catch Rate increases by x12/5 / x5/12 for 5 Activations if they like/dislike Dry flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "cornn-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "xv7Bqixv0OoHjBJt",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!xv7Bqixv0OoHjBJt"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/custap-berry.json
+++ b/packs/core-gear/custap-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The user gains +1 EVA Stage for 5 activations. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "custap-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "qy77STD1Hb92LqJn",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!qy77STD1Hb92LqJn"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/drash-berry.json
+++ b/packs/core-gear/drash-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -39,29 +40,14 @@
     ],
     "description": "Cures the user of @Affliction[Splinter]. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "drash-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "70AIKNJFvyAoVZvi",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!70AIKNJFvyAoVZvi"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/durin-berry.json
+++ b/packs/core-gear/durin-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 5 Ticks of HP, 3 Ticks of PP, and their Catch Rate increases by x16/5 / x5/16 for 5 Activations if they like/dislike Bitter flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "durin-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "AOaRCG5wCMFG5OfP",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!AOaRCG5wCMFG5OfP"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/enigma-berry.json
+++ b/packs/core-gear/enigma-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user heals 6 Ticks of HP, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "enigma-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "KvNesQefbFh983fo",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!KvNesQefbFh983fo"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/figy-berry.json
+++ b/packs/core-gear/figy-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The target gains 6 Ticks of HP. Confuses if the user dislikes Spicy flavors. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "figy-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "UVxaQB25eP6KZMTz",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!UVxaQB25eP6KZMTz"
+  "folder": "yR1GFstYOCdI2jOz"
 }


### PR DESCRIPTION
"Berries": Oran Berry
- Update Consumable: Aguav Berry
- Update Consumable: Apicot Berry
- Update Consumable: Aspear Berry
- Update Consumable: Babiri Berry
- Update Consumable: Belue Berry
- Update Consumable: Bluk Berry
- Update Consumable: Charti Berry
- Update Consumable: Cheri Berry
- Update Consumable: Chesto Berry
- Update Consumable: Chilan Berry
- Update Consumable: Chople Berry
- Update Consumable: Coba Berry
- Update Consumable: Colbur Berry
- Update Consumable: Cornn Berry
- Update Consumable: Custap Berry
- Update Consumable: Drash Berry
- Update Consumable: Durin Berry
- Update Consumable: Enigma Berry
- Update Consumable: Figy Berry