### PR TITLE
Foundry Data Sync - Missile + Contact Moves

### DIFF
--- a/packs/core-moves/psybolt.json
+++ b/packs/core-moves/psybolt.json
@@ -12,7 +12,6 @@
         "traits": [
           "missile",
           "priority-1",
-          "contact",
           "pp-updated"
         ],
         "range": {
@@ -31,20 +30,22 @@
         "types": [
           "psychic"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "E",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "WGAbjWP0WJxwcHYj",

--- a/packs/core-moves/rock-blast.json
+++ b/packs/core-moves/rock-blast.json
@@ -12,7 +12,6 @@
         "traits": [
           "5-strike",
           "missile",
-          "contact",
           "pp-updated"
         ],
         "range": {
@@ -30,7 +29,8 @@
         "types": [
           "rock"
         ],
-        "img": "systems/ptr2e/img/svg/rock_icon.svg"
+        "img": "systems/ptr2e/img/svg/rock_icon.svg",
+        "predicate": []
       }
     ],
     "grade": "B",
@@ -38,7 +38,13 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "sTRyJHmIeZHJGAD9",


### PR DESCRIPTION
Fixes both these moves to remove Contact. Also checked and found there're no others with this issue.
- Update Move: Rock Blast
- Update Move: Psybolt