### PR TITLE
Foundry Data Sync - Tutor Move Grade and PP Fixes

### DIFF
--- a/packs/core-moves/abrasion.json
+++ b/packs/core-moves/abrasion.json
@@ -28,10 +28,11 @@
         ],
         "category": "status",
         "accuracy": 85,
-        "description": "<p>Effect: On hit, the target gains @Affliction[splinter] 5.</p>"
+        "description": "<p>Effect: On hit, the target gains @Affliction[splinter] 5.</p>",
+        "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "_migration": {
       "version": null,
       "previous": null
@@ -40,8 +41,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": "undefined"
+    },
+    "traits": []
   },
   "effects": [
     {
@@ -60,7 +63,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,

--- a/packs/core-moves/acid.json
+++ b/packs/core-moves/acid.json
@@ -29,10 +29,11 @@
           "poison"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 10% chance of losing -1 SPDEF Stage for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "_migration": {
       "version": null,
       "previous": null
@@ -41,8 +42,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": "undefined"
+    },
+    "traits": []
   },
   "_id": "KMCeb4zaaJR8LoRZ",
   "effects": [
@@ -62,7 +65,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,

--- a/packs/core-moves/acupressure.json
+++ b/packs/core-moves/acupressure.json
@@ -15,7 +15,6 @@
         ],
         "range": {
           "target": "self",
-          "distance": 0,
           "unit": "m"
         },
         "cost": {
@@ -23,17 +22,13 @@
           "powerPoints": 1
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
-        "description": "<p>Effect: Roll 1d8 and raise the Stages of the stat in the corresponding table by +2 for 5 Activations.</p><p><ol><li>ATK</li><li>DEF</li><li>SPATK</li><li>SPDEF</li><li>SPD</li><li>ACC</li><li>EVA</li><li>User Choice<></ol></p>",
-        "contestType": "",
-        "contestEffect": "",
+        "description": "<p>Effect: Roll 1d8 and raise the Stages of the stat in the corresponding table by +2 for 5 Activations.</p><ol><li>ATK</li><li>DEF</li><li>SPATK</li><li>SPDEF</li><li>SPD</li><li>ACC</li><li>EVA</li><li>User Choice</li></ol>",
         "variant": "acupressure",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/normal_icon.svg",
+        "predicate": []
       },
       {
         "slug": "acupressure",
@@ -54,25 +49,25 @@
           "powerPoints": 2
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
-        "description": "<p>Effect: Roll 1d8 and raise the Stages of the stat in the corresponding table by +2 for 5 Activations.</p><p><ol><li>ATK</li><li>DEF</li><li>SPATK</li><li>SPDEF</li><li>SPD</li><li>ACC</li><li>EVA</li><li>User Choice<></ol></p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "description": "<p>Effect: Roll 1d8 and raise the Stages of the stat in the corresponding table by +2 for 5 Activations.</p><ol><li>ATK</li><li>DEF</li><li>SPATK</li><li>SPDEF</li><li>SPD</li><li>ACC</li><li>EVA</li><li>User Choice</li></ol>",
+        "img": "systems/ptr2e/img/svg/normal_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "E",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
       ]
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "DymPJiI57iCzqLp1",

--- a/packs/core-moves/bubble-beam.json
+++ b/packs/core-moves/bubble-beam.json
@@ -30,10 +30,11 @@
           "water"
         ],
         "description": "<p>Effect: On hit, the target has a 10% chance of losing -1 SPD Stage for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "_migration": {
       "version": null,
       "previous": null
@@ -42,8 +43,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": "undefined"
+    },
+    "traits": []
   },
   "_id": "cfZjUganrYbHUYFm",
   "effects": [
@@ -63,7 +66,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,

--- a/packs/core-moves/bubble.json
+++ b/packs/core-moves/bubble.json
@@ -20,16 +20,17 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2
+          "powerPoints": 1
         },
         "category": "special",
         "power": 40,
-        "accuracy": 100,
+        "accuracy": 95,
         "types": [
           "water"
         ],
         "description": "<p>Effect: On hit, all valid targets have a 10% chance of losing -1 SPD Stage for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/svg/water_icon.svg",
+        "predicate": []
       }
     ],
     "grade": "E",
@@ -42,7 +43,8 @@
       "authors": [
         "PTR 2e Team"
       ]
-    }
+    },
+    "traits": []
   },
   "_id": "HUlQklA9AdqWFii9",
   "effects": [
@@ -62,7 +64,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,

--- a/packs/core-moves/clamp.json
+++ b/packs/core-moves/clamp.json
@@ -30,19 +30,22 @@
           "water"
         ],
         "description": "<p>Effect: The user auto-succeeds on a @Affliction[grapple] Maneuver check against the target if Clamp hits. The Target becomes @Affliction[bound] 5. While the target is @Affliction[bound], they take a Tick of HP damage at the end of each of their Activations.</p><p>If either the @Affliction[grapple] or @Affliction[bound] condition ends, the target loses the other condition.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "YJfBFCQHnhiqSGas",

--- a/packs/core-moves/clangor.json
+++ b/packs/core-moves/clangor.json
@@ -4,13 +4,13 @@
   "_id": "agzkVidQZLl8r9CK",
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "clangor",
     "actions": [
       {
         "name": "Clangor",
         "slug": "clangor",
         "type": "attack",
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/steel_icon.svg",
         "traits": [
           "sonic"
         ],
@@ -23,44 +23,28 @@
           "activation": "complex",
           "powerPoints": 1
         },
-        "variant": null,
         "types": [
           "steel"
         ],
-        "category": "physical",
+        "category": "special",
         "power": 45,
         "accuracy": 95,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: All creatures in Range are cured of @Affliction[drowsy].</p>"
+        "description": "<p>Effect: All creatures in Range are cured of @Affliction[drowsy].</p>",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "E",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
       ]
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721311933643,
-    "modifiedTime": 1721312182524,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/corrupt.json
+++ b/packs/core-moves/corrupt.json
@@ -13,34 +13,36 @@
           "pp-updated"
         ],
         "range": {
-          "target": "self",
-          "distance": 0,
+          "target": "creature",
+          "distance": 1,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2
+          "powerPoints": 3
         },
         "category": "status",
-        "power": null,
         "accuracy": 85,
         "types": [
           "poison"
         ],
-        "description": "<p>Effect: Roll 2d8 and decrease the Stage of the stats in the corresponding table by -2 for 5 Activations.</p><p><ol><li>ATK</li><li>DEF</li><li>SPATK</li><li>SPDEF</li><li>SPD</li><li>ACC</li><li>EVA</li><li>User Choice<></ol></p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "description": "<p>Effect: Roll 2d8 and decrease the Stage of the stats in the corresponding table by -2 for 5 Activations.</p><ol><li>ATK</li><li>DEF</li><li>SPATK</li><li>SPDEF</li><li>SPD</li><li>ACC</li><li>EVA</li><li>User Choice</li></ol>",
+        "img": "systems/ptr2e/img/svg/poison_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "C",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "Gjdv2pC50rh1lvrG",

--- a/packs/core-moves/creeping-feeling.json
+++ b/packs/core-moves/creeping-feeling.json
@@ -1,0 +1,121 @@
+{
+  "name": "Creeping Feeling",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "creeping-feeling",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "<p>Effect: On hit, the target has a 30% chance of being Flinched.</p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Creeping Vibe",
+        "slug": "creeping-vibe",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/ghost_icon.svg",
+        "traits": [
+          "pulse",
+          "social",
+          "flinch-chance-3",
+          "pp-updated"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 6,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 1
+        },
+        "types": [
+          "ghost"
+        ],
+        "category": "special",
+        "power": 35,
+        "accuracy": 95,
+        "predicate": [],
+        "description": "<p>undefined</p>"
+      }
+    ],
+    "grade": "E"
+  },
+  "_id": "NBrY9HtsrILhtrgZ",
+  "img": "systems/ptr2e/img/svg/ghost_icon.svg",
+  "effects": [
+    {
+      "name": "Astonish",
+      "type": "passive",
+      "_id": "wpyTNqaE9BlZUYiL",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "creeping-feeling-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 30%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.05gTyZzErLsW9RtE.ActiveEffect.dStoecgRLGTkIVx9",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.0.7.beta",
+        "createdTime": 1740927920269,
+        "modifiedTime": 1740927930662,
+        "lastModifiedBy": "01onCaJSVMVOgMDI"
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-moves/drain-punch.json
+++ b/packs/core-moves/drain-punch.json
@@ -32,20 +32,22 @@
         "types": [
           "fighting"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "60l7jRB3D6KfRbHL",

--- a/packs/core-moves/fairy-jinx.json
+++ b/packs/core-moves/fairy-jinx.json
@@ -4,7 +4,7 @@
   "_id": "WPGxbmWz95ZrKOxn",
   "img": "systems/ptr2e/img/svg/fairy_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "fairy-jinx",
     "actions": [
       {
         "name": "Fairy Jinx",
@@ -23,44 +23,28 @@
           "activation": "complex",
           "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "fairy"
         ],
         "category": "status",
-        "power": null,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, roll 1d8 and drop the target's Stages of the stat in the corresponding table by -2 for 5 Activations.</p><p><ol><li>ATK</li><li>DEF</li><li>SPATK</li><li>SPDEF</li><li>SPD</li><li>ACC</li><li>EVA</li><li>User Choice<></ol></p>"
+        "description": "<p>Effect: On hit, roll 1d8 and drop the target's Stages of the stat in the corresponding table by -2 for 5 Activations.</p><p><ol><li>ATK</li><li>DEF</li><li>SPATK</li><li>SPDEF</li><li>SPD</li><li>ACC</li><li>EVA</li><li>User Choice<></ol></p>",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
-  "effects": [],
-  "sort": 3500000,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.0.4",
-    "createdTime": 1718992127121,
-    "modifiedTime": 1719971994938,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/flip-turn.json
+++ b/packs/core-moves/flip-turn.json
@@ -29,19 +29,22 @@
           "water"
         ],
         "description": "<p>Effect: On hit, the user may freely move themselves up to half of the Movement Score of their choice away from the target. If the user is an owned Pokémon, they may then immediately be returned their Poké Ball and another Pokémon may immediately be sent out in their place.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "mQ7A5gRxvfUfZ8ew",

--- a/packs/core-moves/force-palm.json
+++ b/packs/core-moves/force-palm.json
@@ -32,10 +32,11 @@
           "fighting"
         ],
         "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[paralysis] 5.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "_migration": {
       "version": null,
       "previous": null
@@ -44,8 +45,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": "undefined"
+    },
+    "traits": []
   },
   "_id": "7eWAp2IGkSaGo0e0",
   "effects": [
@@ -65,7 +68,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,

--- a/packs/core-moves/horn-leech.json
+++ b/packs/core-moves/horn-leech.json
@@ -30,20 +30,22 @@
         "types": [
           "grass"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "Ki7LREDznF0jR6QG",

--- a/packs/core-moves/howling-blaster.json
+++ b/packs/core-moves/howling-blaster.json
@@ -29,10 +29,11 @@
         "category": "special",
         "power": 130,
         "accuracy": 90,
-        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[frostbite] 5. On resolution, the user loses -2 SPATK Stages for 5 Activations.</p>"
+        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[frostbite] 5. On resolution, the user loses -2 SPATK Stages for 5 Activations.</p>",
+        "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "A",
     "_migration": {
       "version": null,
       "previous": null
@@ -41,8 +42,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": "undefined"
+    },
+    "traits": []
   },
   "effects": [
     {
@@ -61,7 +64,8 @@
             "affects": "self",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           },
           {
             "type": "roll-effect",
@@ -72,7 +76,8 @@
             "affects": "origin",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,

--- a/packs/core-moves/hydrolysis.json
+++ b/packs/core-moves/hydrolysis.json
@@ -4,7 +4,7 @@
   "_id": "MZs1e84dHCiNg6Dt",
   "img": "systems/ptr2e/img/svg/water_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "hydrolysis",
     "actions": [
       {
         "name": "Hydrolysis",
@@ -23,44 +23,28 @@
           "activation": "complex",
           "powerPoints": 4
         },
-        "variant": null,
         "types": [
           "water"
         ],
         "category": "special",
         "power": 70,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": ""
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "B",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721318312626,
-    "modifiedTime": 1721318452464,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/jet-punch.json
+++ b/packs/core-moves/jet-punch.json
@@ -31,20 +31,22 @@
         "types": [
           "water"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "lyjLX6WIIrbdvqXS",

--- a/packs/core-moves/low-sweep.json
+++ b/packs/core-moves/low-sweep.json
@@ -29,10 +29,11 @@
           "fighting"
         ],
         "description": "<p>Effect: On hit, the target loses -1 SPD Stage for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "_migration": {
       "version": null,
       "previous": null
@@ -41,8 +42,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": "undefined"
+    },
+    "traits": []
   },
   "_id": "AmMOS6DFYz7rSI4O",
   "effects": [
@@ -62,7 +65,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,

--- a/packs/core-moves/metal-whip.json
+++ b/packs/core-moves/metal-whip.json
@@ -28,19 +28,22 @@
           "steel"
         ],
         "description": "<p>Effect: The Target becomes @Affliction[bound] 5. While the target is @Affliction[bound], they take a Tick of HP damage at the end of each of their Activations. If used at melee range, the user auto-succeeds on a @Affliction[grapple] Maneuver check against the target if this attack hits. If either the @Affliction[grapple] or @Affliction[bound] condition ends, the target loses the other condition.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "wm3vkiBKzww4NiOP",

--- a/packs/core-moves/mirage-edge.json
+++ b/packs/core-moves/mirage-edge.json
@@ -4,13 +4,13 @@
   "_id": "TUnhlxSbtzMAQjpF",
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "mirage-edge",
     "actions": [
       {
         "name": "Mirage Edge",
         "slug": "mirage-edge",
         "type": "attack",
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/steel_icon.svg",
         "traits": [
           "sharp",
           "crit-1",
@@ -23,47 +23,32 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 8,
+          "powerPoints": 3,
           "priority": 2
         },
-        "variant": null,
         "types": [
           "steel"
         ],
         "category": "physical",
         "power": 40,
         "accuracy": 95,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: This attack is more powerful the faster the user is compared to the target, ranging from 40 to 160.</p><blockquote><p>Damage Formula: Power = min(160, (20*UserSPD / TargetSPD) + 40)</p></blockquote>"
+        "description": "<p>Effect: This attack is more powerful the faster the user is compared to the target, ranging from 40 to 160.</p><blockquote><p>Damage Formula: Power = min(160, (20*UserSPD / TargetSPD) + 40)</p></blockquote>",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "C",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721310775426,
-    "modifiedTime": 1721440520171,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/mirror-shot.json
+++ b/packs/core-moves/mirror-shot.json
@@ -32,7 +32,7 @@
         "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "_migration": {
       "version": null,
       "previous": null
@@ -41,8 +41,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": "undefined"
+    },
+    "traits": []
   },
   "_id": "vALidK8djNyae3c0",
   "effects": [
@@ -88,7 +90,17 @@
       "transfer": true,
       "statuses": [],
       "sort": 0,
-      "flags": {}
+      "flags": {},
+      "_stats": {
+        "coreVersion": "12.331",
+        "systemId": null,
+        "systemVersion": null,
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null
+      }
     }
   ]
 }

--- a/packs/core-moves/needle-arm.json
+++ b/packs/core-moves/needle-arm.json
@@ -35,7 +35,7 @@
         "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "traits": [],
     "_migration": {
       "version": null,
@@ -45,7 +45,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
     }
   },
   "_id": "x4u1OPhedtM8DpwL",

--- a/packs/core-moves/paralytic-venom.json
+++ b/packs/core-moves/paralytic-venom.json
@@ -4,7 +4,7 @@
   "_id": "yH35AaKAFxZs5tOa",
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "paralytic-venom",
     "actions": [
       {
         "name": "Paralytic Venom",
@@ -24,24 +24,19 @@
           "activation": "complex",
           "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "poison"
         ],
         "category": "status",
-        "power": null,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: On hit, the target gains @Affliction[poison] 5.</p>"
+        "description": "<p>Effect: On hit, the target gains @Affliction[poison] 5.</p>",
+        "predicate": []
       },
       {
         "name": "Paralytic Venom (Poisoned)",
         "slug": "paralytic-venom-poisoned",
         "type": "attack",
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/poison_icon.svg",
         "traits": [
           "contact",
           "pp-updated"
@@ -61,39 +56,25 @@
           "poison"
         ],
         "category": "status",
-        "power": null,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
         "free": true,
-        "slot": null,
-        "description": "<p>The target has has @Affliction[poison].</p><p>Effect: On hit, the target gains @Affliction[paralysis] 5.</p>"
+        "description": "<p>Trigger: The target has @Affliction[poison].</p><p>Effect: On hit, the target gains @Affliction[paralysis] 5.</p>",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "<p>Effect: On hit, the target gains @Affliction[poison] 5. If the target has @Affliction[poison], the target instead gains @Affliction[paralysis] 5.</p>"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721257537086,
-    "modifiedTime": 1721258533678,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/pincer-attack.json
+++ b/packs/core-moves/pincer-attack.json
@@ -28,11 +28,8 @@
         "types": [
           "bug"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "slug": "pincer-attack-advantageous",
@@ -58,19 +55,22 @@
           "bug"
         ],
         "description": "<p>Effect: If the target has taken damage since its last Activation, Pincer Attack is one step more effective.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "<p>Effect: If the target has taken damage since its last Activation, Pincer Attack is one step more effective.</p>"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "KoVmOrdjtvcvL7fI",

--- a/packs/core-moves/pounce.json
+++ b/packs/core-moves/pounce.json
@@ -30,13 +30,11 @@
           "bug"
         ],
         "description": "<p>Effect: On hit, the target loses -1 SPD Stage for 5 Activations.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "_migration": {
       "version": null,
       "previous": null
@@ -45,8 +43,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": "undefined"
+    },
+    "traits": []
   },
   "_id": "XZEhadRz7qlH4dYS",
   "effects": [
@@ -66,7 +66,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,

--- a/packs/core-moves/powder.json
+++ b/packs/core-moves/powder.json
@@ -27,25 +27,26 @@
           "priority": 1
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "bug"
         ],
         "description": "<p>Effect: All valid targets are covered in a flammable Powder for 5 Activations. If a creature covered in Powder attempts to use a Fire-typed move, the attack fails and they deal 4 Ticks of their HP as damage to themselves and all adjacent creatures, and the Powder is removed. If a creature covered in Powder is hit by a Fire-type move, they deal 4 Ticks of their HP as damage to themselves and all adjacent creatures, and the Powder is removed.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D",
+    "grade": "E",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "XOezqCVXnuNgBQRS",

--- a/packs/core-moves/pressure-wave.json
+++ b/packs/core-moves/pressure-wave.json
@@ -4,7 +4,7 @@
   "_id": "3sW2cnSDFm8C8HAF",
   "img": "systems/ptr2e/img/svg/ground_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "pressure-wave",
     "actions": [
       {
         "name": "Pressure Wave",
@@ -25,44 +25,28 @@
           "activation": "complex",
           "powerPoints": 4
         },
-        "variant": null,
         "types": [
           "ground"
         ],
         "category": "physical",
         "power": 40,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": ""
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "B",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720799098464,
-    "modifiedTime": 1720799152767,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/rolling-kick.json
+++ b/packs/core-moves/rolling-kick.json
@@ -37,7 +37,7 @@
         "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "traits": [],
     "_migration": {
       "version": null,
@@ -47,7 +47,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
     }
   },
   "_id": "2XdJAb5S6kQJMF2e",

--- a/packs/core-moves/sandtrap.json
+++ b/packs/core-moves/sandtrap.json
@@ -4,7 +4,7 @@
   "_id": "2rktRS5pOJDKLPtZ",
   "img": "systems/ptr2e/img/svg/ground_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "sandtrap",
     "actions": [
       {
         "name": "Sandtrap",
@@ -25,44 +25,29 @@
           "activation": "complex",
           "powerPoints": 7
         },
-        "variant": null,
         "types": [
           "ground"
         ],
         "category": "physical",
         "power": 140,
         "accuracy": 90,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": "<p>Effect: Set-Up: The user is surrounded in falling sand, gaining @Affliction[braced] 1 and gains +1 DEF, SPDEF, and EVA Stages for 3 Activations. If the weather is Dusty, the user Sets-Up and resolves Sandtrap on the same Activation.</p><p>Resolution: On their next Activation, they attack with and resolve this attack. If the weather is not Dusty, Windy, or Clear, this attack's Power is reduced by 50%.</p>"
+        "description": "<p>Effect: Set-Up: The user is surrounded in falling sand, gaining @Affliction[braced] 1 and gains +1 DEF, SPDEF, and EVA Stages for 3 Activations. If the weather is Dusty, the user Sets-Up and resolves Sandtrap on the same Activation.</p><p>Resolution: On their next Activation, they attack with and resolve this attack. If the weather is not Dusty, Windy, or Clear, this attack's Power is reduced by 50%.</p>",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "A",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720799892120,
-    "modifiedTime": 1720800029573,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/saw-blade.json
+++ b/packs/core-moves/saw-blade.json
@@ -4,13 +4,13 @@
   "_id": "3shXx43N4Lh4bsAv",
   "img": "systems/ptr2e/img/svg/steel_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "saw-blade",
     "actions": [
       {
         "name": "Saw Blade",
         "slug": "saw-blade",
         "type": "attack",
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/steel_icon.svg",
         "traits": [
           "sharp",
           "crit-1",
@@ -24,46 +24,30 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "steel"
         ],
         "category": "physical",
         "power": 70,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": ""
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
-  "effects": [],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1721313852048,
-    "modifiedTime": 1721313918885,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  "effects": []
 }

--- a/packs/core-moves/seismic-fist.json
+++ b/packs/core-moves/seismic-fist.json
@@ -34,7 +34,7 @@
         "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "traits": [],
     "_migration": {
       "version": null,
@@ -44,7 +44,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
     }
   },
   "_id": "uYan2yXFlkGlHgQH",
@@ -65,7 +66,8 @@
             "affects": "target",
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,

--- a/packs/core-moves/steamroller.json
+++ b/packs/core-moves/steamroller.json
@@ -37,7 +37,7 @@
         "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "traits": [],
     "_migration": {
       "version": null,
@@ -47,7 +47,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
     }
   },
   "_id": "2SDRWYsw9hgCRMIZ",

--- a/packs/core-perks/mightyena-tactic.json
+++ b/packs/core-perks/mightyena-tactic.json
@@ -26,13 +26,17 @@
     "description": "<p>Gain +20 Power when attacking targets that have a net negative SPD stage.</p>",
     "traits": [],
     "prerequisites": [],
-    "cost": 3,
+    "cost": 2,
     "_migration": {
       "version": null,
       "previous": null
     },
     "nodes": [
       {
+        "x": 64,
+        "y": 180,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "hamstring",
           "skirmish",
@@ -41,18 +45,14 @@
           "improved-overland-9"
         ],
         "config": {
+          "texture": "systems/ptr2e/img/perk-icons/Hunting.svg",
           "alpha": null,
-          "backgroundColor": "#804000",
+          "backgroundColor": null,
           "borderColor": null,
           "borderWidth": null,
-          "texture": "systems/ptr2e/img/perk-icons/Hunting.svg",
           "tint": null,
           "scale": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 64,
-        "y": 180,
         "tier": null
       }
     ],
@@ -62,13 +62,14 @@
     "design": {
       "arena": "physical",
       "approach": "finesse",
-      "archetype": "Hunter"
+      "archetype": "hunter"
     },
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": "undefined"
     }
   },
   "effects": []

--- a/packs/core-perks/run-down.json
+++ b/packs/core-perks/run-down.json
@@ -9,7 +9,7 @@
       {
         "name": "Run Down",
         "slug": "run-down",
-        "description": "<p>Trigger: You successfully hit an opponent with an attack.<br><br>May spend 4 PP to gain +1 SPD stage for 5 activations as a Free Action at [Interrupt 2].</p>",
+        "description": "<p>Trigger: The user successfully hits an opponent with an attack.<br><br>Effect: The user may spend 2 PP to gain +1 SPD stage for 5 activations as a Free Action at [Interrupt 2].</p>",
         "traits": [],
         "type": "attack",
         "range": {
@@ -18,7 +18,7 @@
         },
         "cost": {
           "activation": "free",
-          "powerPoints": 4
+          "powerPoints": 2
         },
         "img": "systems/ptr2e/img/perk-icons/Cavalier.svg",
         "types": [
@@ -68,7 +68,7 @@
     "design": {
       "arena": "physical",
       "approach": "power",
-      "archetype": "Hunter"
+      "archetype": "hunter"
     },
     "publication": {
       "source": "PTR 2e Core",

--- a/packs/core-perks/skirmish.json
+++ b/packs/core-perks/skirmish.json
@@ -9,14 +9,14 @@
       {
         "name": "Skirmish",
         "slug": "skirmish",
-        "description": "<p>Trigger: The user enters Combat.</p><p>Effect: The user advances their Initiative by 50%.</p><blockquote>Ideally this should be done prior to the GM pressing the 'Begin Combat' button.</blockquote>",
+        "description": "<p>Trigger: The user enters Combat.</p><p>Effect: The user advances their Initiative by 50%.</p><blockquote><p>Ideally this should be done prior to the GM pressing the 'Begin Combat' button.</p></blockquote>",
         "traits": [
           "interrupt-2"
         ],
         "type": "generic",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
+          "powerPoints": 6,
           "trigger": "The user enters Combat."
         },
         "range": {
@@ -65,7 +65,7 @@
     "design": {
       "arena": "physical",
       "approach": "finesse",
-      "archetype": "Hunter"
+      "archetype": "hunter"
     },
     "publication": {
       "source": "PTR 2e Core",


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Move: Fairy Jinx
- Update Move: Drain Punch
- Update Move: Low Sweep
- Update Move: Force Palm
- Update Move: Rolling Kick
- Update Move: Needle Arm
- Update Move: Horn Leech
- Update Move: Sandtrap
- Update Move: Pressure Wave
- Update Move: Seismic Fist
- Update Move: Howling Blaster
- Update Move: Metal Whip
- Update Move: Saw Blade
- Update Move: Mirror Shot
- Update Move: Mirage Edge
- Update Move: Clangor
- Update Move: Abrasion
- Update Move: Creeping Feeling
- Update Move: Powder
- Update Move: Pounce
- Update Move: Steamroller
- Update Move: Pincer Attack
- Update Perk: Skirmish
- Update Perk: Run Down
- Update Perk: Mightyena Tactic
- Update Move: Corrupt
- Update Move: Paralytic Venom
- Update Move: Acupressure
- Update Move: Acid
- Update Move: Clamp
- Update Move: Bubble Beam
- Update Move: Flip Turn
- Update Move: Bubble
- Update Move: Hydrolysis
- Update Move: Jet Punch