### PR TITLE
Foundry Data Sync - Adding New Arcane Moves

### DIFF
--- a/packs/core-moves/arcane-empowerment.json
+++ b/packs/core-moves/arcane-empowerment.json
@@ -1,0 +1,117 @@
+{
+  "name": "Arcane Empowerment",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "arcane-empowerment",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "<p>Effect: The user gains +1 SPATK and ACC Stage for 5 activations.</p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Arcane Empowerment",
+        "slug": "arcane-empowerment",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "arcane",
+          "manipulate"
+        ],
+        "range": {
+          "target": "self",
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 2
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "predicate": [],
+        "description": "<p>Effect: The user gains +1 SPATK and ACC Stage for 5 activations.</p>"
+      }
+    ],
+    "grade": "C"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [
+    {
+      "name": "Arcane Empowerment",
+      "type": "passive",
+      "_id": "kINaFI0ySOg77Pw4",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "arcane-empowerment-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAa",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "arcane-empowerment-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.iv1l5qSwT9ykajV0",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.ACTyejrBHHBe0sJV.ActiveEffect.86MqRTUBSBxW0IXb",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "nXt5NxMWToZ39Qxc"
+}

--- a/packs/core-moves/arcane-enforcement.json
+++ b/packs/core-moves/arcane-enforcement.json
@@ -1,0 +1,129 @@
+{
+  "name": "Arcane Enforcement",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "arcane-enforcement",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "<p>Effect: The user gains +1 DEF, SPDEF, and EVA Stage for 5 activations.</p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Arcane Enforcement",
+        "slug": "arcane-enforcement",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "arcane",
+          "manipulate"
+        ],
+        "range": {
+          "target": "enemy",
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "predicate": [],
+        "description": "<p>Effect: The user gains +1 DEF, SPDEF, and EVA Stage for 5 activations.</p>"
+      }
+    ],
+    "grade": "B"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [
+    {
+      "name": "Arcane Enforcement",
+      "type": "passive",
+      "_id": "P55Esjm1O3wF9c4o",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "arcane-enforcement-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.sMystTj3FBJ00AZp",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "arcane-enforcement-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.jEX7s3GbbAtzgyS3",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "arcane-enforcement-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.OUBNweJOMjAEtAye",
+            "predicate": [],
+            "chance": 100,
+            "affects": "self",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.c9FXYfGD2lhUFyJ5.ActiveEffect.8i8zaX2kdlqHnCDJ",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "HjMKMDPFOCCPmJpl"
+}

--- a/packs/core-moves/arcane-fury.json
+++ b/packs/core-moves/arcane-fury.json
@@ -1,0 +1,138 @@
+{
+  "name": "Arcane Fury",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "arcane-fury",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "<p>Effect: On hit, all valid targets lose -1 SPDEF stage for 5 activations, and have a 20% chance to be Flinched.</p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Arcane Fury",
+        "slug": "arcane-fury",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "adaptable",
+          "arcane",
+          "pulse",
+          "flinch-chance-3"
+        ],
+        "range": {
+          "target": "cone",
+          "distance": 3,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 30,
+        "accuracy": 90,
+        "predicate": [],
+        "description": "<p>Effect: On hit, all valid targets lose -1 SPDEF stage for 5 activations, and have a 20% chance to be Flinched.</p>"
+      }
+    ],
+    "grade": "C"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [
+    {
+      "name": "Arcane Fury",
+      "type": "passive",
+      "_id": "WeEPO3fDDgfZ663n",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "arcane-fury-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinched 30%"
+              },
+              {
+                "mode": 2,
+                "property": "",
+                "value": 0
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "arcane-fury-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.3KCZGRV9lMmb44FC.ActiveEffect.uM9lEbJS6Ee0AHd9",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "OfbZThjuYVPlwRsY"
+}

--- a/packs/core-moves/arcane-storm.json
+++ b/packs/core-moves/arcane-storm.json
@@ -1,0 +1,127 @@
+{
+  "name": "Arcane Storm",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "arcane-storm",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "<p>Effect: On hit, all valid targets have a 10% chance of losing -1 ATK and SPD for 5 Activations.</p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Arcane Storm",
+        "slug": "arcane-storm",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "adaptable",
+          "arcane",
+          "pulse",
+          "wind"
+        ],
+        "range": {
+          "target": "wide-line",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 8
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 60,
+        "accuracy": 85,
+        "predicate": [],
+        "description": "<p>Effect: On hit, all valid targets have a 10% chance of losing -1 ATK and SPD for 5 Activations.</p>"
+      }
+    ],
+    "grade": "A"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [
+    {
+      "name": "Arcane Storm",
+      "type": "affliction",
+      "_id": "my7s5vSmFrpaH4NJ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "arcane-storm-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.ikCAv5w4iNfHHqaE",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "label": "Arcane Storm 1",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "arcane-storm-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.HLAV9dhz632Rfp1K",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "label": "Arcane Storm 2",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.j42qPlBO6UlbdaV6.ActiveEffect.wNiNp4SdaZCiOFxa",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "zSzWgoQV50H0IDvZ"
+}

--- a/packs/core-moves/bane.json
+++ b/packs/core-moves/bane.json
@@ -1,0 +1,120 @@
+{
+  "name": "Bane",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "bane",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[suppressed] 5 and @Affliction[splinter] 5.</p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Bane",
+        "slug": "bane",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "adaptable",
+          "arcane"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 6,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 35,
+        "accuracy": 85,
+        "predicate": [],
+        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[suppressed] 5 and @Affliction[splinter] 5.</p>"
+      }
+    ],
+    "grade": "C"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [
+    {
+      "name": "Bane",
+      "type": "passive",
+      "_id": "fhP2Jja4p4qNvJSo",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "bane-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.splinterconditem",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "bane-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.suppressedcoitem",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.15GtkCYhWPhaRycg.ActiveEffect.kD9guYXqkGZD6vb0",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "uOvGmvCx7wJuc3ul"
+}

--- a/packs/core-moves/cone-of-force.json
+++ b/packs/core-moves/cone-of-force.json
@@ -1,0 +1,55 @@
+{
+  "name": "Cone of Force",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "cone-of-force",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Cone of Force",
+        "slug": "cone-of-force",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "adaptable",
+          "arcane",
+          "push-5",
+          "pulse"
+        ],
+        "range": {
+          "target": "cone",
+          "distance": 5,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 8
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 55,
+        "accuracy": 85,
+        "predicate": [],
+        "description": "<p>undefined</p>"
+      }
+    ],
+    "grade": "C"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "PtLQwF3roouF2ceS"
+}

--- a/packs/core-moves/entropic-wasting.json
+++ b/packs/core-moves/entropic-wasting.json
@@ -1,0 +1,55 @@
+{
+  "name": "Entropic Wasting",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "entropic-wasting",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Entropic Wasting",
+        "slug": "entropic-wasting",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "arcane",
+          "adaptable",
+          "ray",
+          "manipulate"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 4,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 50,
+        "accuracy": 90,
+        "predicate": [],
+        "description": "<p>Effect: The target cannot fall below 1 HP by damage from this attack.</p>"
+      }
+    ],
+    "grade": "C"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "QyJABjFWjjILj8ey"
+}

--- a/packs/core-moves/imperil-curse.json
+++ b/packs/core-moves/imperil-curse.json
@@ -1,0 +1,134 @@
+{
+  "name": "Imperil Curse",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "imperil-curse",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "<p>Effect: On hit, the target has a 50% chance of losing -1 DEF and SPDEF for 5 Activations, and a 20% chance of gaining @Affliction[cursed] 5.</p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Imperil Curse",
+        "slug": "imperil-curse",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "arcane",
+          "adaptable",
+          "ray",
+          "manipulate"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 6,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 25,
+        "accuracy": 80,
+        "predicate": [],
+        "description": "<p>Effect: On hit, the target has a 50% chance of losing -1 DEF and SPDEF for 5 Activations, and a 20% chance of gaining @Affliction[cursed] 5.</p>"
+      }
+    ],
+    "grade": "C"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [
+    {
+      "name": "Imperil Curse",
+      "type": "passive",
+      "_id": "R3yyR6v10SFMHu4G",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "imperil-curse-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "imperil-curse-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "imperil-curse-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.cursedcondititem",
+            "predicate": [],
+            "chance": 20,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.15GtkCYhWPhaRycg.ActiveEffect.kD9guYXqkGZD6vb0",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "uV727qfHvv12MBD5"
+}

--- a/packs/core-moves/luminaire.json
+++ b/packs/core-moves/luminaire.json
@@ -1,0 +1,123 @@
+{
+  "name": "Luminaire",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "luminaire",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "<p>Effect: Set-Up: The user gains +1 SPATK and EVA Stage for 5 Activations, and ends their Activation.</p><p>Resolution: On their next Activation, they attack with and resolve Luminaire. On hit, all valid targets have a 30% chance of losing -1 ACC for 5 Activations, and a 10% chance of gaining @Affliction[blinded] 5.</p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Luminaire",
+        "slug": "luminaire",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "arcane",
+          "adaptable",
+          "ray",
+          "pulse",
+          "set-up"
+        ],
+        "range": {
+          "target": "cone",
+          "distance": 6,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 11
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 160,
+        "accuracy": 90,
+        "predicate": [],
+        "description": "<p>Effect: Set-Up: The user gains +1 SPATK and EVA Stage for 5 Activations, and ends their Activation.</p><p>Resolution: On their next Activation, they attack with and resolve Luminaire. On hit, all valid targets have a 30% chance of losing -1 ACC for 5 Activations, and a 10% chance of gaining @Affliction[blinded] 5.</p>"
+      }
+    ],
+    "grade": "A"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [
+    {
+      "name": "Luminaire",
+      "type": "passive",
+      "_id": "4U2OfXfhMFNhjYMh",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "luminaire-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.wA5oCsgHmZLcHHSn",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "luminaire-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.blindedcondiitem",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.15GtkCYhWPhaRycg.ActiveEffect.kD9guYXqkGZD6vb0",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "jdY1fMOVV4wODaSR"
+}

--- a/packs/core-moves/magick-blaster.json
+++ b/packs/core-moves/magick-blaster.json
@@ -1,0 +1,121 @@
+{
+  "name": "Magick Blaster",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "magick-blaster",
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": "<p>Effect: On hit, the target has a 20% chance of being Flinched.</p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Magick Blaster",
+        "slug": "magick-blaster",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "arcane",
+          "adaptable",
+          "pulse",
+          "missile",
+          "2-strike",
+          "flinch-chance-2"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 5
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 60,
+        "accuracy": 85,
+        "predicate": [],
+        "description": "<p>Effect: On hit, the target has a 20% chance of being Flinched.</p>"
+      }
+    ],
+    "grade": "B"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [
+    {
+      "name": "Magick Blaster",
+      "type": "passive",
+      "_id": "efQofiqd3Q3QPmSZ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "magick-blaster-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -20
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinched 20%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.3KCZGRV9lMmb44FC.ActiveEffect.uM9lEbJS6Ee0AHd9",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "0QldRXlb3HavAAW3"
+}

--- a/packs/core-moves/magick-scintilla.json
+++ b/packs/core-moves/magick-scintilla.json
@@ -1,0 +1,56 @@
+{
+  "name": "Magick Scintilla",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "magick-scintilla",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Magick Scintilla",
+        "slug": "magick-scintilla",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "arcane",
+          "ray",
+          "friendly",
+          "priority-3",
+          "adaptable"
+        ],
+        "range": {
+          "target": "emanation",
+          "distance": 2,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 6
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 80,
+        "accuracy": 90,
+        "predicate": [],
+        "description": "<p>Effect: On hit. all valid targets are unable to make Attacks of Opportunity for 5 activations.</p>"
+      }
+    ],
+    "grade": "A"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "uwSvNbcpggaajrhw"
+}

--- a/packs/core-moves/mana-blast.json
+++ b/packs/core-moves/mana-blast.json
@@ -1,0 +1,133 @@
+{
+  "name": "Mana Blast",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "mana-blast",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [],
+      "notes": "undefined"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Mana Blast",
+        "slug": "mana-blast",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "blast-1",
+          "arcane",
+          "pulse",
+          "adaptable",
+          "explode",
+          "flinch-chance-1"
+        ],
+        "range": {
+          "target": "blast",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 70,
+        "accuracy": 95,
+        "predicate": [],
+        "description": "<p>Effect: On hit, the target has a 10% chance of losing -1 EVA Stage for 5 Activations, and a 50% chance of being Flinched.</p>"
+      }
+    ],
+    "grade": "C"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [
+    {
+      "name": "Mana Blast",
+      "type": "passive",
+      "_id": "jXGrd0eVuDQFnAqQ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "mana-blast-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -10
+              },
+              {
+                "mode": 5,
+                "property": "name",
+                "value": "Flinched 10%"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "mana-blast-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.hIE6W3Y5E9CyHiTy",
+            "predicate": [],
+            "chance": 10,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.3KCZGRV9lMmb44FC.ActiveEffect.uM9lEbJS6Ee0AHd9",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "sJd0tznkt5DWhquq"
+}

--- a/packs/core-moves/mana-shot.json
+++ b/packs/core-moves/mana-shot.json
@@ -1,0 +1,56 @@
+{
+  "name": "Mana Shot",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "mana-shot",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Mana Shot",
+        "slug": "mana-shot",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "arcane",
+          "adaptable",
+          "pulse",
+          "missile"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 15,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 2
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 40,
+        "accuracy": 100,
+        "defensiveStat": "def",
+        "predicate": [],
+        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>"
+      }
+    ],
+    "grade": "D"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "LEWxzncsMGrEC6JR"
+}

--- a/packs/core-moves/mana-whorl.json
+++ b/packs/core-moves/mana-whorl.json
@@ -1,0 +1,123 @@
+{
+  "name": "Mana Whorl",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "mana-whorl",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "<p>Effect: On hit, all valid targets become @Affliction[bound] 5. While @Affliction[bound], they also suffer from @Affliction[wracked].</p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Mana Whorl",
+        "slug": "mana-whorl",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "trap",
+          "blast-2",
+          "arcane",
+          "pulse",
+          "adaptable"
+        ],
+        "range": {
+          "target": "blast",
+          "distance": 8,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 5
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 45,
+        "accuracy": 75,
+        "predicate": [],
+        "description": "<p>Effect: On hit, all valid targets become @Affliction[bound] 5. While @Affliction[bound], they also suffer from @Affliction[wracked].</p>"
+      }
+    ],
+    "grade": "B"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [
+    {
+      "name": "Mana Whorl",
+      "type": "passive",
+      "_id": "htghEM6LYKTXaFy9",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "mana-whorl-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.boundconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "mana-whorl-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.wrackedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.gADis21rh3UuejhI.ActiveEffect.vWdwJhCMiSPqzBXU",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "3Qn2xyUwYBF24n5y"
+}

--- a/packs/core-moves/rending-spell.json
+++ b/packs/core-moves/rending-spell.json
@@ -1,0 +1,56 @@
+{
+  "name": "Rending Spell",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "rending-spell",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Rending Spell",
+        "slug": "rending-spell",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "adaptable",
+          "arcane",
+          "ray",
+          "pierce",
+          "manipulate"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 35,
+        "accuracy": 90,
+        "predicate": [],
+        "description": "<p>Effect: On hit, the target takes @Tick[-1].</p>"
+      }
+    ],
+    "grade": "B"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "6NULx72JeXAvsstZ"
+}

--- a/packs/core-moves/resonance-beam.json
+++ b/packs/core-moves/resonance-beam.json
@@ -1,0 +1,54 @@
+{
+  "name": "Resonance Beam",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": "<p>Effect: </p>"
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Resonance Beam",
+        "slug": "resonance-beam",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "use-opponents-stats",
+          "adaptable",
+          "arcane",
+          "ray"
+        ],
+        "range": {
+          "target": "line",
+          "distance": 6,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 6
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 90,
+        "accuracy": 90,
+        "predicate": [],
+        "description": "<p>Effect: This attack uses the targets' SPATK stats for damage calculation instead of the user's.</p>"
+      }
+    ],
+    "grade": "E"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "cMUvjHD8KAJRf1Bt"
+}

--- a/packs/core-moves/secret-force.json
+++ b/packs/core-moves/secret-force.json
@@ -1,0 +1,55 @@
+{
+  "name": "Secret Force",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "secret-force",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Secret Force",
+        "slug": "secret-force",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "arcane",
+          "adaptable",
+          "pulse"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 6,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 70,
+        "accuracy": 100,
+        "defensiveStat": "spa",
+        "predicate": [],
+        "description": "<p>Effect: This attack calculates damage against the target's SPATK, rather than SPDEF.</p>"
+      }
+    ],
+    "grade": "C"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "qORsSv8wOAze5uWE"
+}

--- a/packs/core-moves/spellbolt.json
+++ b/packs/core-moves/spellbolt.json
@@ -1,0 +1,55 @@
+{
+  "name": "Spellbolt",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "spellbolt",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Spellbolt",
+        "slug": "spellbolt",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "4-strike",
+          "arcane",
+          "adaptable",
+          "explode",
+          "pulse"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 15,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 25,
+        "accuracy": 100,
+        "predicate": []
+      }
+    ],
+    "grade": "C"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "BJFfQv4aGA8RmHdG"
+}

--- a/packs/core-moves/spirit-lance.json
+++ b/packs/core-moves/spirit-lance.json
@@ -1,0 +1,55 @@
+{
+  "name": "Spirit Lance",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "spirit-lance",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Spirit Lance",
+        "slug": "spirit-lance",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "adaptable",
+          "arcane",
+          "pulse",
+          "horn"
+        ],
+        "range": {
+          "target": "line",
+          "distance": 10,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 5
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 60,
+        "accuracy": 80,
+        "predicate": [],
+        "description": "<p>Effect: On hit, all targets lose @Tick[-1] for every 2 targets hit.</p>"
+      }
+    ],
+    "grade": "B"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "FYyxeQUkAOgyd4cD"
+}

--- a/packs/core-moves/stagnancy-curse.json
+++ b/packs/core-moves/stagnancy-curse.json
@@ -1,0 +1,146 @@
+{
+  "name": "Stagnancy Curse",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "stagnancy-curse",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Stagnancy Curse",
+        "slug": "stagnancy-curse",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+        "traits": [
+          "arcane",
+          "adaptable",
+          "ray",
+          "manipulate"
+        ],
+        "range": {
+          "target": "creature",
+          "distance": 4,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 5
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 45,
+        "accuracy": 90,
+        "predicate": [],
+        "description": "<p>Effect: On hit, the target has a 30% chance of losing -2 SPD and CRIT Stages for 5 Activations, and a 50% of gaining @Affliction[slowed] 5 and @Affliction[suppressed] 5.</p>"
+      }
+    ],
+    "grade": "B"
+  },
+  "img": "systems/ptr2e/img/svg/untyped_icon.svg",
+  "effects": [
+    {
+      "name": "Stagnancy Curse",
+      "type": "passive",
+      "_id": "hf273Sr2yc5XEn2u",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "stagnancy-curse-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "stagnancy-curse-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 30,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "stagnancy-curse-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.3BSugEZLheQIiDAk",
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "stagnancy-curse-attack",
+            "value": 0,
+            "predicate": [],
+            "chance": 50,
+            "affects": "target",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "alterations": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-moves.Item.15GtkCYhWPhaRycg.ActiveEffect.kD9guYXqkGZD6vb0",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "5Wa6PuAdcPXbfbnm"
+}


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Move: Arcane Empowerment
- Update Move: Arcane Enforcement
- Update Move: Arcane Fury
- Update Move: Arcane Storm
- Update Move: Bane
- Update Move: Cone of Force
- Update Move: Entropic Wasting
- Update Move: Imperil Curse
- Update Move: Stagnancy Curse
- Update Move: Luminaire
- Update Move: Magick Blaster
- Update Move: Magick Scintilla
- Update Move: Mana Blast
- Update Move: Mana Shot
- Update Move: Mana Whorl
- Update Move: Spellbolt
- Update Move: Rending Spell
- Update Move: Resonance Beam
- Update Move: Secret Force
- Update Move: Spirit Lance