### PR TITLE
Foundry Data Sync - Fix Draconic Presence overlap & add an additional route

### DIFF
--- a/packs/core-perks/draconic-presence.json
+++ b/packs/core-perks/draconic-presence.json
@@ -35,21 +35,18 @@
         },
         "hidden": false,
         "type": "normal",
-        "x": 139,
+        "x": 141,
         "y": 79,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
       "arena": "social",
       "approach": "power",
-      "archetype": "Dragon"
+      "archetype": "dragon"
     }
   },
   "img": "systems/ptr2e/img/svg/dragon_icon.svg",
@@ -70,7 +67,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,

--- a/packs/core-perks/night-eyes.json
+++ b/packs/core-perks/night-eyes.json
@@ -33,21 +33,18 @@
         },
         "hidden": false,
         "type": "normal",
-        "x": 148,
-        "y": 92,
+        "x": 146,
+        "y": 93,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
       "arena": "mental",
       "approach": "finesse",
-      "archetype": "Dark"
+      "archetype": "dark"
     }
   },
   "img": "systems/ptr2e/img/svg/dark_icon.svg",

--- a/packs/core-perks/pack-mon.json
+++ b/packs/core-perks/pack-mon.json
@@ -11,21 +11,15 @@
         "slug": "pack-mon",
         "description": "<p>You gain the [Pack Mon] trait and may join a Pack.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "pack-mon",
@@ -67,7 +61,8 @@
           "root-3",
           "rigorous-fundamentals-3",
           "thug",
-          "stat-iv-booster-1-3"
+          "stat-iv-booster-1-3",
+          "stat-iv-booster-1-1"
         ],
         "config": {
           "alpha": null,
@@ -111,13 +106,12 @@
     "autoUnlock": [
       "trait:pack-mon"
     ],
-    "originSlug": null,
     "global": true,
     "webs": [],
     "design": {
       "arena": "social",
       "approach": "resilience",
-      "archetype": "Pack Mon"
+      "archetype": "pack-mon"
     }
   },
   "_id": "g7RkEg1WRz28MU8R",

--- a/packs/core-perks/stat-iv-booster.json
+++ b/packs/core-perks/stat-iv-booster.json
@@ -52,7 +52,9 @@
           "improved-overland-1",
           "plain-irritating",
           "night-eyes",
-          "mindscramble"
+          "mindscramble",
+          "type-specialist",
+          "pack-mon-1"
         ],
         "config": {
           "alpha": null,
@@ -369,13 +371,12 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
     "global": true,
     "webs": [],
     "design": {
       "arena": "physical",
       "approach": "resilience",
-      "archetype": "Stat Ace"
+      "archetype": "stat-ace"
     }
   },
   "_id": "wqHZnaqbcQqOeLO7",
@@ -457,7 +458,19 @@
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
-      "statuses": []
+      "statuses": [],
+      "_stats": {
+        "coreVersion": "12.331",
+        "systemId": null,
+        "systemVersion": null,
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null
+      },
+      "sort": 0,
+      "flags": {}
     }
   ]
 }


### PR DESCRIPTION
Between DoT & Psychic-type perks.
- Update Perk: Draconic Presence
- Update Perk: Pack Mon
- Update Perk: <Stat> IV Booster
- Update Perk: Night Eyes