### PR TITLE
Foundry Data Sync - Protect Automation

### DIFF
--- a/packs/core-effects/protected.json
+++ b/packs/core-effects/protected.json
@@ -1,0 +1,78 @@
+{
+  "name": "Protected",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>While Protected, the creature cannot be affected by any attacks which lack the @Trait[pierce] trait. @Trait[pierce] effects remove this effect.<br><br>If the action that granted this effect was used Proactively by the affected Creature instead of Reactively or being set by an ally, make sure to increase the duration to 2 to prevent it from expiring when your activation ends.</p>",
+    "traits": [
+      "shield"
+    ]
+  },
+  "img": "icons/svg/castle.svg",
+  "effects": [
+    {
+      "name": "Protected",
+      "type": "affliction",
+      "_id": "xJOVkIiB9bvLh5pP",
+      "img": "icons/svg/castle.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "damaging-attack-damage-percentile",
+            "value": -100000,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 1,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.3.8.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "z7BfyuquHkly9OfK"
+}

--- a/packs/core-effects/shadow-tag-aura-effect.json
+++ b/packs/core-effects/shadow-tag-aura-effect.json
@@ -11,9 +11,10 @@
       "authors": [],
       "notes": ""
     },
-    "traits": []
+    "traits": [],
+    "slug": "shadow-tag-aura-effect"
   },
-  "img": "systems/ptr2e/img/icons/effect_icon.webp",
+  "img": "systems/ptr2e/img/conditions/stuck.svg",
   "effects": [
     {
       "name": "Shadow Tag",
@@ -74,7 +75,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -96,15 +99,16 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
         "systemVersion": "1.1.0.beta",
         "createdTime": null,
         "modifiedTime": null,
-        "lastModifiedBy": null
+        "lastModifiedBy": null,
+        "exportSource": null
       }
     }
   ],
-  "flags": {},
-  "_id": "8GlD03CzKP8ofSE4"
+  "_id": "8GlD03CzKP8ofSE4",
+  "folder": "sP8yfpABdpdAz4aV"
 }

--- a/packs/core-moves/protect.json
+++ b/packs/core-moves/protect.json
@@ -11,12 +11,12 @@
         "type": "attack",
         "traits": [
           "shield",
-          "pp-updated",
           "interrupt-6"
         ],
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "cost": {
           "activation": "complex",
@@ -47,5 +47,72 @@
     }
   },
   "_id": "DwzmkHqd28xR3P3c",
-  "effects": []
+  "effects": [
+    {
+      "name": "Protect",
+      "type": "passive",
+      "_id": "crhf3boVuYzfHF7z",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "protect-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.disabledconditem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "protect-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.z7BfyuquHkly9OfK",
+            "predicate": [],
+            "chance": 10,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.3.8.beta",
+        "createdTime": 1752937357436,
+        "modifiedTime": 1752937419158,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Fixes #1755
Fixes #1340

We can pick up Protect-like moves as we go along and apply the Protected effect automation as per this example here with Protect.
- Update Effect: Shadow Tag (Aura Effect)
- Update Effect: Protected
- Update Move: Protect