### PR TITLE
Foundry Data Sync - "Poké Balls": Basic Ball

### DIFF
--- a/packs/core-gear/air-ball.json
+++ b/packs/core-gear/air-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "4x Catch Rate modifier if used on a Flying- or Ice-Type creature. 1x Catch Rate modifier otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "air-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Y1dSMzWwPG9gKM6v",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!Y1dSMzWwPG9gKM6v"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/basic-ball.json
+++ b/packs/core-gear/basic-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -33,28 +34,14 @@
     "description": "A basic PokeBall for capturing Pokemon. Gives no bonuses on capture checks.",
     "modifier": 1,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "basic-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "RmxpPT0msnrx1mv4",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!RmxpPT0msnrx1mv4"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/beacon-ball.json
+++ b/packs/core-gear/beacon-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "5x Catch Rate modifier with Foggy Weather present. 2.5x Catch Rate modifier if only natural fog is present. 1x Catch Rate modifier otherwise.",
     "modifier": 2.5,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "beacon-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "JBPkoTh8GFAL1u3P",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!JBPkoTh8GFAL1u3P"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/beast-ball.json
+++ b/packs/core-gear/beast-ball.json
@@ -3,7 +3,6 @@
   "img": "systems/ptr2e/img/item-icons/beast ball.webp",
   "type": "consumable",
   "system": {
-    "cost": null,
     "crafting": {
       "skill": "electronics",
       "spans": 10,
@@ -21,7 +20,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "rare",
     "consumableType": "pokeball",
@@ -33,28 +33,14 @@
     "description": "12x Catch Rate modifer if used on a [Ultra Beast] creature. 1x Catch Rate modifer otherwise.",
     "modifier": 12,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "beast-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "iEBm80ZVOLR1CiKc",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!iEBm80ZVOLR1CiKc"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/boost-ball.json
+++ b/packs/core-gear/boost-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "1x Catch Rate modifier. Upon capture, creature gains double the total amount of EXP required to advance from its current level to the next.",
     "modifier": 1,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "boost-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "r9HVD7XBp9Bg3W60",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!r9HVD7XBp9Bg3W60"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/cherish-ball.json
+++ b/packs/core-gear/cherish-ball.json
@@ -3,7 +3,6 @@
   "img": "systems/ptr2e/img/item-icons/cherish ball.webp",
   "type": "consumable",
   "system": {
-    "cost": null,
     "crafting": {
       "skill": null,
       "spans": null,
@@ -18,7 +17,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "unique",
     "consumableType": "pokeball",
@@ -30,28 +30,14 @@
     "description": "A fancy, eye-catching ball given out during promotional events. Gives no bonuses on capture checks.",
     "modifier": 1,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "cherish-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "tTsIjyrNL20afchW",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!tTsIjyrNL20afchW"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/coolant-ball.json
+++ b/packs/core-gear/coolant-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "rare",
     "consumableType": "pokeball",
@@ -35,28 +36,14 @@
     "description": "4x Catch Rate modifier on a Nuclear-Type creature, plus 5x Catch Rate with Glowy Weather present. 1x Catch Rate modifer otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "coolant-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "ilpg3PzmA3HCvVzq",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!ilpg3PzmA3HCvVzq"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/dark-ball.json
+++ b/packs/core-gear/dark-ball.json
@@ -3,7 +3,6 @@
   "img": "systems/ptr2e/img/item-icons/dark_ball.webp",
   "type": "consumable",
   "system": {
-    "cost": null,
     "crafting": {
       "skill": "electronics",
       "spans": 2,
@@ -21,7 +20,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "rare",
     "consumableType": "pokeball",
@@ -33,28 +33,14 @@
     "description": "8x Catch Rate modifer if used on a [Shadow Pokemon] creature. 1x Catch Rate modifer otherwise.",
     "modifier": 8,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "dark-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "rLHED5VHbPkaEqrw",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!rLHED5VHbPkaEqrw"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/dive-ball.json
+++ b/packs/core-gear/dive-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "8x Catch Rate modifer if used on a target that is Swimming. 1x Catch Rate modifer otherwise. This Ball can target creatures 4m underwater from the user.",
     "modifier": 8,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "dive-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "1RAmn9H3LSZCk4X2",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!1RAmn9H3LSZCk4X2"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/dream-ball.json
+++ b/packs/core-gear/dream-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "6x Catch Rate modifer if used on a target that has @Affliction[drowsy], @Affliction[nightmares], or is sleeping. 1x Catch Rate modifer otherwise.",
     "modifier": 6,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "dream-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "ECMaMJtCh6TyWCOl",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!ECMaMJtCh6TyWCOl"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/dusk-ball.json
+++ b/packs/core-gear/dusk-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "5x Catch Rate modifier with Gloomy Weather present. 2x Catch Rate modifier if it is only nighttime or otherwise dark. 1x Catch Rate modifier otherwise.",
     "modifier": 2,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "dusk-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Tf7l91f61dumDDyG",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!Tf7l91f61dumDDyG"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/earth-ball.json
+++ b/packs/core-gear/earth-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "4x Catch Rate modifier if used on a Grass- or Ground-Type creature. 1x Catch Rate modifier otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "earth-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "J0x8IYmTQtENBjCK",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!J0x8IYmTQtENBjCK"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/fast-ball.json
+++ b/packs/core-gear/fast-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "4x Catch Rate modifier if the target's base speed is greater than 100. 1x Catch Rate modifier otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "fast-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "8YGA6mOsuB2s0pIz",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!8YGA6mOsuB2s0pIz"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/feather-ball.json
+++ b/packs/core-gear/feather-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 100
+      "accuracy": 100,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -33,28 +34,14 @@
     "description": "1x Catch Rate modifier. Catch Rate modifier increases by +2x vs creatures that are in Flight.",
     "modifier": 3,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "feather-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "OshRvOSAkRGET7Au",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!OshRvOSAkRGET7Au"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/friend-ball.json
+++ b/packs/core-gear/friend-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "8x Catch Rate modifer if used on a target that has a Friendly Rapport or higher. 1x Catch Rate modifier otherwise.",
     "modifier": 8,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "friend-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "QXJ83W2hZ10Ouy9j",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!QXJ83W2hZ10Ouy9j"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/gigaton-ball.json
+++ b/packs/core-gear/gigaton-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 50,
-      "accuracy": 85
+      "accuracy": 85,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -33,28 +34,14 @@
     "description": "5x Catch Rate modifier.",
     "modifier": 5,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 3
+    "slug": "gigaton-ball",
+    "stack": 3,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "HC12vQhqD7gZ5hGc",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!HC12vQhqD7gZ5hGc"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/gossamer-ball.json
+++ b/packs/core-gear/gossamer-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "4x Catch Rate modifier if used on a Normal- or Fairy-Type creature. 1x Catch Rate modifier otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "gossamer-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "vtwlgqMb7fBvSdZw",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!vtwlgqMb7fBvSdZw"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/great-ball.json
+++ b/packs/core-gear/great-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -33,28 +34,14 @@
     "description": "1.75x Catch Rate modifier.",
     "modifier": 1.75,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "great-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "dQNf6C22Bxd2xSK0",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!dQNf6C22Bxd2xSK0"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/hail-ball.json
+++ b/packs/core-gear/hail-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "5x Catch Rate modifier with Snowy Weather present. 2.5x Catch Rate modifier if natural snowfall is present. 1x Catch Rate modifier otherwise.",
     "modifier": 2.5,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "hail-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "og6QFbXvO5aHdLHd",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!og6QFbXvO5aHdLHd"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/haunt-ball.json
+++ b/packs/core-gear/haunt-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "4x Catch Rate modifier if used on a Ghost- or Dark-Type creature. 1x Catch Rate modifier otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "haunt-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "azAEQjHVZjf4VcI3",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!azAEQjHVZjf4VcI3"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/heal-ball.json
+++ b/packs/core-gear/heal-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "1x Catch Rate modifier. Upon capture, heals the captured creature's HP, PP, and removes all of its Status Afflictions.",
     "modifier": 1,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "heal-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "4A4CPITprvVAVOkM",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!4A4CPITprvVAVOkM"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/heat-ball.json
+++ b/packs/core-gear/heat-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "4x Catch Rate modifier if used on a Fire- or Electric-Type creature. 1x Catch Rate modifier otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "heat-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "wR10qXM6v9rQ8sqq",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!wR10qXM6v9rQ8sqq"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/heavy-ball.json
+++ b/packs/core-gear/heavy-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "<p>0.75x Catch Rate modifier if used on a creature WC 7 or lower.c1x Catch Rate modifier on WC 8-9.<br>3x Catch Rate modifier on WC 9-11.<br>x5 Catch Rate modifier on WC 11-14.<br>x7 Catch Rate modifer on WC 15-16.</p>",
     "modifier": 0.75,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "heavy-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Rjl9DyuksMUjeXkB",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!Rjl9DyuksMUjeXkB"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/hefty-ball.json
+++ b/packs/core-gear/hefty-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 40,
-      "accuracy": 85
+      "accuracy": 85,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -33,28 +34,14 @@
     "description": "2x Catch Rate modifier.",
     "modifier": 2,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 3
+    "slug": "hefty-ball",
+    "stack": 3,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "79EKurPbRzXPOCR5",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!79EKurPbRzXPOCR5"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/jet-ball.json
+++ b/packs/core-gear/jet-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 100
+      "accuracy": 100,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -33,28 +34,14 @@
     "description": "2.5x Catch Rate modifier. Catch Rate modifier increases by +2.5x vs creatures that are in Flight.",
     "modifier": 5,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "jet-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "g74RkfDpUI6xZAy7",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!g74RkfDpUI6xZAy7"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/leaden-ball.json
+++ b/packs/core-gear/leaden-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 45,
-      "accuracy": 85
+      "accuracy": 85,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -33,28 +34,14 @@
     "description": "3.5x Catch Rate modifier.",
     "modifier": 3.5,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 3
+    "slug": "leaden-ball",
+    "stack": 3,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "iWcPq9fyjji5ZUge",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!iWcPq9fyjji5ZUge"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/level-ball.json
+++ b/packs/core-gear/level-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "Catch Rate increases by 1x for every 5 levels the user is over the target, up to a maximum of 8x.",
     "modifier": 1,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "level-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "6qpFM7IdGkJQTA5I",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!6qpFM7IdGkJQTA5I"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/love-ball.json
+++ b/packs/core-gear/love-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "8x Catch Rate modifer if used on a target that is @Affliction[charmed]. 1x Catch Rate modifer otherwise.",
     "modifier": 8,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "love-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "yadrYEhvWoIn8xPb",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!yadrYEhvWoIn8xPb"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/lure-ball.json
+++ b/packs/core-gear/lure-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "6x Catch Rate modifier if uses on a target that was hooked by a rod. 1x Catch Rate modifier otherwise",
     "modifier": 6,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "lure-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Ig4n69h36Vb3g1eg",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!Ig4n69h36Vb3g1eg"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/luxury-ball.json
+++ b/packs/core-gear/luxury-ball.json
@@ -3,7 +3,6 @@
   "img": "systems/ptr2e/img/item-icons/luxury ball.webp",
   "type": "consumable",
   "system": {
-    "cost": null,
     "crafting": {
       "skill": "electronics",
       "spans": 2,
@@ -21,7 +20,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +34,14 @@
     "description": "3.5x Catch Rate modifier.",
     "modifier": 3.5,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "luxury-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "tIiki4hc6xYtQgky",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!tIiki4hc6xYtQgky"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/master-ball.json
+++ b/packs/core-gear/master-ball.json
@@ -3,7 +3,6 @@
   "img": "systems/ptr2e/img/item-icons/master ball.webp",
   "type": "consumable",
   "system": {
-    "cost": null,
     "crafting": {
       "skill": null,
       "spans": null,
@@ -18,7 +17,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": null
+      "accuracy": 100,
+      "hide": null
     },
     "rarity": "unique",
     "consumableType": "pokeball",
@@ -29,28 +29,14 @@
     "description": "Will catch any Pokemon without fail. This item cannot miss.",
     "modifier": 999,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 1
+    "slug": "master-ball",
+    "stack": 1,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "mxks7lB2rkG3Uedl",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!mxks7lB2rkG3Uedl"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/mold-ball.json
+++ b/packs/core-gear/mold-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "4x Catch Rate modifier if used on a Poison- or Fighting-Type creature. 1x Catch Rate modifier otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "mold-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "4WnKfAmf1qUWBiQm",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!4WnKfAmf1qUWBiQm"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/moon-ball.json
+++ b/packs/core-gear/moon-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "6x Catch Rate modifer if the target's evolutionary line can utilize an Evolutionary Stone or Keepsake to evolve. 1x Catch Rate modifier otherwise.",
     "modifier": 6,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "moon-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Lhsmwu7WE2CzIP7G",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!Lhsmwu7WE2CzIP7G"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/mystic-ball.json
+++ b/packs/core-gear/mystic-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "4x Catch Rate modifier if used on a Dragon- or Psychic-Type creature. 1x Catch Rate modifier otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "mystic-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Tu549WwWKMNU8p88",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!Tu549WwWKMNU8p88"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/net-ball.json
+++ b/packs/core-gear/net-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "4x Catch Rate modifier if used on a Water- or Bug-Type creature. 1x Catch Rate modifier otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "net-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "YxpKMeMK5XLjH1sH",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!YxpKMeMK5XLjH1sH"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/park-ball.json
+++ b/packs/core-gear/park-ball.json
@@ -3,7 +3,6 @@
   "img": "systems/ptr2e/img/item-icons/park ball.webp",
   "type": "consumable",
   "system": {
-    "cost": null,
     "crafting": {
       "skill": null,
       "spans": null,
@@ -18,7 +17,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "rare",
     "consumableType": "pokeball",
@@ -30,28 +30,14 @@
     "description": "A ball given for use in specific catching contests. 5x Catch Rate modifier.",
     "modifier": 5,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "park-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "xDpeTsEsMN32Lf7S",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!xDpeTsEsMN32Lf7S"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/power-ball.json
+++ b/packs/core-gear/power-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "4x Catch Rate modifier on creatures less than half the user's level, and upon capture those creatures' levels are increased to half the user's level. 1x Catch Rate modifer otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "power-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "RUULWuRuFXbRqjsR",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!RUULWuRuFXbRqjsR"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/premier-ball.json
+++ b/packs/core-gear/premier-ball.json
@@ -3,7 +3,6 @@
   "img": "systems/ptr2e/img/item-icons/premier ball.webp",
   "type": "consumable",
   "system": {
-    "cost": null,
     "crafting": {
       "skill": null,
       "spans": null,
@@ -18,7 +17,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -30,28 +30,14 @@
     "description": "A sleek, pretty ball given out during promotional events. Gives no bonuses on capture checks.",
     "modifier": 1,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "premier-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "1DyQ3ufyPpixrxtP",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!1DyQ3ufyPpixrxtP"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/quick-ball.json
+++ b/packs/core-gear/quick-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "Catch Rate modifier starts at 6x, and decreases by 1x after each of the user's turns.",
     "modifier": 6,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "quick-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "mm2VA3udokrf30am",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!mm2VA3udokrf30am"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/rain-ball.json
+++ b/packs/core-gear/rain-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "5x Catch Rate modifier with Rainy Weather present. 2x Catch Rate modifier if only natural rainfall is present. 1x Catch Rate modifier otherwise.",
     "modifier": 2,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "rain-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "C1Tz1K3ugyH0S1G3",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!C1Tz1K3ugyH0S1G3"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/repeat-ball.json
+++ b/packs/core-gear/repeat-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "8x Catch Rate modifer if used on a Pokemon whose Species has already been registered by the user. 1x Catch Rate modifer otherwise.",
     "modifier": 8,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "repeat-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Cp3thGOpyzYOlDDI",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!Cp3thGOpyzYOlDDI"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/safari-ball.json
+++ b/packs/core-gear/safari-ball.json
@@ -3,7 +3,6 @@
   "img": "systems/ptr2e/img/item-icons/safari ball.webp",
   "type": "consumable",
   "system": {
-    "cost": null,
     "crafting": {
       "skill": null,
       "spans": null,
@@ -18,7 +17,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "rare",
     "consumableType": "pokeball",
@@ -30,28 +30,14 @@
     "description": "A ball given for use in specific catching contests. Gives no bonus on capture checks.",
     "modifier": 1,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 20
+    "slug": "safari-ball",
+    "stack": 20,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "SfFSplgjlMMgZesh",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!SfFSplgjlMMgZesh"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/sand-ball.json
+++ b/packs/core-gear/sand-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "5x Catch Rate modifier with Dusty Weather present. 2.5x Catch Rate modifier if natural dust or sand storms are present. 1x Catch Rate modifier otherwise.",
     "modifier": 2.5,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "sand-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "Sla18tcyQccrcQw9",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!Sla18tcyQccrcQw9"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/smog-ball.json
+++ b/packs/core-gear/smog-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "5x Catch Rate modifier with Smoggy Weather present. 1x Catch Rate modifier otherwise.",
     "modifier": 5,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "smog-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "snHusywqmnb6mMlR",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!snHusywqmnb6mMlR"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/solid-ball.json
+++ b/packs/core-gear/solid-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "4x Catch Rate modifier if used on a Rock- or Steel-Type creature. 1x Catch Rate modifier otherwise.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "solid-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "ChUBfCpKyt7YCLd4",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!ChUBfCpKyt7YCLd4"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/sport-ball.json
+++ b/packs/core-gear/sport-ball.json
@@ -3,7 +3,6 @@
   "img": "systems/ptr2e/img/item-icons/sport ball.webp",
   "type": "consumable",
   "system": {
-    "cost": null,
     "crafting": {
       "skill": null,
       "spans": null,
@@ -18,7 +17,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "rare",
     "consumableType": "pokeball",
@@ -30,28 +30,14 @@
     "description": "A ball given for use in specific catching contests. 2.5x Catch Rate modifier.",
     "modifier": 2.5,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 10
+    "slug": "sport-ball",
+    "stack": 10,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "dcMRu1DwEVSnpwkD",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!dcMRu1DwEVSnpwkD"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/strange-ball.json
+++ b/packs/core-gear/strange-ball.json
@@ -3,7 +3,6 @@
   "img": "systems/ptr2e/img/icons/consumable_icon.webp",
   "type": "consumable",
   "system": {
-    "cost": null,
     "crafting": {
       "skill": "electronics",
       "spans": 10,
@@ -21,7 +20,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "rare",
     "consumableType": "pokeball",
@@ -33,28 +33,14 @@
     "description": "12x Catch Rate modifer if used on a [Paradox] creature. 1x Catch Rate modifer otherwise.",
     "modifier": 12,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "strange-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "yRg97xxzNbQGfFWe",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!yRg97xxzNbQGfFWe"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/sun-ball.json
+++ b/packs/core-gear/sun-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "5x Catch Rate modifier with Sunny Weather present. 2x Catch Rate modifier if only natural sunlight is present. 1x Catch Rate modifier otherwise.",
     "modifier": 2,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "sun-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "3QYLN0PsST3TqyUM",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!3QYLN0PsST3TqyUM"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/tiller-ball.json
+++ b/packs/core-gear/tiller-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "8x Catch Rate modifer if used on a target that is Burrowing. 1x Catch Rate modifer otherwise. This Ball can target creatures 4m underground from the user.",
     "modifier": 8,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "tiller-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "XrexQs4vfSW01bsu",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!XrexQs4vfSW01bsu"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/timer-ball.json
+++ b/packs/core-gear/timer-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "Catch Rate modifier increases by 1x at the end of each round, up to a maximum of 8x.",
     "modifier": 1,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "timer-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "RJMD48otYg9d88AO",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!RJMD48otYg9d88AO"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/ultra-ball.json
+++ b/packs/core-gear/ultra-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -33,28 +34,14 @@
     "description": "2.5x Catch Rate modifier.",
     "modifier": 2.5,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "ultra-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "fTL8qcLLIKuPE45z",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!fTL8qcLLIKuPE45z"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/vane-ball.json
+++ b/packs/core-gear/vane-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 95
+      "accuracy": 95,
+      "hide": null
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -34,28 +35,14 @@
     "description": "5x Catch Rate modifier with Windy Weather present. 2x Catch Rate modifier if only natural winds are present. 1x Catch Rate modifier otherwise.",
     "modifier": 2,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "vane-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "ws0SP7fr74PHDi2e",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!ws0SP7fr74PHDi2e"
+  "folder": "bIBkUsgkWMXMOtHm"
 }

--- a/packs/core-gear/wing-ball.json
+++ b/packs/core-gear/wing-ball.json
@@ -21,7 +21,8 @@
     "fling": {
       "type": "untyped",
       "power": 0,
-      "accuracy": 100
+      "accuracy": 100,
+      "hide": null
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -33,28 +34,14 @@
     "description": "1.75x Catch Rate modifier. Catch Rate modifier increases by +2.25x vs creatures that are in Flight.",
     "modifier": 4,
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "stack": 5
+    "slug": "wing-ball",
+    "stack": 5,
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
   },
   "_id": "eqFrWrjv5sSIvpmW",
   "effects": [],
-  "folder": "V4skAU6G3OH5fXab",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!eqFrWrjv5sSIvpmW"
+  "folder": "bIBkUsgkWMXMOtHm"
 }


### PR DESCRIPTION
"Poké Balls": Basic Ball
- Update Consumable: Air Ball
- Update Consumable: Basic Ball
- Update Consumable: Beacon Ball
- Update Consumable: Beast Ball
- Update Consumable: Boost Ball
- Update Consumable: Cherish Ball
- Update Consumable: Coolant Ball
- Update Consumable: Dark Ball
- Update Consumable: Dive Ball
- Update Consumable: Dream Ball
- Update Consumable: Dusk Ball
- Update Consumable: Earth Ball
- Update Consumable: Fast Ball
- Update Consumable: Feather Ball
- Update Consumable: Friend Ball
- Update Consumable: Gigaton Ball
- Update Consumable: Gossamer Ball
- Update Consumable: Great Ball
- Update Consumable: Hail Ball
- Update Consumable: Haunt Ball
- Update Consumable: Heal Ball
- Update Consumable: Heat Ball
- Update Consumable: Heavy Ball
- Update Consumable: Hefty Ball
- Update Consumable: Jet Ball
- Update Consumable: Leaden Ball
- Update Consumable: Level Ball
- Update Consumable: Love Ball
- Update Consumable: Lure Ball
- Update Consumable: Luxury Ball
- Update Consumable: Master Ball
- Update Consumable: Mold Ball
- Update Consumable: Moon Ball
- Update Consumable: Mystic Ball
- Update Consumable: Net Ball
- Update Consumable: Park Ball
- Update Consumable: Power Ball
- Update Consumable: Premier Ball
- Update Consumable: Quick Ball
- Update Consumable: Rain Ball
- Update Consumable: Repeat Ball
- Update Consumable: Safari Ball
- Update Consumable: Sand Ball
- Update Consumable: Smog Ball
- Update Consumable: Solid Ball
- Update Consumable: Sport Ball
- Update Consumable: Strange Ball
- Update Consumable: Sun Ball
- Update Consumable: Tiller Ball
- Update Consumable: Timer Ball
- Update Consumable: Ultra Ball
- Update Consumable: Vane Ball
- Update Consumable: Wing Ball