### PR TITLE
Foundry Data Sync - New Gear + Some Folder Reorganisation

### DIFF
--- a/packs/core-gear/ability-shield.json
+++ b/packs/core-gear/ability-shield.json
@@ -17,7 +17,7 @@
     "traits": [
       "combat",
       "defensive",
-      "held"
+      "worn"
     ],
     "actions": [],
     "description": "<p>Effect: The user cannot have any of its Abilities replaced or @Affliction[nullified].</p>",
@@ -53,6 +53,5 @@
   "img": "systems/ptr2e/img/icons/equipment_icon.webp",
   "effects": [],
   "folder": "UUWElZA9w1KEqZS7",
-  "flags": {},
   "_id": "XSvdaGlgsUhe8e7z"
 }

--- a/packs/core-gear/active-camouflage.json
+++ b/packs/core-gear/active-camouflage.json
@@ -1,0 +1,56 @@
+{
+  "folder": "6VDJBcrqVDh5bYtA",
+  "name": "Active Camouflage",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR2e - SciFi",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "sci-fi",
+      "accessory"
+    ],
+    "actions": [],
+    "description": "<p>This large poncho-like accessory houses an active light refraction technology, allowing the user to bend light around themselves in order to temporarily appear invisible. May use it to spend 5 PP to gain @Affliction[invisible] 5.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "accessory"
+    },
+    "grade": "B",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "7GLE6Uao6mzuibZV"
+}

--- a/packs/core-gear/altru-polar-gear.json
+++ b/packs/core-gear/altru-polar-gear.json
@@ -1,5 +1,5 @@
 {
-  "folder": "PGpYU7mfnRpzOZSm",
+  "folder": "UUWElZA9w1KEqZS7",
   "name": "Altru Polar Gear",
   "type": "equipment",
   "system": {
@@ -48,7 +48,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "img": "systems/ptr2e/img/icons/equipment_icon.webp",

--- a/packs/core-gear/auspicious-armor.json
+++ b/packs/core-gear/auspicious-armor.json
@@ -52,7 +52,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "img": "systems/ptr2e/img/icons/equipment_icon.webp",
@@ -137,6 +138,6 @@
       }
     }
   ],
-  "folder": "PGpYU7mfnRpzOZSm",
+  "folder": "UUWElZA9w1KEqZS7",
   "_id": "CFFlKZuXaoUni0V8"
 }

--- a/packs/core-gear/bicycle.json
+++ b/packs/core-gear/bicycle.json
@@ -1,0 +1,57 @@
+{
+  "folder": "PGpYU7mfnRpzOZSm",
+  "name": "Bicycle",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "vehicle",
+      "rapid",
+      "held"
+    ],
+    "actions": [],
+    "description": "<p>Whilst riding a Bicycle, you gain the @Trait[rapid] trait, resulting in a 50% increase in your Overland Movement Allowance. Mounting a Bicycle is a Complex Action unless you have the Trained Rider perk. Skill checks made to operate a mechanical Bicycle use the Ride Skill.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": 1,
+      "slot": "held"
+    },
+    "grade": "D",
+    "fling": {
+      "type": "untyped",
+      "power": 80,
+      "accuracy": 60,
+      "hide": false
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/item-icons/acro%20bike.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "R1Q83uyT6WXTLUSC"
+}

--- a/packs/core-gear/malicious-armor.json
+++ b/packs/core-gear/malicious-armor.json
@@ -138,6 +138,6 @@
       }
     }
   ],
-  "folder": "PGpYU7mfnRpzOZSm",
+  "folder": "UUWElZA9w1KEqZS7",
   "_id": "wQCKwcdil3wD3eBS"
 }

--- a/packs/core-gear/old-rod.json
+++ b/packs/core-gear/old-rod.json
@@ -1,0 +1,59 @@
+{
+  "folder": "V4skAU6G3OH5fXae",
+  "name": "Old Rod",
+  "type": "gear",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": {
+        "schema": 0.11,
+        "foundry": "12.331",
+        "system": "1.0.7.beta"
+      }
+    },
+    "traits": [
+      "fishing-rod"
+    ],
+    "actions": [],
+    "description": "<p>This Old Rod will allow you to go fishing, but it's not particularly helpful.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": 2,
+      "slot": "held"
+    },
+    "grade": "E",
+    "fling": {
+      "type": "normal",
+      "power": 30,
+      "accuracy": 100,
+      "hide": true
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    }
+  },
+  "img": "systems/ptr2e/img/icons/gear_icon.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "V5HyeyMdtvpz7UwA"
+}

--- a/packs/core-gear/personal-forcefield.json
+++ b/packs/core-gear/personal-forcefield.json
@@ -1,0 +1,56 @@
+{
+  "folder": "V4skAU6G3OH5fXad",
+  "name": "Personal Forcefield",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e - SciFi",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "sci-fi",
+      "backpack"
+    ],
+    "actions": [],
+    "description": "<p>A highly experimental technology reverse engineered from an alien device, the personal forcefield integrates with the wearer's implants and vitals. As a complex action, the wielder may convert ticks of Power Points into ticks of Shields at a 1-to-1 ratio. Shields gained in this manner may not benefit from the Improved Shielding perk. </p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": null,
+      "slot": "backpack"
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "2uTgT9SkZP8ycKxD"
+}


### PR DESCRIPTION
Adds the Active Camo, Personal Forcefield sci-fi items, and the Bicycle and Old Rod items.
- Update Gear: Old Rod
- Update Equipment: Active Camouflage
- Update Equipment: Bicycle
- Update Equipment: Personal Forcefield
- Update Equipment: Malicious Armor
- Update Equipment: Altru Polar Gear
- Update Equipment: Auspicious Armor
- Update Equipment: Ability Shield