### PR TITLE
Foundry Data Sync - Weak Armor Buff

### DIFF
--- a/packs/core-abilities/weak-armor.json
+++ b/packs/core-abilities/weak-armor.json
@@ -23,7 +23,7 @@
         "img": "systems/ptr2e/img/perk-icons/Combat.svg"
       }
     ],
-    "description": "<p>Trigger: The user is hit by a Physical-Category attack. </p><p>Effect: The user loses -1 DEF Stage and gains +1 SPD Stage for 5 Activations.</p>",
+    "description": "<p>Trigger: The user is hit by a Physical-Category attack.</p><p>Effect: The user loses -1 DEF Stage and gains +2 SPD Stage for 5 Activations.</p>",
     "traits": [],
     "slug": "weak-armor",
     "_migration": {
@@ -34,7 +34,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "NlLmGi66S7A0TTjg",
@@ -53,20 +54,24 @@
             "predicate": [],
             "chance": 100,
             "affects": "defensive",
+            "dontMerge": false,
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           },
           {
             "type": "roll-effect",
             "key": "physical-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLM",
+            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLZ",
             "predicate": [],
             "chance": 100,
             "affects": "defensive",
+            "dontMerge": false,
             "mode": 2,
             "priority": null,
-            "ignored": false
+            "ignored": false,
+            "alterations": []
           }
         ],
         "slug": null,
@@ -97,10 +102,10 @@
         "duplicateSource": null,
         "coreVersion": "12.331",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.2",
+        "systemVersion": "1.1.3.beta",
         "createdTime": 1729246091402,
-        "modifiedTime": 1736881773684,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+        "modifiedTime": 1743348724253,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
       }
     }
   ]


### PR DESCRIPTION
To bring it in line with the buff introduced in Gen8 by gamefreak.
- Update Ability: Weak Armor