### PR TITLE
Foundry Data Sync - Ability Perk Auto-Unlocks

### DIFF
--- a/packs/core-perks/one-with-the-green.json
+++ b/packs/core-perks/one-with-the-green.json
@@ -13,21 +13,15 @@
         "slug": "one-with-the-green",
         "description": "<p>You add the Sap Sipper Ability to your Trained Abilities list.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "one-with-the-green",
@@ -59,22 +53,22 @@
         "tier": null
       }
     ],
-    "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
+    "autoUnlock": [
+      "ability:sap-sipper"
+    ],
     "global": true,
     "webs": [],
     "design": {
       "arena": "physical",
       "approach": "resilience",
-      "archetype": "[Grass]"
+      "archetype": "grass"
     },
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "ks3F2x6TCKlFrWTO",

--- a/packs/core-perks/swan-song.json
+++ b/packs/core-perks/swan-song.json
@@ -45,13 +45,14 @@
     "design": {
       "arena": "social",
       "approach": "power",
-      "archetype": ""
+      "archetype": "musician"
     },
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "img": "systems/ptr2e/img/perk-icons/Musician.svg",

--- a/packs/core-perks/vigilant-guardian.json
+++ b/packs/core-perks/vigilant-guardian.json
@@ -36,7 +36,7 @@
       }
     ],
     "autoUnlock": [
-      "friend-guard"
+      "ability:friend-guard"
     ],
     "global": true,
     "webs": [],

--- a/packs/core-perks/vigilant-guardian.json
+++ b/packs/core-perks/vigilant-guardian.json
@@ -35,7 +35,9 @@
         "tier": null
       }
     ],
-    "autoUnlock": [],
+    "autoUnlock": [
+      "friend-guard"
+    ],
     "global": true,
     "webs": [],
     "design": {
@@ -47,7 +49,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "img": "systems/ptr2e/img/perk-icons/Combat.svg",


### PR DESCRIPTION
Should make it so that the 3 perks in question auto-unlock if the actor already has those abilities.
- Update Perk: Swan Song
- Update Perk: One With The Green
- Update Perk: Vigilant Guardian