### PR TITLE
Various Move and Ability Revisions.

### DIFF
--- a/packs/core-abilities/ballistic.json
+++ b/packs/core-abilities/ballistic.json
@@ -5,23 +5,41 @@
   "system": {
     "actions": [
       {
-        "traits": [],
-        "name": "Ballistic",
-        "slug": "ballistic",
+        "traits": [
+          "interrupt-4",
+          "delay-3"
+        ],
+        "name": "Ballistic (Active)",
+        "slug": "ballistic-active",
         "type": "generic",
         "cost": {
+          "trigger": "The user declares a @Trait[contact] Attack.",
           "activation": "free",
-          "powerPoints": 2
+          "powerPoints": 2,
+          "delay": 3
         },
         "range": {
           "target": "self",
           "unit": "m"
         },
-        "description": "The user's next [Contact] Attack loses [Contact], gains [Missile] (if it already had [Missile], its Power increases by +30%), and has its Range multiplied by x6 until it is resolved.</p>",
+        "description": "<p>Trigger: The user declares a @Trait[contact] Attack.</p><p>Effect: Until the triggering Attack is resolved, it loses @Trait[contact] and gains @Trait[missile]. has its range change. If the attack has a target of Creature, its range increases by 500% based on its effective range (the Attack’s range considering the user’s Reach), and Emanation Attacks become Blast, with a range of 10m and their @Trait[blast-x] equal to their base Emanation range (f.e., a 2m Emanation becomes @Trait[blast-2]).</p>",
+        "img": "icons/svg/explosion.svg"
+      },
+      {
+        "traits": [],
+        "name": "Ballistic (Passive)",
+        "slug": "ballistic-passive",
+        "type": "passive",
+        "cost": {},
+        "range": {
+          "target": "self",
+          "unit": "m"
+        },
+        "description": "<p>Effect: The user’s @Trait[missile] Attacks have 30% increased Power.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "The user's next [Contact] Attack loses [Contact], gains [Missile] (if it already had [Missile], its Power increases by +30%), and has its Range multiplied by x6 until it is resolved.</p>",
+    "description": "<p>Trigger: The user declares a @Trait[contact] Attack.</p><p>Effect: Until the triggering Attack is resolved, it loses @Trait[contact] and gains @Trait[missile]. has its range change. If the attack has a target of Creature, its range increases by 500% based on its effective range (the Attack’s range considering the user’s Reach), and Emanation Attacks become Blast, with a range of 10m and their @Trait[blast-x] equal to their base Emanation range (f.e., a 2m Emanation becomes @Trait[blast-2]).</p><p>Passive: The user’s @Trait[missile] Attacks have 30% increased Power.</p>",
     "traits": [],
     "slug": "ballistic",
     "_migration": {
@@ -36,5 +54,62 @@
     }
   },
   "_id": "qgENOMqdeuKBs47a",
-  "effects": []
+  "effects": [
+    {
+      "name": "Ballistic",
+      "type": "affliction",
+      "_id": "Ballisticyj07dBR",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "missile-trait-attack-power",
+            "value": 30,
+            "predicate": [],
+            "label": "Ballistic",
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Actor.JH7UeUyIDJg5n2rR.Item.RU6oP9DaZzGVCwYh.ActiveEffect.0vSjQQtCO3XYkB40",
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.2.0.3",
+        "createdTime": 1721933367671,
+        "modifiedTime": 1721933367671,
+        "lastModifiedBy": "y4EIjJlrc2eCclW7"
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/damp.json
+++ b/packs/core-abilities/damp.json
@@ -6,26 +6,22 @@
     "actions": [
       {
         "traits": [
-          "interrupt-3"
+          "defensive"
         ],
         "name": "Damp",
         "slug": "damp",
-        "type": "generic",
-        "cost": {
-          "activation": "free",
-          "powerPoints": 3,
-          "trigger": "<p>A creature in range declares an [Explode] Attack or Ability.</p>"
-        },
+        "type": "passive",
+        "cost": {},
         "range": {
-          "target": "creature",
+          "target": "aura",
           "distance": 15,
           "unit": "m"
         },
-        "description": "<p>Trigger: A creature in range uses an [Explode] Attack or Ability.</p><p>Effect: The triggering action fails and becomes @Affliction[disabled] 5 if it was an Attack, or @Affliction[nullified] 5 if it was an Ability.</p>",
+        "description": "<p>Effect: @Trait[explode] and @Trait[firearm] Attacks and Abilities fail when they are declared in range, consuming their costs as normal. These declared Attacks gain @Affliction[disabled 2] (if the Attack originated from a Weapon, all of that weapon’s @Trait[explode] and @Trait[firearm] Attacks are @Affliction[disabled 2]), and these declared Abilities gain @Affliction[nullified 2].</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Trigger: A creature in range uses an [Explode] Attack or Ability.</p><p>Effect: The triggering action fails and becomes @Affliction[disabled] 5 if it was an Attack, or @Affliction[nullified] 5 if it was an Ability.</p>",
+    "description": "<p>Effect: @Trait[explode] and @Trait[firearm] Attacks and Abilities fail when they are declared in range, consuming their costs as normal. These declared Attacks gain @Affliction[disabled 2] (if the Attack originated from a Weapon, all of that weapon’s @Trait[explode] and @Trait[firearm] Attacks are @Affliction[disabled 2]), and these declared Abilities gain @Affliction[nullified 2].</p>",
     "traits": [],
     "slug": "damp",
     "_migration": {

--- a/packs/core-abilities/disenchant.json
+++ b/packs/core-abilities/disenchant.json
@@ -16,11 +16,11 @@
           "target": "self",
           "unit": "m"
         },
-        "description": "<p>Effect: The user is immune to the Fairy type, and resists the Ghost type one step further.</p>",
+        "description": "<p>Effect: The user is immune to @Trait[fairy] Type Attacks, and resists the @Trait[ghost] Type and @Trait[arcane] Attacks one step further.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Effect: The user is immune to the Fairy type, and resists the Ghost type one step further.</p>",
+    "description": "<p>Effect: The user is immune to @Trait[fairy] Type Attacks, and resists the @Trait[ghost] Type and @Trait[arcane] Attacks one step further.</p>",
     "traits": [],
     "slug": "disenchant",
     "_migration": {

--- a/packs/core-abilities/frisk.json
+++ b/packs/core-abilities/frisk.json
@@ -13,25 +13,26 @@
         "type": "generic",
         "cost": {
           "activation": "free",
-          "trigger": "<p>The user successfully hits with a [Contact] attack.</p>"
+          "powerPoints": 3,
+          "trigger": "<p>The user hits a creature with a @Trait[contact] Action. </p>"
         },
         "range": {
           "target": "creature",
           "distance": 1,
           "unit": "m"
         },
-        "description": "<p>Trigger: The user successfully hits with a [Contact] attack.</p><p>Effect: The user learns of one item the attack target has equipped, including details about the item and amount if applicable.</p>",
+        "description": "<p>Trigger: The user hits a creature with a @Trait[contact] Action.</p><p>Effect: The user freely uses Embargo on the targeted creature.</p>",
         "img": "icons/svg/explosion.svg"
       },
       {
         "traits": [],
-        "name": "Frisk",
-        "slug": "frisk",
+        "name": "Frisk (Passive)",
+        "slug": "frisk-passive",
         "type": "passive",
         "cost": {
           "activation": "free"
         },
-        "description": "<p>Passive: The user gains +10 to their Sleight of Hand.</p>",
+        "description": "<p>Passive: The user gains +10 to their Sleight of Hand and +5 RES.</p>",
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
@@ -39,7 +40,7 @@
         }
       }
     ],
-    "description": "<p>Trigger: The user successfully hits with a [Contact] attack.</p><p>Effect: The user learns of one item the attack target has equipped, including details about the item and amount if applicable. Passive: The user gains +10 to their Sleight of Hand.</p>",
+    "description": "<p>Trigger: The user hits a creature with a @Trait[contact] Action.</p><p>Effect: Connection - Embargo. The user freely uses Embargo on the targeted creature.</p><p>Passive: The user gains +10 to their Sleight of Hand and +5 RES.</p>",
     "traits": [],
     "slug": "frisk",
     "_migration": {
@@ -56,7 +57,7 @@
   "_id": "m3G3abHjeyxhULLM",
   "effects": [
     {
-      "name": "Frisk Passive",
+      "name": "Frisk (Passive)",
       "type": "passive",
       "_id": "EhMbi4LWYpA3IVUh",
       "img": "systems/ptr2e/img/icons/effect_icon.webp",
@@ -72,6 +73,73 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "coreVersion": "12.331",
+        "systemId": "ptr2e",
+        "systemVersion": "0.10.0-alpha.3.0.0",
+        "createdTime": 1729417497118,
+        "modifiedTime": 1729417508518,
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
+      }
+    },
+    {
+      "name": "Frisk",
+      "type": "passive",
+      "_id": "Frisk4LWYpA3IVUh",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.9dEqQGUDJ3L0OTpc",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "mode": 2,
+            "priority": null,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            }
           }
         ],
         "slug": null,

--- a/packs/core-abilities/hunters-prowess.json
+++ b/packs/core-abilities/hunters-prowess.json
@@ -17,7 +17,7 @@
         },
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 20,
           "unit": "m"
         },
         "description": "<p>Trigger: The user enters combat.</p><p>Effect: The user selects a creature, inflicting them with @Affliction[marked] 5. Whenever the user Moves, they gain +2 to their Movement Score as long as they are moving towards a @Affliction[marked] creature. The first time the user attacks a @Affliction[marked] creature, the attack is one step more effective.</p>",

--- a/packs/core-abilities/multitype.json
+++ b/packs/core-abilities/multitype.json
@@ -19,7 +19,7 @@
           "target": "self",
           "unit": "m"
         },
-        "description": "<p><span style=\"font-family: Signika, sans-serif\">Trigger: The user declares Judgment.</span></p><p style=\"box-sizing: border-box; user-select: text; scrollbar-width: thin; scrollbar-color: rgb(93, 20, 43) rgba(0, 0, 0, 0); margin: 0.5rem 0px; color: rgb(239, 230, 216); font-family: Signika, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; text-align: start\"><span style=\"font-family: Signika, sans-serif\">Effect: The user may change the Type of the triggering attack to any available Type of their choosing (except Typeless) for the rest of their Activation.</span></p>",
+        "description": "<p>Trigger: The user declares Judgment.</p><p>Effect: The user may change the Type of the triggering attack to any available Type of their choosing (except Typeless) for the rest of their Activation.</span></p>",
         "img": "systems/ptr2e/img/perk-icons/Touched.svg"
       },
       {

--- a/packs/core-abilities/mystic-blades.json
+++ b/packs/core-abilities/mystic-blades.json
@@ -22,11 +22,11 @@
           "target": "self",
           "unit": "m"
         },
-        "description": "<p>Trigger: The user declares a [Sharp] attack.</p><p>Effect: The triggering attack has its Power increase by 30%, its Range increase by 4, and becomes Special-Category until the end of the user's Activation.</p>",
+        "description": "<p>Trigger: The user declares a [Sharp] attack.</p><p>Effect: The triggering attack has its Power increase by 30% and either change its Category to Special, or change the attack to target the foe’s SPDEF.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a [Sharp] attack.</p><p>Effect: The triggering attack has its Power increase by 30%, its Range increase by 4, and becomes Special-Category until the end of the user's Activation.</p>",
+    "description": "<p>Trigger: The user declares a [Sharp] attack.</p><p>Effect: The triggering attack has its Power increase by 30% and either change its Category to Special, or change the attack to target the foe’s SPDEF.</p>",
     "traits": [
       "innate",
       "aura"

--- a/packs/core-abilities/power-fists.json
+++ b/packs/core-abilities/power-fists.json
@@ -22,11 +22,11 @@
           "target": "self",
           "unit": "m"
         },
-        "description": "<p>Trigger: The user declares a [Punch] attack.</p><p>Effect: The triggering attack has its Power increase by 30%, its Range increase by 4, and and becomes Special-Category until the end of the user's Activation.</p>",
+        "description": "<p>Trigger: The user declares a [Punch] attack.</p><p>Effect: The triggering attack has its Power increase by 30% and either change its Category to Special, or change the attack to target the foe’s SPDEF.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a [Punch] attack.</p><p>Effect: The triggering attack has its Power increase by 30%, its Range increase by 4, and and becomes Special-Category until the end of the user's Activation.</p>",
+    "description": "<p>Trigger: The user declares a [Punch] attack.</p><p>Effect: The triggering attack has its Power increase by 30% and either change its Category to Special, or change the attack to target the foe’s SPDEF</p>",
     "traits": [
       "innate",
       "aura"

--- a/packs/core-abilities/sighting-system.json
+++ b/packs/core-abilities/sighting-system.json
@@ -16,11 +16,11 @@
           "target": "self",
           "unit": "m"
         },
-        "description": "<p>Effect: The user's Attacks with 80 or less Accuracy cause the user to be Flinched 4, and the user is treated as having +3 ACC when using [Pulse], [Ray], [Missile] and [Explode] attacks.</p>",
+        "description": "<p>Effect: The user has +3 default ACC when using @Trait[pulse], @Trait[ray], @Trait[missile] and @Trait[explode] Attacks, and the user is Delayed X% upon using these Attacks, where X equals 110 minus the Attack’s base Accuracy.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Effect: The user's Attacks with 80 or less Accuracy cause the user to be Flinched 4, and the user is treated as having +3 ACC when using [Pulse], [Ray], [Missile] and [Explode] attacks.</p>",
+    "description": "<p>Effect: The user has +3 default ACC when using @Trait[pulse], @Trait[ray], @Trait[missile] and @Trait[explode] Attacks, and the user is Delayed X% upon using these Attacks, where X equals 110 minus the Attack’s base Accuracy.</p>",
     "traits": [],
     "slug": "sighting-system",
     "_migration": {

--- a/packs/core-abilities/stall.json
+++ b/packs/core-abilities/stall.json
@@ -16,11 +16,11 @@
           "target": "self",
           "unit": "m"
         },
-        "description": "<p>Effect: All of the user's Physical- and Special-Category attacks gain [Delay 3] and have 50% increased Power.</p>",
+        "description": "<p>Effect: The user takes 30% less damage from creatures that have a higher BaseAV than the user.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Effect: All of the user's Physical- and Special-Category attacks gain [Delay 3] and have 50% increased Power.</p>",
+    "description": "<p>Effect: The user takes 30% less damage from creatures that have a higher BaseAV than the user.</p>",
     "traits": [],
     "slug": "stall",
     "_migration": {

--- a/packs/core-gear/big-leek.json
+++ b/packs/core-gear/big-leek.json
@@ -32,7 +32,7 @@
         "name": "Big Leek",
         "slug": "big-leek",
         "type": "generic",
-        "description": "Effect: The user has their Base ATK increased by 150%, but their default ACC is decreased by -1.",
+        "description": "Effect: The user has their Base ATK increased by 150%, but their default ACC is decreased by -1. The user gains @Trait[bladed].",
         "traits": [
           "Combat",
           "Farfetch'd",

--- a/packs/core-moves/counter.json
+++ b/packs/core-moves/counter.json
@@ -22,7 +22,8 @@
           "powerPoints": 3,
           "trigger": "<p>The user is damaged by a Physical damaging attack.</p>"
         },
-        "category": "status",
+        "category": "physical",
+        "power": null,
         "accuracy": 100,
         "types": [
           "fighting"

--- a/packs/core-moves/flail.json
+++ b/packs/core-moves/flail.json
@@ -53,7 +53,7 @@
           {
             "type": "flat-modifier",
             "key": "flail-attack-power",
-            "value": "1.8 * system.health.percent",
+            "value": "1.8 * (100-@actor.system.health.percent)",
             "label": "Flail",
             "predicate": [],
             "mode": 2,

--- a/packs/core-moves/mirror-coat.json
+++ b/packs/core-moves/mirror-coat.json
@@ -22,7 +22,7 @@
           "powerPoints": 3,
           "trigger": "<p>The user is damaged by a Special damaging attack.</p>"
         },
-        "category": "status",
+        "category": "special",
         "power": null,
         "accuracy": 100,
         "types": [

--- a/packs/core-moves/reversal.json
+++ b/packs/core-moves/reversal.json
@@ -58,7 +58,7 @@
           {
             "type": "flat-modifier",
             "key": "reversal-attack-power",
-            "value": "1.8 * system.health.percent",
+            "value": "1.8 * (100-@actor.system.health.percent)",
             "label": "Reversal",
             "predicate": [],
             "mode": 2,

--- a/packs/core-moves/shadow-reprisal.json
+++ b/packs/core-moves/shadow-reprisal.json
@@ -53,7 +53,7 @@
           {
             "type": "flat-modifier",
             "key": "shadow-reprisal-attack-power",
-            "value": "1.8 * system.health.percent",
+            "value": "1.8 * (100-@actor.system.health.percent)",
             "label": "Shadow Reprisal",
             "predicate": [],
             "mode": 2,

--- a/packs/core-moves/shed-tail.json
+++ b/packs/core-moves/shed-tail.json
@@ -11,12 +11,12 @@
         "type": "attack",
         "traits": [
           "defensive",
-          "substitute",
-          "tail"
+          "tail",
+          "priority-3"
         ],
         "range": {
           "target": "creature",
-          "distance": 0,
+          "distance": 5,
           "unit": "m"
         },
         "cost": {
@@ -29,7 +29,7 @@
         "types": [
           "normal"
         ],
-        "description": "<p>Effect: The user reduces their HP by 1/2 their Max HP and creates a Substitute. The Substitute's HP is equal to 1/2 the sacrificed HP. The user then switches out with another Pokemon in thier own Party, granting their replacement the Substitute.</p>",
+        "description": "<p>Effect: The user loses @Tick[-4], and may freely move itself up to half of the Movement Score of their choice. The target gains Shields equal to 1.5x the HP the user sacrificed. If the user is an owned Pokemon, they may immediately be returned to their Ball after moving, and another Pokemon sent out in their place, and this replacement Pokemon may be designated as the target of this Attack, ignoring range.</p>",
         "contestType": "",
         "contestEffect": "",
         "free": false,

--- a/packs/core-moves/teleport.json
+++ b/packs/core-moves/teleport.json
@@ -18,8 +18,8 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "simple",
-          "powerPoints": 2
+          "activation": "complex",
+          "powerPoints": 5
         },
         "category": "status",
         "power": null,
@@ -27,7 +27,7 @@
         "types": [
           "psychic"
         ],
-        "description": "<p>Effect: The user freely Teleports up to their Teleport Score. If they do not possess a Teleport Score, their effective Teleport Score is 8 for this Attack.</p>",
+        "description": "<p>Effect: The user may freely Move itself up 1.5x its Teleport Score (minimum 6m). If the user is an owned Pokémon, they then may be returned to their Ball and an ally may be sent out in their place, with that ally being Advanced 50%.</p>",
         "contestType": "",
         "contestEffect": "",
         "free": false,

--- a/static/traits.json
+++ b/static/traits.json
@@ -970,7 +970,7 @@
     "slug": "hover",
     "label": "Hover",
     "related": [],
-    "description": "This creature naturally floats, granting immunity to damage and effects from [Earthbound] actions. Does not crash if its deliberate flight is interrupted.",
+    "description": "This creature naturally floats, granting immunity to damage and effects from [Earthbound] actions. Does not crash if its deliberate flight is interrupted. This creatures can use Flight underwater instead of Swim, treating it as Difficult Terrain.",
     "type": "automated",
     "changes": [
       {
@@ -1088,7 +1088,7 @@
     "slug": "jet",
     "label": "Jet",
     "related": [],
-    "description": "This trait identifies an exceptionally fast flyer or swimmer.\nSUBJECT TO CHANGE"
+    "description": "This trait identifies an exceptionally fast flyer or swimmer. If this creature has a Flight Movement Score, they may move full speed using Flight underwater, instead of Swim.\nSUBJECT TO CHANGE"
   },
   {
     "slug": "jump-x",


### PR DESCRIPTION
- Ballistic's effect revised for clarity.
- Damp revised to affect firearms, and is now properly an aura
- Disenchant expanded to include Arcane moves
- Frisk updated to instead have the user freely use Embargo when triggered
- Hunter's Prowess range increased
- Multitype formatting fix
- Mystic Blades effect simplified and improved, allows the user to have the triggered attack either become Special, or target SPDEF
- Power Fists changed as per Mystic Blades
- Sighting System effect revised, gives high Accuracy, but delays the user based on how originally inaccurate the attack was.
- Stall revised into a defensive version of Analytic
- Big Leek now gives the Farfetch'd line [Bladed] while equipped.
