### PR TITLE
Foundry Data Sync - Wickedness aura targeting correction

### DIFF
--- a/packs/core-abilities/wickedness.json
+++ b/packs/core-abilities/wickedness.json
@@ -41,7 +41,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "6o74KpM7eBLJij3Z",
@@ -125,9 +126,7 @@
                 "removeOnExit": true,
                 "includesSelf": false,
                 "appliesSelfOnly": false,
-                "predicate": [
-                  "target:trait:dark"
-                ]
+                "predicate": []
               }
             ],
             "appearance": {
@@ -172,9 +171,9 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "1.1.0.beta",
         "createdTime": 1733415511407,
-        "modifiedTime": 1733415572852,
+        "modifiedTime": 1741611189302,
         "lastModifiedBy": "IcBpMqhFuTck9VpX"
       }
     }


### PR DESCRIPTION
The aura was only buffing dark types. This is incorrect to the effect text.
- Update Ability: Wickedness