### PR TITLE
Foundry Data Sync - Hit & Run Rebalance

### DIFF
--- a/packs/core-perks/hit-run.json
+++ b/packs/core-perks/hit-run.json
@@ -4,8 +4,8 @@
   "folder": "zrVtKATNxzLNxTUe",
   "system": {
     "prerequisites": [],
-    "cost": 1,
-    "description": "<p>After resolving an Attack, you cannot be targeted with [Interrupt X] Actions until the end of your Activation.</p>",
+    "cost": 3,
+    "description": "<p>You gain Run Away as a free, slotless ability.</p>",
     "actions": [
       {
         "name": "Hit & Run",
@@ -31,6 +31,10 @@
     },
     "nodes": [
       {
+        "x": 130,
+        "y": 145,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "muse",
           "root-4",
@@ -42,18 +46,14 @@
           "type-style"
         ],
         "config": {
+          "texture": "systems/ptr2e/img/perk-icons/Combat.svg",
           "alpha": null,
-          "backgroundColor": "#ff8000",
+          "backgroundColor": null,
           "borderColor": null,
           "borderWidth": null,
-          "texture": "systems/ptr2e/img/perk-icons/Combat.svg",
           "tint": null,
           "scale": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 130,
-        "y": 145,
         "tier": null
       }
     ],
@@ -69,7 +69,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "1SjUYN4180BTBYCk",


### PR DESCRIPTION
As written, Hit & Run was kinda toxic. This rework increases the AP cost of the perk, and nerfs it's effect.
- Update Perk: Hit & Run