### PR TITLE
Foundry Data Sync - New Archetype - Musician

### DIFF
--- a/packs/core-perks/break-up-song.json
+++ b/packs/core-perks/break-up-song.json
@@ -1,0 +1,61 @@
+{
+  "folder": "lzLExT1c5IqNcbnB",
+  "name": "Break-Up Song",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Break-Up Song Action (#1)",
+        "slug": "break-up-song",
+        "description": "<p>The user can cure nearby allies of @Affliction[charmed].</p>",
+        "traits": [],
+        "type": "generic",
+        "img": "systems/ptr2e/img/perk-icons/Musician.svg",
+        "range": {
+          "target": "emanation",
+          "distance": 5,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "simple",
+          "powerPoints": 3
+        }
+      }
+    ],
+    "description": "<p>The user can cure nearby allies of @Affliction[charmed].</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.singing.mod}",
+          40
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "musician"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Musician.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "ecTtuQNB6QPAwGwU"
+}

--- a/packs/core-perks/break-up-song.json
+++ b/packs/core-perks/break-up-song.json
@@ -16,7 +16,7 @@
     },
     "actions": [
       {
-        "name": "Break-Up Song Action (#1)",
+        "name": "Break-Up Song",
         "slug": "break-up-song",
         "description": "<p>The user can cure nearby allies of @Affliction[charmed].</p>",
         "traits": [],

--- a/packs/core-perks/cover-artist.json
+++ b/packs/core-perks/cover-artist.json
@@ -1,0 +1,143 @@
+{
+  "folder": "lzLExT1c5IqNcbnB",
+  "name": "Cover Artist",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>You gain access to the Musician tutor list, and learn the moves @UUID[Compendium.ptr2e.core-moves.ddcyCuH4t0mVmB7n]{Sing}, @UUID[Compendium.ptr2e.core-moves.h2xOusyckAvQlQtf]{Bark} and @UUID[Compendium.ptr2e.core-moves.ETIoZqMMiW74sq3s]{Snarl} if you did not already possess them.</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.singing.mod}",
+          40
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 1,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "musician"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Musician.svg",
+  "effects": [
+    {
+      "name": "Cover Artist",
+      "type": "passive",
+      "_id": "9ihEGOB1lzPM2n88",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.ddcyCuH4t0mVmB7n",
+            "predicate": [],
+            "allowDuplicate": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.h2xOusyckAvQlQtf",
+            "predicate": [],
+            "allowDuplicate": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.ETIoZqMMiW74sq3s",
+            "predicate": [],
+            "allowDuplicate": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.2.1.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "DRgegaAcfqpkiBMK"
+}

--- a/packs/core-perks/guerilla-radio.json
+++ b/packs/core-perks/guerilla-radio.json
@@ -1,0 +1,107 @@
+{
+  "folder": "lzLExT1c5IqNcbnB",
+  "name": "Guerilla Radio",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>You gain the @UUID[Compendium.ptr2e.core-abilities.LVKlym7cP5CTEF26]{Punk Rock} ability as a tutored ability for yourself.</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.singing.mod}",
+          55
+        ]
+      }
+    ],
+    "autoUnlock": [
+      "ability:punk-rock"
+    ],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "resilience",
+      "archetype": "musician"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Musician.svg",
+  "effects": [
+    {
+      "name": "Guerilla Radio",
+      "type": "passive",
+      "_id": "TkJC1FA2Nw0lNigO",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.LVKlym7cP5CTEF26",
+            "predicate": [],
+            "allowDuplicate": false,
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.2.1.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "74H8ZsuebIkG27aJ"
+}

--- a/packs/core-perks/meditative-hymn.json
+++ b/packs/core-perks/meditative-hymn.json
@@ -1,0 +1,59 @@
+{
+  "folder": "lzLExT1c5IqNcbnB",
+  "name": "Meditative Hymn",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Meditative Hymn",
+        "slug": "meditative-hymn",
+        "description": "<p>The user can cure nearby allies of @Affliction[confused].</p>",
+        "traits": [],
+        "type": "generic",
+        "img": "systems/ptr2e/img/perk-icons/Musician.svg",
+        "range": {
+          "target": "enemy",
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "simple"
+        }
+      }
+    ],
+    "description": "<p>The user can cure nearby allies of @Affliction[confused].</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.singing.mod}",
+          40
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "musician"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Musician.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "IriqJkYNMBhbX7Rj"
+}

--- a/packs/core-perks/rousing-song.json
+++ b/packs/core-perks/rousing-song.json
@@ -1,0 +1,61 @@
+{
+  "folder": "lzLExT1c5IqNcbnB",
+  "name": "Rousing Song",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Rousing Song",
+        "slug": "rousing-song",
+        "description": "<p>You cure all allies within range of @Affliction[drowsy].</p>",
+        "traits": [],
+        "type": "generic",
+        "img": "systems/ptr2e/img/perk-icons/Musician.svg",
+        "range": {
+          "target": "emanation",
+          "distance": 5,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "simple",
+          "powerPoints": 3
+        }
+      }
+    ],
+    "description": "<p>The user can cure nearby allies of @Affliction[drowsy].</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.singing.mod}",
+          40
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "resilience",
+      "archetype": "musician"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Musician.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "mmH15ZJ0dH2LDfsg"
+}


### PR DESCRIPTION
Pre-sorted with a folder ID, just needs the Musician folder created on the back-end with matching ID. Swan Song should ideally be relocated to this archetype's web location with Perk Web v3.
- Update Perk: Break-Up Song
- Update Perk: Cover Artist
- Update Perk: Guerilla Radio
- Update Perk: Meditative Hymn
- Update Perk: Rousing Song