### PR TITLE
Foundry Data Sync - Air Slash Effect Fix

### DIFF
--- a/packs/core-moves/air-slash.json
+++ b/packs/core-moves/air-slash.json
@@ -50,9 +50,9 @@
   "_id": "lxpXiXqapEF8GFPC",
   "effects": [
     {
-      "name": "Air Slash",
-      "type": "advancement",
-      "_id": "VrxettEItzXCeva9",
+      "name": "Air Slash (Roll Effect)",
+      "type": "passive",
+      "_id": "XLHPx6oPkaiE2Ije",
       "img": "systems/ptr2e/img/icons/effect_icon.webp",
       "system": {
         "changes": [
@@ -68,6 +68,11 @@
                 "mode": 5,
                 "property": "system.amount",
                 "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinch 30%"
               }
             ],
             "mode": 2,
@@ -79,8 +84,7 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0,
-        "amount": 0
+        "stacks": 0
       },
       "disabled": false,
       "duration": {
@@ -104,10 +108,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.2.1",
-        "createdTime": 1737651928799,
-        "modifiedTime": 1737676628954,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+        "systemVersion": "1.0.7.beta",
+        "createdTime": 1740921940039,
+        "modifiedTime": 1740922008149,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }
   ]


### PR DESCRIPTION
Should solve the odd behaviour of air slash decaying at end of turn.
- Update Move: Air Slash