### PR TITLE
Foundry Data Sync - Quick Claw Attack Automation

### DIFF
--- a/packs/core-gear/quick-claw.json
+++ b/packs/core-gear/quick-claw.json
@@ -10,14 +10,15 @@
     },
     "equipped": {
       "slot": "accessory",
-      "carryType": "stowed",
-      "handsHeld": null
+      "carryType": "equipped",
+      "handsHeld": 0
     },
     "grade": "C",
     "fling": {
       "type": "untyped",
       "power": null,
-      "accuracy": 100
+      "accuracy": 100,
+      "hide": null
     },
     "rarity": "uncommon",
     "traits": [
@@ -34,21 +35,16 @@
         ],
         "range": {
           "target": "creature",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "complex"
         },
-        "variant": null
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "Effect: When the user declares an Attack, they have a 20% chance of gaining [Priority 1] on that Attack (or increasing that Action's existing Priority value by +1 for that Attack's use).",
-    "slug": null,
-    "container": null,
+    "slug": "quick-claw",
     "quantity": 1,
     "identification": {
       "misidentified": null,
@@ -58,26 +54,72 @@
         "img": "systems/ptu/css/images/icons/item_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
+    },
+    "_migration": {
+      "version": 0.11,
+      "previous": {
+        "schema": null,
+        "foundry": "12.331",
+        "system": "1.0.6.beta"
+      }
     }
   },
   "_id": "QhuAmW1i4HVqoqmU",
-  "effects": [],
-  "folder": "V4skAU6G3OH5fXad",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!QhuAmW1i4HVqoqmU"
+  "effects": [
+    {
+      "name": "Quick Claw",
+      "type": "passive",
+      "_id": "qJpGOvUuSDEPKYEB",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": 0,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.6.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "folder": "V4skAU6G3OH5fXad"
 }


### PR DESCRIPTION
Added an automatic effect on Quick Claw to grant Advance 10% on a 20% chance.
- Create Equipment: Quick Claw