### PR TITLE
Foundry Data Sync - Gambler and Occult Archetype Starts,  a bunch of new perks, some perk wording updates.

### DIFF
--- a/packs/core-moves/ally-recall.json
+++ b/packs/core-moves/ally-recall.json
@@ -1,0 +1,54 @@
+{
+  "name": "Ally Recall",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "ally-recall",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Ally Recall",
+        "slug": "ally-recall",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/psychic_icon.svg",
+        "traits": [
+          "delay-2",
+          "blast-5",
+          "teleport"
+        ],
+        "range": {
+          "target": "blast",
+          "distance": 25,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 6,
+          "delay": 2
+        },
+        "types": [
+          "psychic"
+        ],
+        "category": "status",
+        "accuracy": 90,
+        "predicate": [],
+        "description": "<p>Effect: All valid allied targets in range are relocated to spaces as close to the user as possible, as per Teleport Movement. On miss, a target is Scattered from RI3 (as per [Fling]). Relocated creatures fill the spaces closet to the user from the relocated creature’s original location, and it is at the GM’s discretion to position creatures avoiding squeezing and overly dangerous environmental conditions (such as moving a creature above a bottomless pit.)</p>"
+      }
+    ],
+    "grade": "A"
+  },
+  "img": "systems/ptr2e/img/svg/psychic_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "vfD9OztxBbceUce5"
+}

--- a/packs/core-perks/arthroarmor.json
+++ b/packs/core-perks/arthroarmor.json
@@ -1,0 +1,103 @@
+{
+  "folder": "o5iIUG4Bj40M86yi",
+  "name": "Arthroarmor",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "arthroarmor",
+    "description": "<p>Effect: The user gains Chitin Plates as a Tutored Ability.</p>",
+    "traits": [],
+    "prerequisites": [
+      "trait:bug"
+    ],
+    "autoUnlock": [
+      "item:perk:chitin-plates"
+    ],
+    "cost": 2,
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "bug"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/creatures/invertebrates/beetle-stag-tan-brown.webp",
+  "effects": [
+    {
+      "name": "Arthroarmor",
+      "type": "passive",
+      "_id": "kc8ikOMwT7wKUVK5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.gDSxrDlryQod2sNV",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.2.1.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "755YpplHAof2NTRe"
+}

--- a/packs/core-perks/arthroprods.json
+++ b/packs/core-perks/arthroprods.json
@@ -1,0 +1,39 @@
+{
+  "folder": "o5iIUG4Bj40M86yi",
+  "name": "Arthroprods",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "arthroprods",
+    "description": "<p>Effect: The user’s [Jaw], [Horn], [Wind], [Sonic], [Tail], and [Sharp] have +10% Power, deal +5 flat damage, and gain [Crit 1] (or have their Crit value increased by 1).</p>",
+    "traits": [],
+    "prerequisites": [
+      "trait:bug"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "bug"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/creatures/invertebrates/beetle-grub-larvae-gray.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "gm8Mi7b91bUE385m"
+}

--- a/packs/core-perks/away-with-you.json
+++ b/packs/core-perks/away-with-you.json
@@ -1,0 +1,39 @@
+{
+  "folder": "F4b52L00KrAtdPu5",
+  "name": "Away With You!",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "away-with-you",
+    "description": "<p>Effect: The user may spend X PP as a Free Action to have their next Physical or Special-Category Attack gain [Push 2*X] (or have its Push value increased by 2*X) and [Delay 2] (or have its Delay increased by 2).</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:telekinetic-potential"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "mental",
+      "approach": "power",
+      "archetype": "psychic"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/magic/air/air-wave-gust-blue.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "0TjRIqv3V1uPA34b"
+}

--- a/packs/core-perks/beckoning-the-beyond.json
+++ b/packs/core-perks/beckoning-the-beyond.json
@@ -1,0 +1,39 @@
+{
+  "folder": "gB7SZ3Y6wf3Qjjtr",
+  "name": "Beckoning the Beyond",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "beckoning-the-beyond",
+    "description": "<p>Effect: By spending 2 IP as an Exploration Action, the user can conduct a Séance. These rituals summon spirits from around the user’s location – could be local nature spirits, the spirits of the recently deceased, revenants haunting the area, or perhaps transient entities. A Séance is primarily conducted to gather information from the beckoned spirits at the GM’s discretion, though entities that are more powerful, devious, or transactional, may offer or do more than that, and could interact more physically with the user and their allies. GMs and Players – be wary of what is offered and what narrative implications could result from a Séance, minor, major, successful, and unsuccessful.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:channeling-spirit"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "Szrr0tN1cFvouEx2"
+}

--- a/packs/core-perks/bedrock-body.json
+++ b/packs/core-perks/bedrock-body.json
@@ -1,0 +1,103 @@
+{
+  "folder": "YOjkwRlXiBOynxGV",
+  "name": "Bedrock Body",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "bedrock-body",
+    "description": "<p>Effect: The user gains Solid Rock as a Tutored Ability.</p>",
+    "traits": [],
+    "prerequisites": [
+      "trait:rock"
+    ],
+    "autoUnlock": [
+      "item:perk:solid-rock"
+    ],
+    "cost": 3,
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "rock"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/svg/rock_icon.svg",
+  "effects": [
+    {
+      "name": "Bedrock Body",
+      "type": "passive",
+      "_id": "udXXiDf789liZ2CZ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.KgcLrZ8cl6dviEuW",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.2.1.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "uhJZqZCBEbR6BtrT"
+}

--- a/packs/core-perks/cant-break-my-winning-streak.json
+++ b/packs/core-perks/cant-break-my-winning-streak.json
@@ -1,0 +1,39 @@
+{
+  "folder": "E5JYWji5073kTXhD",
+  "name": "Can’t Break My Winning Streak",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "cant-break-my-winning-streak",
+    "description": "<p>Effect: When the user or an ally uses Push Your Luck and fails, the user gains +2 Luck and Resolved 2.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:lets-go-gambling"
+    ],
+    "autoUnlock": [],
+    "cost": 1,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "gambler"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/commodities/currency/coins-plain-stack-gold-yellow.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "d0dhiR7eW7AwAoF0"
+}

--- a/packs/core-perks/channeling-spirit.json
+++ b/packs/core-perks/channeling-spirit.json
@@ -1,0 +1,176 @@
+{
+  "name": "Channeling Spirit",
+  "type": "perk",
+  "system": {
+    "prerequisites": [
+      {
+        "or": [
+          {
+            "and": [
+              {
+                "gte": [
+                  "{actor|skills.aura-control.mod}",
+                  55
+                ]
+              },
+              "trait:aura-user"
+            ]
+          },
+          {
+            "gte": [
+              "{actor|skills.spiritual.mod}",
+              70
+            ]
+          },
+          {
+            "gte": [
+              "{actor|skills.ghost.mod}",
+              70
+            ]
+          },
+          {
+            "gte": [
+              "{actor|skills.parapsychology.mod}",
+              70
+            ]
+          }
+        ]
+      }
+    ],
+    "cost": 2,
+    "description": "<p>You have practiced the technique known as Channeling, and may use it to communicate with the spirits of the dead. You also gain +10 on Aura Sense skill checks pertaining to [Ghost][Pokemon].</p><p>(Should be relocated out of the Aura web, and moved nearby the other Occult stuff)</p>",
+    "actions": [
+      {
+        "name": "Channeling Spirit",
+        "slug": "aura-channeling",
+        "description": "<p>Effect: You have become versed in the art of Channeling, whether through refining aura control, spiritual enlightenment, or being a general occult nut. You gain the [Medium] Trait and gain a +10 toward interactions with [Ghost] creatures.</p>",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "type": "exploration",
+        "traits": [],
+        "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
+        "range": {
+          "target": "enemy",
+          "unit": "m"
+        }
+      }
+    ],
+    "slug": "channeling-spirit",
+    "traits": [],
+    "_migration": {
+      "version": 0.111,
+      "previous": {
+        "schema": null,
+        "foundry": "12.331",
+        "system": "1.2.1.beta"
+      }
+    },
+    "nodes": [
+      {
+        "x": 182,
+        "y": 29,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "aura-bonding"
+        ],
+        "config": {
+          "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
+          "alpha": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "borderWidth": null,
+          "tint": null,
+          "scale": null
+        },
+        "tier": null
+      }
+    ],
+    "autoUnlock": [],
+    "global": true,
+    "webs": [],
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "aura"
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    }
+  },
+  "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
+  "effects": [
+    {
+      "name": "Channeling Spirit",
+      "type": "passive",
+      "_id": "2LNe30UmesAzva9h",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "aura-control-check",
+            "value": 10,
+            "predicate": [
+              "Manual"
+            ],
+            "label": "Ghost Pokemon?",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "medium",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.2.1.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "folder": "gB7SZ3Y6wf3Qjjtr",
+  "_id": "klQo99noqkYbXTSm"
+}

--- a/packs/core-perks/cleansing-shield.json
+++ b/packs/core-perks/cleansing-shield.json
@@ -7,7 +7,7 @@
   "system": {
     "actions": [],
     "slug": "cleansing-shield",
-    "description": "<p>On gaining a Shield, you may spend 3PP to reduce the stacks of any Afflictions that you may have by 1. You do not suffer any negative effects of reducing these stacks.</p>",
+    "description": "<p>Effect: When the user gains any amount of Shields, they have a 20% chance to be cured of one Affliction they possess – @Trait[major-affliction]s are cured first, and @Trait[minor-affliction]s are cured if the user has no @Trait[major-affliction]s.</p>",
     "traits": [],
     "prerequisites": [
       "item:perk:improved-shielding"
@@ -19,41 +19,39 @@
     },
     "nodes": [
       {
+        "x": 88,
+        "y": 104,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "improved-shielding"
         ],
         "config": {
+          "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
           "alpha": null,
-          "backgroundColor": "#408080",
+          "backgroundColor": null,
           "borderColor": null,
           "borderWidth": null,
-          "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
           "tint": null,
           "scale": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 88,
-        "y": 104,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
       "arena": "mental",
       "approach": "resilience",
-      "archetype": "Tank"
+      "archetype": "tank"
     },
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "effects": []

--- a/packs/core-perks/contingency-hex.json
+++ b/packs/core-perks/contingency-hex.json
@@ -1,0 +1,107 @@
+{
+  "folder": "a1w2zpzavg6qtJFn",
+  "name": "Contingency Hex",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "contingency-hex",
+    "description": "<p>Effect: The user gains Cursed Body as a Tutored Ability.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:hexcraft",
+      {
+        "gte": [
+          "{actor|skills.ghost.mod}",
+          60
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "hexcrafter"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
+  "effects": [
+    {
+      "name": "Contingency Hex",
+      "type": "passive",
+      "_id": "LUyP85Sfy7k31bpg",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.rIKiInEzes5D9bVC",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.2.1.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "KqftmY17o4LtStCs"
+}

--- a/packs/core-perks/dimensional-scream.json
+++ b/packs/core-perks/dimensional-scream.json
@@ -1,0 +1,92 @@
+{
+  "folder": "1osM6JY51pvLkJ3Q",
+  "name": "Dimensional Scream",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "dimensional-scream",
+    "description": "<p>Effect: The user gains the Premonition Trait. The GM may choose to confer other “past” and “future” sight capabilities to the user as narratively appropriate.</p>",
+    "traits": [],
+    "prerequisites": [
+      "trait:ace",
+      "GM Permission"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "mental",
+      "approach": "power",
+      "archetype": "exploration"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/magic/sonic/explosion-shock-sound-wave.webp",
+  "effects": [
+    {
+      "name": "Dimensional Scream",
+      "type": "passive",
+      "_id": "q6rly45kkPAygE9t",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "premonition",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.2.1.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "5YTMpUcb3JdiAh3B"
+}

--- a/packs/core-perks/dryad-striding.json
+++ b/packs/core-perks/dryad-striding.json
@@ -1,0 +1,39 @@
+{
+  "folder": "eXSEV54jXXZfP27D",
+  "name": "Dryad Striding",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "dryad-striding",
+    "description": "<p>Effect: The user treats Rough Terrain consisting of plants, shrubbery, logs, forest/jungle floors, etc. as Normal Terrain, and can pass through organic materials/surfaces (trees, wood walls, etc.) as if they had @Trait[phasing].</p>",
+    "traits": [],
+    "prerequisites": [
+      "trait:grass"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/magic/nature/tree-spirit-green.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "uoI9vBdvFchWKOMz"
+}

--- a/packs/core-perks/flare-ignition.json
+++ b/packs/core-perks/flare-ignition.json
@@ -1,0 +1,39 @@
+{
+  "folder": "oguAsvaOzTLs8f97",
+  "name": "Flare Ignition",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "flare-ignition",
+    "description": "<p>Effect: The user maintains an Ignition Clock, 10 Spans in size. The Clock ticks forward two Spans at the end of the user’s Activation if they have moved 3m or more since the end of their last Activation, and two Spans if the user has not been hit by a Physical- or Special-Category Attack in the same timeframe. The Clock ticks back one Span if the user has not moved in the timeframe, and back by one each time they get hit by a Physical- or Special-Category Attack. The Clock empties at the end of Combat.</p><p>The user’s ATK, SPATK, and SPD are reduced by -25% if the Clock is empty, and increase by 10% per filled Span, up to 75% at 10 Spans.</p>",
+    "traits": [],
+    "prerequisites": [
+      "trait:fire"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "fire"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/svg/fire_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "d5xDTqhMKlNaX4Cw"
+}

--- a/packs/core-perks/gaean-retribution.json
+++ b/packs/core-perks/gaean-retribution.json
@@ -1,0 +1,39 @@
+{
+  "folder": "eXSEV54jXXZfP27D",
+  "name": "Gaean Retribution",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "gaean-retribution",
+    "description": "<p>Effect: When the user takes super effective or critical damage or is afflicted with a Major Affliction, they gain +1 to a random stat for 5 Activations, are Boosted 5 and Progressed 5.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:natures-punishment"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "grass"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/magic/nature/root-vine-beanstolk-green.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "f4j32ICrKkHuDBB0"
+}

--- a/packs/core-perks/holistic-care.json
+++ b/packs/core-perks/holistic-care.json
@@ -7,13 +7,13 @@
   "system": {
     "actions": [],
     "slug": "holistic-care",
-    "description": "<p>When healing a creature, you may spend an additional 3PP to remove 1 Stack from any Afflictions the creature may be suffering, without triggering the negative effects of removing those Stacks.</p>",
+    "description": "<p>Effect: The user gains Healer as a Tutored Ability.</p>",
     "traits": [],
     "prerequisites": [
       {
         "gte": [
           "{actor|skills.medicine.mod}",
-          30
+          60
         ]
       }
     ],
@@ -24,23 +24,23 @@
     },
     "nodes": [
       {
+        "x": 46,
+        "y": 80,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "chansey-medicine",
           "involuntary-transfusion"
         ],
         "config": {
+          "texture": "systems/ptr2e/img/perk-icons/Knowledge.svg",
           "alpha": null,
-          "backgroundColor": "#ff0000",
+          "backgroundColor": null,
           "borderColor": null,
           "borderWidth": null,
-          "texture": "systems/ptr2e/img/perk-icons/Knowledge.svg",
           "tint": null,
           "scale": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 46,
-        "y": 80,
         "tier": null
       }
     ],
@@ -56,8 +56,71 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Holistic Care",
+      "type": "passive",
+      "_id": "2njpYM0zfxEWHjoW",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.cEAOUdK51hPAaOtP",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.2.1.beta",
+        "createdTime": 1746675474333,
+        "modifiedTime": 1746675498283,
+        "lastModifiedBy": "5ImYyhOS2D6D7ypO"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/homeostatic-treatments.json
+++ b/packs/core-perks/homeostatic-treatments.json
@@ -1,0 +1,50 @@
+{
+  "folder": "4UhJK1LInml07WJf",
+  "name": "Homeostatic Treatments",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "homeostatic-treatments",
+    "description": "<p>Effect: The user’s @Trait[healing] Actions and their Use Actions utilizing a [Healing] item have a 10% chance of curing one Affliction the target possesses – @Trait[major-affliction]s are cured first, and @Trait[minor-affliction]s are cured if the user has no @Trait[major-affliction]s.</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.medicine.mod}",
+          90
+        ]
+      },
+      {
+        "gte": [
+          "{actor|skills.pharmacy.mod}",
+          70
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "healer"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/consumables/potions/potion-flash-open-blue.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "bML0Bv3EApf0gjZ1"
+}

--- a/packs/core-perks/inner-hospitality.json
+++ b/packs/core-perks/inner-hospitality.json
@@ -1,0 +1,39 @@
+{
+  "folder": "gB7SZ3Y6wf3Qjjtr",
+  "name": "Inner Hospitality",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "inner-hospitality",
+    "description": "<p>Effect: As part of a Séance, the user can invite one of the summoned entities to inhabit their body. The user, while hosting this entity, can communicate with it and draw upon its knowledge, and the increase in soul density, while invigorating, is taxing and can leave the host drained.</p><p>The user hosts a spiritual entity for 5 Daytime Spans. With a hosted entity, the user’s ATK, DEF, SPATK, SPDEF, and SPD increase by 10%, their Movement Scores are increased by +2, their Jump is increased by +1 and gain a +5 bonus to Skill Rolls. In some cases, the entity may be able to roll their Skills in place of the user’s. After the 5 Spans elapse or the spirit otherwise leaves, the user accrues +2 Weary.</p><p>Like with Séances, powerful, devious, or transactional spirits can be hosted, which, up to GM discretion, could provide a number of changes – the user’s stats are increased even further, the user gains extra Moves, Abilities, or Traits, the user is given a permanent affliction while hosting, the entity could influence or outright take control of the user’s Actions, the entity remains in the host longer than 5 Spans, or the penalty for unhosting the entity could be even more severe. The potential for Faustian bargaining is at the whim of the GM.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:beckoning-the-beyond"
+    ],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "occultism"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "0jefYz4tjS5wn87V"
+}

--- a/packs/core-perks/ionization.json
+++ b/packs/core-perks/ionization.json
@@ -1,0 +1,48 @@
+{
+  "folder": "YOjkwRlXiBOynxGV",
+  "name": "Ionization",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "ionization",
+    "description": "<p>Effect: The user gains their choice of Anionic or Cationic as a Tutored Ability.</p><p>NOTE: needs to become tiered.</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "or": [
+          "trait:rock",
+          "trait:steel",
+          "trait:electric",
+          "trait:fire",
+          "trait:water",
+          "trait:ice"
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "rock"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/commodities/stone/masonry-block-cube-grey-teal.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "gqinWHq2LiHX7DQj"
+}

--- a/packs/core-perks/jockeying.json
+++ b/packs/core-perks/jockeying.json
@@ -1,0 +1,39 @@
+{
+  "folder": "E5JYWji5073kTXhD",
+  "name": "Jockeying",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "jockeying",
+    "description": "<p>Effect: The user can spend 2 Luck at [Delay 2] [Interrupt 2] to reroll the Accuracy Check of a missed Physical- or Special-Category Attack of themselves or a member of their Team, but the rerolled Attack gains [Crash 1/2]. This can affect a non-Team Ally by spending another 3 Luck.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:lets-go-gambling"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "gambler"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/environment/creatures/horse-tan.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "rtXYdd3mYvnn2OTI"
+}

--- a/packs/core-perks/kinetic-dynamo.json
+++ b/packs/core-perks/kinetic-dynamo.json
@@ -1,0 +1,36 @@
+{
+  "folder": "2JITUAwLwao03qoc",
+  "name": "Kinetic Dynamo",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Effect: The user maintains a Dynamo Clock, 12 Spans in size. The Clock ticks forward one Span when the user is hit by a [Contact] or Electric-Type Attack. When the Clock is full, it empties and the user gains Charged, Boosted 5, and +2 SPD Stages for 5 Activations. The Dynamo Clock resets on Rest.</p>",
+    "traits": [],
+    "prerequisites": [],
+    "autoUnlock": [],
+    "cost": 1,
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "electric"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/svg/electric_icon.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "tMZHV5xDJixAbnbN"
+}

--- a/packs/core-perks/lets-go-gambling.json
+++ b/packs/core-perks/lets-go-gambling.json
@@ -1,0 +1,104 @@
+{
+  "folder": "E5JYWji5073kTXhD",
+  "name": "Let's Go Gambling!",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "lets-go-gambling",
+    "description": "<p>Effect: The user learns Metronome, and can Tutor it to any creature, albeit at a -30 if the creature does not have it on a Tutor List. The user earns double the Luck from The Devil’s Deal.</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "and": [
+          "item:perk:gambit-style",
+          "trait:ace"
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "gambler"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/sundries/gaming/dice-pair-white-green.webp",
+  "effects": [
+    {
+      "name": "Let's Go Gambling!",
+      "type": "passive",
+      "_id": "rtmLG6Y2O1p35sSE",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.m6eeM9WpSKpSS3rw",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.2.1.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "3dakhQVtvPyUlnAh"
+}

--- a/packs/core-perks/lucky-duck.json
+++ b/packs/core-perks/lucky-duck.json
@@ -1,0 +1,101 @@
+{
+  "folder": "E5JYWji5073kTXhD",
+  "name": "Lucky Duck",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "lucky-duck",
+    "description": "<p>Effect: The user gains Super Luck as a Tutored Ability.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:cant-break-my-winning-streak"
+    ],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "gambler"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/creatures/birds/duck-green.webp",
+  "effects": [
+    {
+      "name": "Lucky Duck",
+      "type": "passive",
+      "_id": "av5IxTZYyy11IiAc",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.gmQOMy4k3rqhNYrs",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.2.1.beta",
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "4kXOJ5lOfe6z0rNK"
+}

--- a/packs/core-perks/millionary-protection.json
+++ b/packs/core-perks/millionary-protection.json
@@ -1,0 +1,71 @@
+{
+  "folder": "gB7SZ3Y6wf3Qjjtr",
+  "name": "Millionary Protection",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "millionary-protection",
+    "description": "<p>Effect: You have learned to gain the protection of the local nature spirits, generally aiding you against the domains they govern. The user takes 25% less damage from Types shared by the environment and Terrain (as per the Types of the Moves in the Nature Power Table).</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "or": [
+          {
+            "and": [
+              {
+                "gte": [
+                  "{actor|skills.aura-control.mod}",
+                  55
+                ]
+              },
+              "trait:aura-user"
+            ]
+          },
+          {
+            "gte": [
+              "{actor|skills.spiritual.mod}",
+              70
+            ]
+          },
+          {
+            "gte": [
+              "{actor|skills.ghost.mod}",
+              70
+            ]
+          },
+          {
+            "gte": [
+              "{actor|skills.parapsychology.mod}",
+              70
+            ]
+          }
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "zmwpNLsXTB0V3rGx"
+}

--- a/packs/core-perks/mulligan.json
+++ b/packs/core-perks/mulligan.json
@@ -1,0 +1,39 @@
+{
+  "folder": "E5JYWji5073kTXhD",
+  "name": "Mulligan",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "mulligan",
+    "description": "<p>Effect: The user can spend 4 Luck at [Delay 3] [Interrupt 3] to force a reroll of an Effect Roll, Critical Hit Roll, Shake Roll, or Critical Capture Roll from their own or another creature’s roll. The user, allies, or neutral creature that are, or would be, affected by the reroll are Flinched 3, while foes are Progressed 3.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:jockeying"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "gambler"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/sundries/gaming/dice-runed-tan.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "wdBLycAWtfTDK3Sl"
+}

--- a/packs/core-perks/natures-punishment.json
+++ b/packs/core-perks/natures-punishment.json
@@ -1,0 +1,44 @@
+{
+  "folder": "eXSEV54jXXZfP27D",
+  "name": "Nature’s Punishment",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "natures-punishment",
+    "description": "<p>Effect: The user can spend 3 PP as a Complex Action and gain @Affliction[rebound 5].</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "or": [
+          "trait:grass",
+          "trait:ground"
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "grass"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/magic/nature/root-vine-entwined-thorns.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "6B96M4qcy1ScbyWO"
+}

--- a/packs/core-perks/nightingale-pledge.json
+++ b/packs/core-perks/nightingale-pledge.json
@@ -1,0 +1,44 @@
+{
+  "folder": "4UhJK1LInml07WJf",
+  "name": "Nightingale Pledge",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "nightingale-pledge",
+    "description": "<p>Effect: When the user recovers HP from a [Healing] item or effect, they may choose to confer half of the amount healed to a creature within 5m.</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.medicine.mod}",
+          90
+        ]
+      }
+    ],
+    "autoUnlock": [
+      "item:perk:healing-hands"
+    ],
+    "cost": 4,
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "healer"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/creatures/birds/songbird-yellow-flying.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "aDwIXZ7n0kjuzMgu"
+}

--- a/packs/core-perks/pick-three-drop-two.json
+++ b/packs/core-perks/pick-three-drop-two.json
@@ -1,0 +1,39 @@
+{
+  "folder": "E5JYWji5073kTXhD",
+  "name": "Pick Three Drop Two",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "pick-three-drop-two",
+    "description": "<p>Effect: The user can spend 4 Luck at [Delay 4] [Interrupt 1] when they or a member of their Team declares Metronome. The GM draws three moves from the Metronome Deck, and the user selects one Move to be resolved through the Triggering Metronome. This can affect a non-Team Ally by spending another 3 Luck.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:cant-break-my-winning-streak"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "gambler"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/sundries/gaming/playing-cards-black.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "tfeg7bOfGE8RL1iO"
+}

--- a/packs/core-perks/planar-tactician.json
+++ b/packs/core-perks/planar-tactician.json
@@ -1,0 +1,131 @@
+{
+  "folder": "F4b52L00KrAtdPu5",
+  "name": "Planar Tactician",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "planar-tactician",
+    "traits": [],
+    "prerequisites": [
+      "item:move:ally-switch",
+      {
+        "gte": [
+          "{actor|skills.psychic.mod}",
+          80
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 1,
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "psychic"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "icons/magic/light/explosion-star-glow-purple.webp",
+  "effects": [
+    {
+      "name": "Planar Tactician",
+      "type": "passive",
+      "_id": "GjNBmA2qzg2MNYp0",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.GFHmsvlYP7sgp7em",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 2,
+                "property": "system.actions.0.free",
+                "value": 0
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.vfD9OztxBbceUce5",
+            "predicate": [],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "alterations": [],
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "1.2.1.beta",
+        "createdTime": 1746674836313,
+        "modifiedTime": 1746678072843,
+        "lastModifiedBy": "5ImYyhOS2D6D7ypO"
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "kkdV5AfafK6scbd9"
+}

--- a/packs/core-perks/reflection.json
+++ b/packs/core-perks/reflection.json
@@ -7,7 +7,7 @@
   "system": {
     "actions": [],
     "slug": "reflection",
-    "description": "<p> If you suffer damage that would break your shields, you may spend 2PP to inflict a tick of damage on the creature responsible as a Free Action at [Interrupt 2].</p>",
+    "description": "<p>Effect: When the user suffers damage that would cause them their Shield to break, the user may spend 2 PP at @Trait[interrupt-2] to inflict @Tick[-1] on the attacker, and give them Flinched 3.</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 2,
@@ -17,42 +17,40 @@
     },
     "nodes": [
       {
+        "x": 89,
+        "y": 96,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "guard-up",
           "punishment-ward"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#0080ff",
-          "borderColor": "#000000",
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Combat.svg",
+          "alpha": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "borderWidth": null,
           "tint": null,
           "scale": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 89,
-        "y": 96,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
       "arena": "physical",
       "approach": "power",
-      "archetype": ""
+      "archetype": null
     },
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "effects": []

--- a/packs/core-perks/superior-specimen.json
+++ b/packs/core-perks/superior-specimen.json
@@ -1,0 +1,39 @@
+{
+  "folder": "aUkQAkBYAmrv6REK",
+  "name": "Superior Specimen",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Dev"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "superior-specimen",
+    "description": "<p>Effect: [Fossil] creatures that the user has Reanimated gain Fossilized as a Tutored Ability. Creatures that gain the Ability naturally gain Fossilized as an Extra Ability when they would get it.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:palaeontologist"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "palaeontology"
+    },
+    "global": true,
+    "webs": [],
+    "nodes": []
+  },
+  "img": "systems/ptr2e/img/perk-icons/Knowledge.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "a7QWQTo9JXah9s4R"
+}


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Perk: Holistic Care
- Update Perk: Cleansing Shield
- Update Perk: Reflection
- Update Perk: Can’t Break My Winning Streak
- Update Perk: Let's Go Gambling!
- Update Perk: Lucky Duck
- Update Perk: Mulligan
- Update Perk: Pick Three Drop Two
- Update Perk: Jockeying
- Update Perk: Nightingale Pledge
- Update Perk: Homeostatic Treatments
- Update Perk: Dimensional Scream
- Update Move: Ally Recall
- Update Perk: Arthroprods
- Update Perk: Arthroarmor
- Update Perk: Bedrock Body
- Update Perk: Contingency Hex
- Update Perk: Away With You!
- Update Perk: Flare Ignition
- Update Perk: Gaean Retribution
- Update Perk: Dryad Striding
- Update Perk: Ionization
- Update Perk: Kinetic Dynamo
- Update Perk: Nature’s Punishment
- Create Perk: Planar Tactician
- Update Perk: Superior Specimen
- Update Perk: Channeling Spirit
- Update Perk: Beckoning the Beyond
- Update Perk: Millionary Protection
- Update Perk: Inner Hospitality