### PR TITLE
Foundry Data Sync - "Berries": Oran Berry

### DIFF
--- a/packs/core-gear/ganlon-berry.json
+++ b/packs/core-gear/ganlon-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The user gains +1 DEF Stage for 5 activations. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "ganlon-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "BMo3iYPBhyMkYXZQ",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!BMo3iYPBhyMkYXZQ"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/grepa-berry.json
+++ b/packs/core-gear/grepa-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 2 Ticks of HP, 1 Tick of PP, and their Catch Rate increases by x9/5 / x5/9 for 5 Activations if they like/dislike Sour flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "grepa-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "qcdpxjwQNdfqxka7",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!qcdpxjwQNdfqxka7"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/haban-berry.json
+++ b/packs/core-gear/haban-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "haban-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "DAoHAhHody6ivhzb",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!DAoHAhHody6ivhzb"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/hondew-berry.json
+++ b/packs/core-gear/hondew-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 2 Ticks of HP, 1 Tick of PP, and their Catch Rate increases by x9/5 / x5/9 for 5 Activations if they like/dislike Bitter flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "hondew-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "zRvjsc7yNwhVahuw",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!zRvjsc7yNwhVahuw"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/hopo-berry.json
+++ b/packs/core-gear/hopo-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -39,29 +40,14 @@
     ],
     "description": "The target is healed 5 Ticks of PP, but has the default Stage of one of its stats (randomly determined) decrease by -1 until they Take a Rest.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "hopo-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "PyfMOQBXiL0NexN5",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!PyfMOQBXiL0NexN5"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/iapapa-berry.json
+++ b/packs/core-gear/iapapa-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The target gains 6 Ticks of HP. Confuses if the user dislikes Sour flavors. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "iapapa-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "a82FfmY6QzBfO6Km",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!a82FfmY6QzBfO6Km"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/jaboca-berry.json
+++ b/packs/core-gear/jaboca-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The attacking creature loses 3 Ticks of HP, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "jaboca-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "GS4iA0Bz19Mab6Zg",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!GS4iA0Bz19Mab6Zg"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/kasib-berry.json
+++ b/packs/core-gear/kasib-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "kasib-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "SVXPanTTNZzSnRyy",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!SVXPanTTNZzSnRyy"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/kebia-berry.json
+++ b/packs/core-gear/kebia-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "kebia-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "4HuJ3JVRJr9D8Rqy",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!4HuJ3JVRJr9D8Rqy"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/kee-berry.json
+++ b/packs/core-gear/kee-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -39,29 +40,14 @@
     ],
     "description": "The user gains +2 DEF Stages for 5 activations, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "kee-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "LYDa6xK9rhu0MNdT",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!LYDa6xK9rhu0MNdT"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/kelpsy-berry.json
+++ b/packs/core-gear/kelpsy-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 2 Ticks of HP, 1 Tick of PP, and their Catch Rate increases by x9/5 / x5/9 for 5 Activations if they like/dislike Dry flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "kelpsy-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "CUvZOjfsJ1bJ4ihj",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!CUvZOjfsJ1bJ4ihj"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/lansat-berry.json
+++ b/packs/core-gear/lansat-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -40,29 +41,14 @@
     ],
     "description": "The user gains +1 CRIT Stage for 5 activations. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "lansat-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "AgCXb9WF6mj9Lgmk",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!AgCXb9WF6mj9Lgmk"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/leppa-berry.json
+++ b/packs/core-gear/leppa-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -39,29 +40,14 @@
     ],
     "description": "The target is healed 4 Ticks of PP. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "leppa-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "H2bGU0vljpYpu8SB",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!H2bGU0vljpYpu8SB"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/liechi-berry.json
+++ b/packs/core-gear/liechi-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The user gains +1 ATK Stage for 5 activations. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "liechi-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "cRVqzmRmUOyuyVdU",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!cRVqzmRmUOyuyVdU"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/lum-berry.json
+++ b/packs/core-gear/lum-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -39,29 +40,14 @@
     ],
     "description": "The target is cured of up to 2 Major Status Afflictions and 2 Minor Status Afflictions they are afflicted with. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "lum-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "GAGSGXZdnlh8FseY",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!GAGSGXZdnlh8FseY"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/mago-berry.json
+++ b/packs/core-gear/mago-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The target gains 6 Ticks of HP. Confuses if the user dislikes Sweet flavors. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "mago-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "89a9H3ZSJ58wr2Ue",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!89a9H3ZSJ58wr2Ue"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/magost-berry.json
+++ b/packs/core-gear/magost-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 3 Ticks of HP, 2 Ticks of PP, and their Catch Rate increases by x12/5 / x5/12 for 5 Activations if they like/dislike Sweet flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "magost-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "AkM8tNdnLMxIj7XY",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!AkM8tNdnLMxIj7XY"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/maranga-berry.json
+++ b/packs/core-gear/maranga-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -39,29 +40,14 @@
     ],
     "description": "The user gains +2 SPDEF Stages for 5 activations, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "maranga-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "2bEeZsyg1BAGfth1",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!2bEeZsyg1BAGfth1"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/micle-berry.json
+++ b/packs/core-gear/micle-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The user gains +1 ACC Stage for 5 activations. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "micle-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "X4OhzjHGUawf3EZe",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!X4OhzjHGUawf3EZe"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/nanab-berry.json
+++ b/packs/core-gear/nanab-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain a Tick of HP, and their Catch Rate increases by x6/5 / x5/6 for 5 Activations if they like/dislike Sweet flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "nanab-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "tF0MJziXD3389kR0",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!tF0MJziXD3389kR0"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/nomel-berry.json
+++ b/packs/core-gear/nomel-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 3 Ticks of HP, 2 Ticks of PP, and their Catch Rate increases by x12/5 / x5/12 for 5 Activations if they like/dislike Sour flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "nomel-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "oVZnPq9eTYp6j7u5",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!oVZnPq9eTYp6j7u5"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/occa-berry.json
+++ b/packs/core-gear/occa-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "occa-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "RVQf1Fl35rUY5N3U",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!RVQf1Fl35rUY5N3U"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/pamtre-berry.json
+++ b/packs/core-gear/pamtre-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 5 Ticks of HP, 3 Ticks of PP, and their Catch Rate increases by x16/5 / x5/16 for 5 Activations if they like/dislike Dry flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "pamtre-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "4HL6QyIjQW71hztX",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!4HL6QyIjQW71hztX"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/passho-berry.json
+++ b/packs/core-gear/passho-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "passho-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "ul1erx6YRkYPLtMk",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!ul1erx6YRkYPLtMk"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/payapa-berry.json
+++ b/packs/core-gear/payapa-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "payapa-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "qkKGsSBT0vaKNRFh",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!qkKGsSBT0vaKNRFh"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/pecha-berry.json
+++ b/packs/core-gear/pecha-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "Cures the user of @Affliction[poison] and @Affliction[blight]. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "pecha-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "70AIKNJFvyAoVZvz",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!70AIKNJFvyAoVZvz"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/persim-berry.json
+++ b/packs/core-gear/persim-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -39,29 +40,14 @@
     ],
     "description": "The target is cured of one Minor Status Affliction they are afflicted with. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "persim-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "uI3C626Yaci1DrN1",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!uI3C626Yaci1DrN1"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/petaya-berry.json
+++ b/packs/core-gear/petaya-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The user gains +1 SPDEF Stage for 5 activations. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "petaya-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "E0dXWodJh0xRSjQu",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!E0dXWodJh0xRSjQu"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/pinap-berry.json
+++ b/packs/core-gear/pinap-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain a Tick of HP, and their Catch Rate increases by x6/5 / x5/6 for 5 Activations if they like/dislike Sour flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "pinap-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "NTbaqUUmwxgQadmS",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!NTbaqUUmwxgQadmS"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/pomeg-berry.json
+++ b/packs/core-gear/pomeg-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 2 Ticks of HP, 1 Tick of PP, and their Catch Rate increases by x9/5 / x5/9 for 5 Activations if they like/dislike Spicy flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "pomeg-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "EKURIXwLcQFwpts1",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!EKURIXwLcQFwpts1"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/qualot-berry.json
+++ b/packs/core-gear/qualot-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 2 Ticks of HP, 1 Tick of PP, and their Catch Rate increases by x9/5 / x5/9 for 5 Activations if they like/dislike Sweet flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "qualot-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "jBxGeYIfeRqE7uMO",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!jBxGeYIfeRqE7uMO"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/rabuta-berry.json
+++ b/packs/core-gear/rabuta-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 3 Ticks of HP, 2 Ticks of PP, and their Catch Rate increases by x12/5 / x5/12 for 5 Activations if they like/dislike Bitter flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "rabuta-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "N2zmIQM1Nl6ofRXt",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!N2zmIQM1Nl6ofRXt"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/rawst-berry.json
+++ b/packs/core-gear/rawst-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "Cures the user of @Affliction[burn]. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "rawst-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "t9oYztMdUAivTdua",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!t9oYztMdUAivTdua"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/razz-berry.json
+++ b/packs/core-gear/razz-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain a Tick of HP, and their Catch Rate increases by x6/5 / x5/6 for 5 Activations if they like/dislike Spicy flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "razz-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "5zfpCV88CwOagoCL",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!5zfpCV88CwOagoCL"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/rindo-berry.json
+++ b/packs/core-gear/rindo-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "rindo-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "xtzkOeUV6Fo42oP7",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!xtzkOeUV6Fo42oP7"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/roseli-berry.json
+++ b/packs/core-gear/roseli-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "roseli-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "8k5BQyVwhmDN7N72",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!8k5BQyVwhmDN7N72"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/rowap-berry.json
+++ b/packs/core-gear/rowap-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The attacking creature loses 3 Ticks of HP, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "rowap-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "7CLZT8S6daXtsS7J",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!7CLZT8S6daXtsS7J"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/salac-berry.json
+++ b/packs/core-gear/salac-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The user gains +1 SPATK Stage for 5 activations. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "salac-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "PVZ8is0aaXCXhmYT",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!PVZ8is0aaXCXhmYT"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/shuca-berry.json
+++ b/packs/core-gear/shuca-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "shuca-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "X16RODTgAxvxymZK",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!X16RODTgAxvxymZK"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/sitrus-berry.json
+++ b/packs/core-gear/sitrus-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -39,29 +40,14 @@
     ],
     "description": "The target is healed 5 Ticks of HP. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "sitrus-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "eNRpYkCQ9hgunONI",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!eNRpYkCQ9hgunONI"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/spelon-berry.json
+++ b/packs/core-gear/spelon-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 5 Ticks of HP, 3 Ticks of PP, and their Catch Rate increases by x16/5 / x5/16 for 5 Activations if they like/dislike Spicy flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "spelon-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "yUGP8r2a0eSKlri8",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!yUGP8r2a0eSKlri8"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/starf-berry.json
+++ b/packs/core-gear/starf-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -40,29 +41,14 @@
     ],
     "description": "The user gains +2 Stages to a random stat for 5 activations. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "starf-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "eWW0mVS00HC61ryj",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!eWW0mVS00HC61ryj"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/tamato-berry.json
+++ b/packs/core-gear/tamato-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 3 Ticks of HP, 2 Ticks of PP, and their Catch Rate increases by x9/5 / x5/9 for 5 Activations if they like/dislike Spicy flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "tamato-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "J325rDUvkQz2ALFq",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!J325rDUvkQz2ALFq"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/tanga-berry.json
+++ b/packs/core-gear/tanga-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "tanga-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "dGzcZGYLr6sv0MR3",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!dGzcZGYLr6sv0MR3"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/wacan-berry.json
+++ b/packs/core-gear/wacan-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "wacan-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "EdKtWQSfI5IRa0MV",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!EdKtWQSfI5IRa0MV"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/watmel-berry.json
+++ b/packs/core-gear/watmel-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "food",
@@ -38,29 +39,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain 5 Ticks of HP, 3 Ticks of PP, and their Catch Rate increases by x16/5 / x5/16 for 5 Activations if they like/dislike Sweet flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "watmel-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "5EjVPXsWj8pW30w1",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!5EjVPXsWj8pW30w1"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/wepear-berry.json
+++ b/packs/core-gear/wepear-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -37,29 +38,14 @@
     ],
     "description": "The target gains 1 Tick of HP. If the target does not possess [Human] or [Ace], they also gain a Tick of HP, and their Catch Rate increases by x6/5 / x5/6 for 5 Activations if they like/dislike Bitter flavors.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "wepear-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "oo1tVuEzKgTsaqJr",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!oo1tVuEzKgTsaqJr"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/wiki-berry.json
+++ b/packs/core-gear/wiki-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The target gains 6 Ticks of HP. Confuses if the user dislikes Dry flavors. This item can be consumed as a Free Action if the user meets the Desperation threshold.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "wiki-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "UJdewDk0TNd20VgM",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!UJdewDk0TNd20VgM"
+  "folder": "yR1GFstYOCdI2jOz"
 }

--- a/packs/core-gear/yache-berry.json
+++ b/packs/core-gear/yache-berry.json
@@ -18,7 +18,8 @@
     "fling": {
       "type": "untyped",
       "power": 10,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "food",
@@ -36,29 +37,14 @@
     ],
     "description": "The user takes 33% less damage from the triggering attack or effect, consuming the item as a Free Action.",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
-    "stack": 1
+    "slug": "yache-berry",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "61DaH8mg4RDcFMUB",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!61DaH8mg4RDcFMUB"
+  "folder": "yR1GFstYOCdI2jOz"
 }


### PR DESCRIPTION
"Berries": Oran Berry
- Update Consumable: Ganlon Berry
- Update Consumable: Grepa Berry
- Update Consumable: Haban Berry
- Update Consumable: Hondew Berry
- Update Consumable: Hopo Berry
- Update Consumable: Iapapa Berry
- Update Consumable: Jaboca Berry
- Update Consumable: Kasib Berry
- Update Consumable: Kebia Berry
- Update Consumable: Kee Berry
- Update Consumable: Kelpsy Berry
- Update Consumable: Lansat Berry
- Update Consumable: Leppa Berry
- Update Consumable: Liechi Berry
- Update Consumable: Lum Berry
- Update Consumable: Mago Berry
- Update Consumable: Magost Berry
- Update Consumable: Maranga Berry
- Update Consumable: Micle Berry
- Update Consumable: Nanab Berry
- Update Consumable: Nomel Berry
- Update Consumable: Occa Berry
- Update Consumable: Passho Berry
- Update Consumable: Pamtre Berry
- Update Consumable: Payapa Berry
- Update Consumable: Pecha Berry
- Update Consumable: Persim Berry
- Update Consumable: Petaya Berry
- Update Consumable: Pinap Berry
- Update Consumable: Pomeg Berry
- Update Consumable: Qualot Berry
- Update Consumable: Rabuta Berry
- Update Consumable: Rawst Berry
- Update Consumable: Razz Berry
- Update Consumable: Rindo Berry
- Update Consumable: Roseli Berry
- Update Consumable: Rowap Berry
- Update Consumable: Salac Berry
- Update Consumable: Shuca Berry
- Update Consumable: Sitrus Berry
- Update Consumable: Spelon Berry
- Update Consumable: Starf Berry
- Update Consumable: Tamato Berry
- Update Consumable: Tanga Berry
- Update Consumable: Wacan Berry
- Update Consumable: Watmel Berry
- Update Consumable: Wepear Berry
- Update Consumable: Wiki Berry
- Update Consumable: Yache Berry