### PR TITLE
Foundry Data Sync - The Falinksening

### DIFF
--- a/packs/core-species/falinks.json
+++ b/packs/core-species/falinks.json
@@ -279,17 +279,21 @@
       "details": null,
       "evolutions": [],
       "uuid": null,
-      "methods": []
+      "methods": [],
+      "perk": {
+        "x": 26,
+        "y": 26
+      }
     },
     "number": 870,
     "traits": [
       "pokemon",
       "gestalt",
       "pack-mon",
-      "underdog",
       "fully-evolved",
       "bipedal",
-      "horned"
+      "horned",
+      "6-headed"
     ],
     "diet": [
       "omnivore"
@@ -305,26 +309,26 @@
       ],
       "basic": [
         {
-          "slug": "bulletproof"
-        },
-        {
           "slug": "phalanx"
-        }
-      ],
-      "advanced": [
-        {
-          "slug": "friend-guard"
         },
         {
           "slug": "mighty-horn"
         }
       ],
-      "master": [
+      "advanced": [
         {
-          "slug": "scrappy"
+          "slug": "bulletproof"
         },
         {
+          "slug": "multi-headed"
+        }
+      ],
+      "master": [
+        {
           "slug": "stamina"
+        },
+        {
+          "slug": "friend-guard"
         }
       ]
     },
@@ -449,7 +453,8 @@
       "source": "PTR 2e Core - Galar Dex",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "mbEaQB9vZEquwAlB",


### PR DESCRIPTION
"And for each Link, came a Head."

(Falinks gains [6 Headed]. Scrappy swapped out for Multi-Headed, Abilities rearranged)
- Update Species: falinks