### PR TITLE
Foundry Data Sync - Weather Ability Automations + New Effect Folders

### DIFF
--- a/packs/core-abilities/blue-cascade.json
+++ b/packs/core-abilities/blue-cascade.json
@@ -29,8 +29,7 @@
     "traits": [
       "domain",
       "aura",
-      "water",
-      "partial-automation"
+      "water"
     ],
     "slug": "blue-cascade",
     "_migration": {
@@ -41,7 +40,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "LmrzkdfdJw8TfOEx",
@@ -50,7 +50,7 @@
       "name": "Blue Cascade",
       "type": "passive",
       "_id": "VmPl9gEjMtUa6X2L",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/water_icon.svg",
       "system": {
         "changes": [
           {
@@ -95,8 +95,87 @@
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.2.0.3",
         "createdTime": 1722258319945,
-        "modifiedTime": 1722258338460,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+        "modifiedTime": 1741609896104,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    },
+    {
+      "name": "Blue Cascade (Aura)",
+      "type": "passive",
+      "_id": "VL6bnPVbrzvxZ4Vj",
+      "img": "systems/ptr2e/img/svg/water_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "aura",
+            "key": "",
+            "value": 0,
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "radius": 5,
+            "effects": [
+              {
+                "uuid": "Compendium.ptr2e.core-effects.Item.GklzCbJSZWPd5lrw",
+                "affects": "all",
+                "events": [
+                  "enter"
+                ],
+                "removeOnExit": true,
+                "includesSelf": false,
+                "appliesSelfOnly": false,
+                "predicate": [
+                  "target:trait:water"
+                ]
+              }
+            ],
+            "appearance": {
+              "border": {
+                "color": "#FF0000",
+                "alpha": 0.75
+              },
+              "highlight": {
+                "color": "user-color",
+                "alpha": 0.25
+              },
+              "texture": null
+            },
+            "mergeExisting": true
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": 1741610126654,
+        "modifiedTime": 1741610199144,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
       }
     }
   ]

--- a/packs/core-abilities/chlorophyll.json
+++ b/packs/core-abilities/chlorophyll.json
@@ -18,11 +18,11 @@
           "target": "self",
           "unit": "m"
         },
-        "description": "<p>Effect: The user's SPD stat is increased by 50% and the user has +2 default SPD Stages in Sunny Weather. The user is treated as having the Grass Type for the effects of Sunny Weather.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user has +2 default SPD Stages in Sunny Weather. The user is treated as having the Grass Type for the effects of Sunny Weather.</p>",
+        "img": "systems/ptr2e/img/svg/grass_icon.svg"
       }
     ],
-    "description": "<p>Effect: The user's SPD stat is increased by 50% and the user has +2 default SPD Stages in Sunny Weather. The user is treated as having the Grass Type for the effects of Sunny Weather.</p>",
+    "description": "<p>Effect: The user has +2 default SPD Stages in Sunny Weather. The user is treated as having the Grass Type for the effects of Sunny Weather.</p>",
     "traits": [
       "environ"
     ],
@@ -39,7 +39,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "8RkpxP9VcH6mzSEM",
@@ -52,28 +53,24 @@
       "system": {
         "changes": [
           {
-            "type": "roll-option",
-            "key": "",
-            "value": "weather:sunny",
-            "predicate": [],
-            "domain": "all",
-            "toggleable": true,
-            "count": false,
-            "alwaysActive": false,
-            "state": true,
-            "mode": 2,
-            "priority": null,
-            "ignored": false,
-            "suboptions": []
-          },
-          {
             "type": "basic",
-            "key": "system.modifiers.speMultiplier",
+            "key": "system.attributes.spe.stage",
             "value": 2,
             "mode": 1,
             "predicate": [
-              "weather:sunny"
+              "effect:summon:sunny-weather"
             ],
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "grass",
+            "predicate": [
+              "effect:summon:sunny-weather"
+            ],
+            "mode": 2,
             "priority": null,
             "ignored": false
           }
@@ -106,10 +103,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.2.0",
+        "systemVersion": "1.1.0.beta",
         "createdTime": null,
-        "modifiedTime": 1730629510330,
-        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
+        "modifiedTime": 1741610457583,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
       }
     }
   ]

--- a/packs/core-abilities/snow-cloak.json
+++ b/packs/core-abilities/snow-cloak.json
@@ -41,7 +41,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "dnKczVUT14Kp8vjB",
@@ -50,31 +51,26 @@
       "name": "Snow Cloak",
       "type": "passive",
       "_id": "tWgSdhloRhfwJyYS",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "icons/magic/air/weather-clouds-snow.webp",
       "system": {
         "changes": [
           {
-            "type": "roll-option",
-            "key": "",
-            "value": "weather:snowy",
-            "predicate": [],
-            "domain": "all",
-            "toggleable": true,
-            "count": false,
-            "state": true,
-            "label": "In Snowy Weather?",
-            "alwaysActive": false,
-            "mode": 2,
-            "priority": null,
-            "ignored": false,
-            "suboptions": []
-          },
-          {
             "type": "basic",
-            "key": "system.battleStats.evasion.Stage",
+            "key": "system.battleStats.evasion.stage",
             "value": 1,
             "predicate": [
-              "weather:snowy"
+              "effect:summon:snowy-weather"
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "ice",
+            "predicate": [
+              "effect:summon:snowy-weather"
             ],
             "mode": 2,
             "priority": null,
@@ -109,10 +105,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.0.0",
+        "systemVersion": "1.1.0.beta",
         "createdTime": 1730213276790,
-        "modifiedTime": 1730213358828,
-        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
+        "modifiedTime": 1741610895583,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
       }
     }
   ]

--- a/packs/core-abilities/swift-swim.json
+++ b/packs/core-abilities/swift-swim.json
@@ -18,11 +18,11 @@
           "target": "self",
           "unit": "m"
         },
-        "description": "<p>Effect: The user's SPD stat is increased by 50% and the user has +2 default SPD Stages in Rainy Weather. The user is considered Water Type for the effects of Rainy Weather.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user has +2 default SPD Stages in Rainy Weather. The user is considered Water Type for the effects of Rainy Weather.</p>",
+        "img": "icons/magic/air/weather-clouds-rain.webp"
       }
     ],
-    "description": "<p>Effect: The user's SPD stat is increased by 50% and the user has +2 default SPD Stages in Rainy Weather. The user is considered Water Type for the effects of Rainy Weather.</p>",
+    "description": "<p>Effect: The user has +2 default SPD Stages in Rainy Weather. The user is considered Water Type for the effects of Rainy Weather.</p>",
     "traits": [
       "environ"
     ],
@@ -35,9 +35,75 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "ENQChf1sKODsTvKL",
-  "effects": []
+  "effects": [
+    {
+      "name": "Swift Swim",
+      "type": "passive",
+      "_id": "VldDhR0YHBilfrTy",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.attributes.spe.stage",
+            "value": 2,
+            "predicate": [
+              "effect:summon:rainy-weather"
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          },
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "water",
+            "predicate": [
+              "effect:summon:rainy-weather"
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": 1741609761601,
+        "modifiedTime": 1741609829063,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ]
 }

--- a/packs/core-effects/blue-cascade.json
+++ b/packs/core-effects/blue-cascade.json
@@ -1,0 +1,74 @@
+{
+  "folder": "sP8yfpABdpdAz4aV",
+  "name": "Blue Cascade",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "traits": []
+  },
+  "_id": "GklzCbJSZWPd5lrw",
+  "img": "systems/ptr2e/img/svg/water_icon.svg",
+  "effects": [
+    {
+      "name": "Blue Cascade",
+      "type": "passive",
+      "_id": "MYA6WgItWi1mxcQq",
+      "img": "systems/ptr2e/img/svg/water_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "water-attack-power",
+            "value": 20,
+            "predicate": [],
+            "label": "Blue Cascade",
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.1.0.beta",
+        "createdTime": 1741610060223,
+        "modifiedTime": 1741610093304,
+        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-effects/boss-dr.json
+++ b/packs/core-effects/boss-dr.json
@@ -6,14 +6,14 @@
       "version": 0.109,
       "previous": null
     },
-    "slug": null,
-    "description": "",
+    "slug": "boss-dr",
     "traits": [],
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "WyIdpwgbw0rWWfWW",
@@ -72,21 +72,5 @@
       }
     }
   ],
-  "folder": null,
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "Kc3DOunCh3ClAeHS": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": "Item.WyIdpwgbw0rWWfWW",
-    "duplicateSource": null,
-    "coreVersion": "12.331",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.4.1.0",
-    "createdTime": 1734210380671,
-    "modifiedTime": 1735915832186,
-    "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-  }
+  "folder": "QUgx4S1LlBbCXWnX"
 }

--- a/packs/core-effects/boss-health.json
+++ b/packs/core-effects/boss-health.json
@@ -6,14 +6,14 @@
       "version": 0.109,
       "previous": null
     },
-    "slug": null,
-    "description": "",
+    "slug": "boss-health",
     "traits": [],
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "u9gG3JhXxCp7fQCA",
@@ -71,21 +71,5 @@
       }
     }
   ],
-  "folder": null,
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "Kc3DOunCh3ClAeHS": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": "Item.u9gG3JhXxCp7fQCA",
-    "duplicateSource": null,
-    "coreVersion": "12.331",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.5.0",
-    "createdTime": 1735915897733,
-    "modifiedTime": 1735915998495,
-    "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-  }
+  "folder": "QUgx4S1LlBbCXWnX"
 }

--- a/packs/core-effects/boss-pp.json
+++ b/packs/core-effects/boss-pp.json
@@ -6,7 +6,13 @@
       "version": 0.11,
       "previous": null
     },
-    "traits": []
+    "traits": [],
+    "slug": "boss-pp",
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    }
   },
   "img": "systems/ptr2e/img/item-icons/pp%20max.webp",
   "effects": [
@@ -62,6 +68,6 @@
       }
     }
   ],
-  "flags": {},
-  "_id": "dXiNkkqCoB3HjYsp"
+  "_id": "dXiNkkqCoB3HjYsp",
+  "folder": "QUgx4S1LlBbCXWnX"
 }

--- a/packs/core-effects/friend-guard-dr.json
+++ b/packs/core-effects/friend-guard-dr.json
@@ -15,8 +15,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "slug": "friend-guard-dr"
   },
   "img": "icons/magic/defensive/illusion-evasion-echo-purple.webp",
   "effects": [
@@ -73,6 +75,6 @@
       }
     }
   ],
-  "flags": {},
-  "_id": "AUlSkFUziUM3nxww"
+  "_id": "AUlSkFUziUM3nxww",
+  "folder": "sP8yfpABdpdAz4aV"
 }

--- a/packs/core-effects/full-iv-booster-for-bosses.json
+++ b/packs/core-effects/full-iv-booster-for-bosses.json
@@ -17,7 +17,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "cwnxDKZUoQdmE4lP",
@@ -119,5 +120,6 @@
         "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
       }
     }
-  ]
+  ],
+  "folder": "QUgx4S1LlBbCXWnX"
 }

--- a/packs/core-effects/graveyard.json
+++ b/packs/core-effects/graveyard.json
@@ -8,12 +8,13 @@
     },
     "traits": [],
     "slug": "graveyard",
-    "description": "<p>Effect for @UUID[Compendium.ptr2e.core-abilities.Item.Xwtf9S4YvML7PRBj].</p>",
+    "description": "<p>Effect for @UUID[Compendium.ptr2e.core-abilities.Item.Xwtf9S4YvML7PRBj]{Xwtf9S4YvML7PRBj}.</p>",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "pqbzkawwRmk3qTr1",
@@ -53,7 +54,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "<p>Effect for @UUID[Compendium.ptr2e.core-abilities.Item.Xwtf9S4YvML7PRBj].</p>",
+      "description": "<p>Effect for @UUID[Compendium.ptr2e.core-abilities.Item.Xwtf9S4YvML7PRBj]{Xwtf9S4YvML7PRBj}.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -71,5 +72,6 @@
         "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
       }
     }
-  ]
+  ],
+  "folder": "sP8yfpABdpdAz4aV"
 }

--- a/packs/core-effects/pollen-field.json
+++ b/packs/core-effects/pollen-field.json
@@ -11,8 +11,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "slug": "pollen-field"
   },
   "_id": "jCPr4ariOybbM3ci",
   "img": "systems/ptr2e/img/svg/bug_icon.svg",
@@ -71,5 +73,5 @@
       }
     }
   ],
-  "flags": {}
+  "folder": "sP8yfpABdpdAz4aV"
 }

--- a/packs/core-effects/wickedness.json
+++ b/packs/core-effects/wickedness.json
@@ -11,8 +11,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "slug": "wickedness"
   },
   "_id": "SPJ5lB8B2MJ17FVC",
   "img": "systems/ptr2e/img/svg/dark_icon.svg",
@@ -71,5 +73,5 @@
       }
     }
   ],
-  "flags": {}
+  "folder": "sP8yfpABdpdAz4aV"
 }


### PR DESCRIPTION
@Ashe

New folders added are "aura effects" and "boss effects", folder IDs should be obvious and easy to grab from PR code. PTR2e Effects compendium ofc.
- Update Ability: Swift Swim
- Update Effect: Boss DR
- Update Effect: Boss Health
- Update Effect: Boss PP
- Update Effect: Friend Guard DR
- Update Effect: Graveyard
- Update Effect: Full IV Booster for Bosses
- Update Effect: Pollen Field
- Update Effect: Wickedness
- Update Effect: Blue Cascade
- Update Ability: Blue Cascade
- Update Ability: Chlorophyll
- Update Ability: Snow Cloak