### PR TITLE
Foundry Data Sync - A ton of Perk fixes & automations

### DIFF
--- a/packs/core-effects/stoked.json
+++ b/packs/core-effects/stoked.json
@@ -7,7 +7,7 @@
       "fire",
       "pseudo-affliction"
     ],
-    "description": "<p>While afflicted with Stoked, the creature's next damaging @Trait[Fire] Attack has +100% Power.</p>",
+    "description": "<p>While afflicted with Stoked, the creature's next damaging @Trait[fire] Attack has +100% Power.</p>",
     "slug": "stoked",
     "publication": {
       "source": "",
@@ -27,7 +27,8 @@
       "duration": {
         "turns": 1,
         "startTime": null,
-        "combat": null
+        "combat": null,
+        "startTurn": null
       },
       "system": {
         "changes": [
@@ -55,18 +56,16 @@
         "formula": "",
         "type": "damage"
       },
-      "description": "While afflicted with Stoked, the creature's next damaging @Trait[fire] Attack has +100% Power.",
-      "statuses": [
-        "stoked"
-      ],
+      "description": "<p>While afflicted with Stoked, the creature's next damaging @Trait[fire] Attack has +100% Power.</p>",
+      "statuses": [],
       "_id": "stokedcondition0",
       "_stats": {
         "coreVersion": "13.346",
         "systemId": null,
         "systemVersion": null,
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
+        "modifiedTime": 1754225613568,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null
@@ -79,23 +78,5 @@
       "flags": {}
     }
   ],
-  "_id": "stokedcondititem",
-  "flags": {
-    "core": {}
-  },
-  "_stats": {
-    "coreVersion": "13.346",
-    "systemId": "ptr2e",
-    "systemVersion": "1.3.8.beta",
-    "createdTime": null,
-    "modifiedTime": 1753615320749,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV",
-    "compendiumSource": "Compendium.ptr2e.core-effects.Item.stokedcondititem",
-    "duplicateSource": null,
-    "exportSource": null
-  },
-  "sort": 0,
-  "ownership": {
-    "default": 0
-  }
+  "_id": "stokedcondititem"
 }

--- a/packs/core-perks/acceptance.json
+++ b/packs/core-perks/acceptance.json
@@ -14,21 +14,16 @@
         "type": "passive",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "free",
-          "powerPoints": 0
+          "activation": "free"
         },
-        "img": "systems/ptr2e/img/perk-icons/Socialite.svg",
-        "variant": null,
-        "ephemeralVariant": false,
-        "hidden": false
+        "img": "systems/ptr2e/img/perk-icons/Socialite.svg"
       }
     ],
     "slug": "acceptance",
-    "description": "<p>Your Attacks with a % effect chance have that chance increased by +10%.</p>",
+    "description": "<p>The Base Chance of Attacks their secondary effect chances is increased by +10%.</p>",
     "traits": [],
     "prerequisites": [
       {
@@ -66,13 +61,10 @@
           "down-to-earth"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#408080",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Socialite.svg",
-          "tint": null,
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
         "tier": null
       }
@@ -91,17 +83,14 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "effects": [
     {
       "name": "Acceptance",
       "type": "passive",
       "_id": "amseAW4sGgf0mMeq",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Socialite.svg",
       "system": {
         "changes": [
           {
@@ -116,9 +105,11 @@
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -130,7 +121,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>The Base Chance of Attacks their secondary effect chances is increased by +10%.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -140,12 +131,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.1.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1729887002738,
-        "modifiedTime": 1729887008796,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS",
+        "modifiedTime": 1754229312892,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/agitator.json
+++ b/packs/core-perks/agitator.json
@@ -3,7 +3,110 @@
   "_id": "ebtHuGuVOmCt5rwj",
   "type": "perk",
   "img": "icons/skills/social/intimidation-impressing.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Agitator",
+      "type": "passive",
+      "_id": "TftNMXyt1SWccZwi",
+      "img": "icons/skills/social/intimidation-impressing.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "agitator",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.NoHd6SBeivDS66M1",
+            "predicate": [],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.wYGAvakAQaDex43K",
+            "predicate": [],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.j42qPlBO6UlbdaV6",
+            "predicate": [],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>You gain the @Trait[agitator] Trait, providing you access to its tutor list and learn @UUID[Compendium.ptr2e.core-moves.NoHd6SBeivDS66M1]{Confide}, @UUID[Compendium.ptr2e.core-moves.wYGAvakAQaDex43K]{Swagger} and @UUID[Compendium.ptr2e.core-moves.j42qPlBO6UlbdaV6]{Growl} if you don't already know them.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754226702511,
+        "modifiedTime": 1754226756614,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -17,8 +120,8 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
-    "description": "<p>You gain access to the [Agitator] tutor list and learn @UUID[Compendium.ptr2e.core-moves.NoHd6SBeivDS66M1]{Confide}, @UUID[Compendium.ptr2e.core-moves.wYGAvakAQaDex43K]{Swagger} and @UUID[Compendium.ptr2e.core-moves.j42qPlBO6UlbdaV6]{Growl} if you don't already know them.</p>",
+    "slug": "agitator",
+    "description": "<p>You gain the @Trait[agitator] Trait, providing you access to its tutor list and learn @UUID[Compendium.ptr2e.core-moves.NoHd6SBeivDS66M1]{Confide}, @UUID[Compendium.ptr2e.core-moves.wYGAvakAQaDex43K]{Swagger} and @UUID[Compendium.ptr2e.core-moves.j42qPlBO6UlbdaV6]{Growl} if you don't already know them.</p>",
     "traits": [],
     "prerequisites": [
       {
@@ -40,29 +143,34 @@
         ]
       }
     ],
-    "autoUnlock": [],
+    "autoUnlock": [
+      "trait:agitator"
+    ],
     "cost": 1,
-    "originSlug": null,
     "design": {
       "arena": "social",
       "approach": "finesse",
       "archetype": "social"
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [
       {
         "x": 167,
         "y": 141,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "condemn",
           "hesitation",
           "not-the-face"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ]

--- a/packs/core-perks/arms-race.json
+++ b/packs/core-perks/arms-race.json
@@ -3,7 +3,66 @@
   "_id": "kUZFfd8U5WQwPh5S",
   "type": "perk",
   "img": "icons/weapons/artillery/cannon-engraved-gold.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Arms Race",
+      "type": "passive",
+      "_id": "89hargPTyxkqDYqz",
+      "img": "icons/weapons/artillery/cannon-engraved-gold.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.XYFBpNyW7MYqcrdY",
+            "predicate": [],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.XYFBpNyW7MYqcrdY]{Artillery} as a Tutored Ability.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754224493242,
+        "modifiedTime": 1754224524237,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -17,8 +76,8 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
-    "description": "<p>Effect: The user gains Artillery as a Tutored Ability.</p>",
+    "slug": "arms-race",
+    "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.XYFBpNyW7MYqcrdY]{Artillery} as a Tutored Ability.</p>",
     "traits": [],
     "prerequisites": [
       {
@@ -32,26 +91,29 @@
     ],
     "autoUnlock": [],
     "cost": 3,
-    "originSlug": null,
     "design": {
       "arena": "mental",
       "approach": "power",
       "archetype": null
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [
       {
         "x": 175,
         "y": 64,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "covering-fire",
           "yeomanry"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ]

--- a/packs/core-perks/clodsire-flesh.json
+++ b/packs/core-perks/clodsire-flesh.json
@@ -3,7 +3,96 @@
   "_id": "QwnZ5DIAwbNYHJSX",
   "type": "perk",
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Clodsire Flesh",
+      "type": "passive",
+      "_id": "w9fsn7k8shYUdIgq",
+      "img": "systems/ptr2e/img/svg/poison_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "choice-set",
+            "key": "",
+            "value": 0,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "choices": [
+              {
+                "value": "Compendium.ptr2e.core-abilities.Item.C5bFrbElBGmp1UM0",
+                "predicate": [
+                  {
+                    "not": "item:ability:poison-point"
+                  }
+                ]
+              },
+              {
+                "value": "Compendium.ptr2e.core-abilities.Item.IQWqxfEZ1OmBuG1d",
+                "predicate": [
+                  {
+                    "not": "item:ability:poison-touch"
+                  }
+                ]
+              }
+            ],
+            "prompt": "PTR2E.ChoiceSetPrompt.Prompt",
+            "adjustName": true,
+            "rollOption": "clodsireFleshChoice",
+            "flag": "clodsireFleshChoice"
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "{effect|flags.ptr2e.choiceSelections.clodsireFleshChoice}",
+            "predicate": [],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>Effect: The user gains one of either @UUID[Compendium.ptr2e.core-abilities.C5bFrbElBGmp1UM0]{Poison Point} or @UUID[Compendium.ptr2e.core-abilities.IQWqxfEZ1OmBuG1d]{Poison Touch} as a tutored ability.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754224773391,
+        "modifiedTime": 1754224950247,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -17,7 +106,7 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
+    "slug": "clodsire-flesh",
     "description": "<p>Effect: The user gains one of either @UUID[Compendium.ptr2e.core-abilities.C5bFrbElBGmp1UM0]{Poison Point} or @UUID[Compendium.ptr2e.core-abilities.IQWqxfEZ1OmBuG1d]{Poison Touch} as a tutored ability.</p>",
     "traits": [
       "poison"
@@ -27,14 +116,11 @@
     ],
     "autoUnlock": [],
     "cost": 2,
-    "originSlug": null,
     "design": {
       "arena": "physical",
       "approach": "resilience",
       "archetype": "poison"
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [

--- a/packs/core-perks/common-capability.json
+++ b/packs/core-perks/common-capability.json
@@ -3,7 +3,72 @@
   "_id": "z4OW5V8NZWxBCVQC",
   "type": "perk",
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Common Capability",
+      "type": "passive",
+      "_id": "g32FwfaYSMOqMkC9",
+      "img": "systems/ptr2e/img/svg/normal_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.DnlBpzjzOQD37SSy",
+            "predicate": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>You gain @UUID[Compendium.ptr2e.core-abilities.DnlBpzjzOQD37SSy]{Tinted Lens} as an Extra Ability.<br /><br />The user learns 3 Moves from its Species, Type, or Egg Tutor lists, up to two Grades above their current Grade.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754229024421,
+        "modifiedTime": 1754229098720,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -17,34 +82,37 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
-    "description": "<p>Connection: Tinted Lens<br><br>The user learns 3 Moves from its Species, Type, or Egg Tutor lists, up to two Grades above their current Grade.</p>",
+    "slug": "common-capability",
+    "description": "<p>You gain @UUID[Compendium.ptr2e.core-abilities.DnlBpzjzOQD37SSy]{Tinted Lens} as an Extra Ability.<br><br>The user learns 3 Moves from its Species, Type, or Egg Tutor lists, up to two Grades above their current Grade.</p>",
     "traits": [],
     "prerequisites": [
       "trait:normal"
     ],
     "autoUnlock": [],
     "cost": 4,
-    "originSlug": null,
     "design": {
       "arena": "social",
       "approach": "power",
       "archetype": "normal"
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [
       {
         "x": 153,
         "y": 95,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "plain-irritating",
           "type-desperation"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ]

--- a/packs/core-perks/conceal-mind.json
+++ b/packs/core-perks/conceal-mind.json
@@ -7,28 +7,23 @@
       "trait:telepath"
     ],
     "cost": 2,
-    "description": "<p>You may hide your mind's presence as an [Interrupt 4] Simple Action in response to an incoming telepathic sweep of the area. You automatically become aware of any telepaths who are actively searching for minds.</p>",
+    "description": "<p>You may hide your mind's presence as an @Trait[interrupt-4] Simple Action in response to an incoming telepathic sweep of the area. You automatically become aware of any telepaths who are actively searching for minds.</p>",
     "actions": [
       {
         "name": "Conceal Mind",
         "slug": "conceal-mind",
-        "description": "<p>You may hide your mind's presence as an [Interrupt 4] Simple Action in response to an incoming telepathic sweep of the area. You automatically become aware of any telepaths who are actively searching for minds.</p>",
+        "description": "<p>You may hide your mind's presence as an @Trait[interrupt-4] Simple Action in response to an incoming telepathic sweep of the area. You automatically become aware of any telepaths who are actively searching for minds.</p>",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
         "type": "generic",
         "traits": [],
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/psychic_icon.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "conceal-mind",
@@ -39,6 +34,10 @@
     },
     "nodes": [
       {
+        "x": 137,
+        "y": 131,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "hypnotic-suggestion",
           "telepathic-potential",
@@ -48,25 +47,15 @@
           "master-mindscanner"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#400000",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/svg/psychic_icon.svg",
-          "tint": "#ffffff",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 137,
-        "y": 131,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/cover-artist.json
+++ b/packs/core-perks/cover-artist.json
@@ -56,7 +56,7 @@
       "name": "Cover Artist",
       "type": "passive",
       "_id": "9ihEGOB1lzPM2n88",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Musician.svg",
       "system": {
         "changes": [
           {
@@ -108,7 +108,7 @@
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
         "stacks": 0,
         "removeAfterAttacking": false,
@@ -124,7 +124,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>The user gains @Trait[musician], and learns @UUID[Compendium.ptr2e.core-moves.ddcyCuH4t0mVmB7n]{Sing} and @UUID[Compendium.ptr2e.core-moves.h2xOusyckAvQlQtf]{Bark}.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -134,7 +134,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "exportSource": null
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
+        "modifiedTime": 1754227030373
       }
     }
   ],

--- a/packs/core-perks/covering-fire.json
+++ b/packs/core-perks/covering-fire.json
@@ -14,22 +14,17 @@
         "type": "generic",
         "range": {
           "target": "object",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
-        "variant": null,
-        "ephemeralVariant": false
+        "img": "systems/ptr2e/img/perk-icons/Tactician.svg"
       }
     ],
     "slug": "covering-fire",
-    "description": "<p>As a Complex Action costing 2PP, the user uses a Ranged Weapon to provide Covering Fire, delayling their next Activation by 20%. Set up a Covering Fire Clock with 3 Spans. The user and their allies may tick a Span on this Clock to claim Light Cover (or Heavy Cover if already in Light Cover) from incoming non-[Contact] attacks. The Covering Fire effect ends when either the clock is filled, or the user's next Activation begins.</p>",
+    "description": "<p>As a Complex Action costing 2PP, the user uses a Ranged Weapon to provide Covering Fire, delayling their next Activation by 20%. Set up a Covering Fire Clock with 3 Spans. The user and their allies may tick a Span on this Clock to claim Light Cover (or Heavy Cover if already in Light Cover) from incoming non-@Trait[contact] attacks. The Covering Fire effect ends when either the clock is filled, or the user's next Activation begins.</p>",
     "traits": [],
     "prerequisites": [
       "trait:wielder"
@@ -41,6 +36,10 @@
     },
     "nodes": [
       {
+        "x": 177,
+        "y": 70,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "hobby-gardener",
           "tainted-blades",
@@ -51,25 +50,15 @@
           "mudrunner"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#808080",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Tactician.svg",
-          "tint": "#000000",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 177,
-        "y": 70,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/down-the-sights.json
+++ b/packs/core-perks/down-the-sights.json
@@ -5,7 +5,7 @@
   "system": {
     "prerequisites": [],
     "cost": 1,
-    "description": "<p>Your next non-[Contact] Attack gains [Crit X] or [Crit X+1] until it resolves.</p>",
+    "description": "<p>Your next non-@Trait[contact] Attack gains @Trait[crit-x] or [Crit X+1] until it resolves.</p>",
     "actions": [
       {
         "name": "Down The Sights",
@@ -20,11 +20,8 @@
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "down-the-sights",
@@ -48,13 +45,10 @@
           "needle-threader"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/perk-icons/Combat.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/perk-icons/Combat.svg",
-          "tint": "#ffffff",
-          "scale": null
+          "tint": null
         },
         "tier": null
       }
@@ -73,10 +67,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "_id": "eHdFNdcyllxflfNA",
   "img": "systems/ptr2e/img/perk-icons/Combat.svg",

--- a/packs/core-perks/down-to-earth.json
+++ b/packs/core-perks/down-to-earth.json
@@ -14,7 +14,7 @@
     },
     "actions": [],
     "slug": "down-to-earth",
-    "description": "<p>The user gains Quaker as a Tutored Ability.</p>",
+    "description": "<p>The user gains @UUID[Compendium.ptr2e.core-abilities.wNYFCTGML9z46vNI]{Quaker} as a Tutored Ability.</p>",
     "traits": [],
     "prerequisites": [
       "trait:ground"
@@ -34,6 +34,8 @@
       {
         "x": 168,
         "y": 77,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "subsidence",
           "minor-buff-27",
@@ -41,14 +43,15 @@
           "fictile",
           "mudrunner"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
-    ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    ]
   },
   "img": "systems/ptr2e/img/svg/ground_icon.svg",
   "effects": [
@@ -56,7 +59,7 @@
       "name": "Down to Earth",
       "type": "passive",
       "_id": "Dtt3fJMUB3N4J4sZ",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/ground_icon.svg",
       "system": {
         "changes": [
           {
@@ -83,7 +86,9 @@
         "traits": [],
         "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -95,7 +100,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>The user gains @UUID[Compendium.ptr2e.core-abilities.wNYFCTGML9z46vNI]{Quaker} as a Tutored Ability.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -105,16 +110,15 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
         "systemVersion": "1.2.1.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
+        "modifiedTime": 1754224600976,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }
   ],
-  "flags": {},
   "_id": "KZVuWSwGSR4LdNOX"
 }

--- a/packs/core-perks/draconic-presence.json
+++ b/packs/core-perks/draconic-presence.json
@@ -7,7 +7,7 @@
       "previous": null
     },
     "actions": [],
-    "description": "<p>Passive: Your Dragon-type attacks gain a 20% chance to inflict Fear 5, or +20% chance to inflict Fear if they would already do so.</p>",
+    "description": "<p>Your @Trait[dragon] Type attacks gain a 20% chance to inflict @Affliction[fear 5], or +20% chance to inflict @Affliction[fear] if they would already do so.</p>",
     "traits": [],
     "prerequisites": [
       "trait:dragon"
@@ -16,6 +16,10 @@
     "slug": "draconic-presence",
     "nodes": [
       {
+        "x": 141,
+        "y": 79,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "acceptance",
           "thug",
@@ -31,18 +35,11 @@
           "the-unassessably-terrible"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/dragon_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/dragon_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 141,
-        "y": 79,
         "tier": null
       }
     ],
@@ -60,10 +57,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "img": "systems/ptr2e/img/svg/dragon_icon.svg",
   "effects": [
@@ -71,7 +65,7 @@
       "name": "Draconic Presence",
       "type": "passive",
       "_id": "Ws5hRtrbWspE6tDW",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/dragon_icon.svg",
       "system": {
         "changes": [
           {
@@ -85,14 +79,17 @@
             "priority": null,
             "ignored": false,
             "alterations": [],
-            "dontMerge": false
+            "dontMerge": false,
+            "isFixedChance": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -104,7 +101,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Your @Trait[dragon] Type attacks gain a 20% chance to inflict @Affliction[fear 5], or +20% chance to inflict @Affliction[fear] if they would already do so.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -114,12 +111,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.0.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
+        "modifiedTime": 1754229722694,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/drakelike.json
+++ b/packs/core-perks/drakelike.json
@@ -47,13 +47,64 @@
         "tier": null
       }
     ],
-    "slug": "drakelike",
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "slug": "drakelike"
   },
   "img": "systems/ptr2e/img/svg/dragon_icon.svg",
-  "effects": [],
-  "flags": {},
+  "effects": [
+    {
+      "name": "Drakelike",
+      "type": "passive",
+      "_id": "AAqzHdgRPYR3HKoW",
+      "img": "systems/ptr2e/img/svg/dragon_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "drakelike",
+            "predicate": [],
+            "priority": null,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>You gain the @Trait[drakelike] trait.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.vgrtXLOiip6DrtUb.ActiveEffect.9sPoZxBVcS4lYsy5",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754229737409,
+        "modifiedTime": 1754229758416,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "_id": "p0WGX5EN83NrI1OZ"
 }

--- a/packs/core-perks/fictile.json
+++ b/packs/core-perks/fictile.json
@@ -46,13 +46,58 @@
         "tier": null
       }
     ],
-    "slug": "fictile",
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "slug": "fictile"
   },
   "img": "systems/ptr2e/img/svg/ground_icon.svg",
-  "effects": [],
-  "flags": {},
+  "effects": [
+    {
+      "name": "Fictile",
+      "type": "passive",
+      "_id": "zjYlMshP5P73NDkO",
+      "img": "systems/ptr2e/img/svg/ground_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "fictile",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>Grants the @Trait[fictile] trait.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.CPI0fLxCQkvDZ1St.ActiveEffect.DKEtnlWBofTgvaHB",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754225207309,
+        "modifiedTime": 1754225222239,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "_id": "aS9I2cNmYETBwOSs"
 }

--- a/packs/core-perks/fighting-momentum.json
+++ b/packs/core-perks/fighting-momentum.json
@@ -8,7 +8,7 @@
       "previous": null
     },
     "actions": [],
-    "description": "<p>Passive: Your Fighting-Type Moves gain a 20% chance to inflict Suppressed 5. If they already had a chance to inflict Suppressed, that chance is increased by 20%.</p>",
+    "description": "<p>Passive: Your @Trait[fighting] Type Moves gain a 20% chance to inflict @Affliction[suppressed 5]. If they already had a chance to inflict @Affliction[suppressed], that chance is increased by 20%.</p>",
     "traits": [],
     "prerequisites": [
       "trait:fighting"
@@ -17,6 +17,10 @@
     "slug": "fighting-momentum",
     "nodes": [
       {
+        "x": 145,
+        "y": 84,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "kinetic-dispersion",
           "acceptance",
@@ -25,25 +29,15 @@
           "minor-buff-34"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/fighting_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/fighting_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 145,
-        "y": 84,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -65,7 +59,7 @@
       "name": "Fighting Momentum",
       "type": "passive",
       "_id": "REBksiKRSKlWhlFP",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/fighting_icon.svg",
       "system": {
         "changes": [
           {
@@ -79,14 +73,17 @@
             "priority": null,
             "ignored": false,
             "alterations": [],
-            "dontMerge": false
+            "dontMerge": false,
+            "isFixedChance": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -98,7 +95,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Passive: Your @Trait[fighting] Type Moves gain a 20% chance to inflict @Affliction[suppressed 5]. If they already had a chance to inflict @Affliction[suppressed], that chance is increased by 20%.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -108,12 +105,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.0.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
+        "modifiedTime": 1754229561050,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/firefly.json
+++ b/packs/core-perks/firefly.json
@@ -6,29 +6,22 @@
       "trait:fire"
     ],
     "cost": 1,
-    "description": "<p>You gain [Glow 3] or [Glow X+2].</p>",
+    "description": "<p>You gain @Trait[glow-3] or [Glow X+2].</p>",
     "actions": [
       {
         "name": "Firefly",
         "slug": "firefly",
         "description": "<p>You gain [Glow 3] or [Glow X+2].</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "firefly",
@@ -39,6 +32,10 @@
     },
     "nodes": [
       {
+        "x": 165,
+        "y": 95,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "midnight-oil",
           "intense-heat",
@@ -49,25 +46,15 @@
           "firestarter"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/fire_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/fire_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 165,
-        "y": 95,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/firestarter.json
+++ b/packs/core-perks/firestarter.json
@@ -46,13 +46,64 @@
         "tier": null
       }
     ],
-    "slug": "firestarter",
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "slug": "firestarter"
   },
   "img": "systems/ptr2e/img/svg/fire_icon.svg",
-  "effects": [],
-  "flags": {},
+  "effects": [
+    {
+      "name": "Firestarter",
+      "type": "passive",
+      "_id": "zZIg8un1uorKBU25",
+      "img": "systems/ptr2e/img/svg/fire_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "firestarter",
+            "predicate": [],
+            "priority": null,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>You gain the @Trait[firestarter] trait.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.vgrtXLOiip6DrtUb.ActiveEffect.9sPoZxBVcS4lYsy5",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754229216982,
+        "modifiedTime": 1754229230228,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "_id": "KSCcFy9qZEpGO84J"
 }

--- a/packs/core-perks/fractalised-contingency.json
+++ b/packs/core-perks/fractalised-contingency.json
@@ -17,8 +17,8 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
-    "description": "<p><span style=\"font-family: -apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Noto Sans&#x27;, Helvetica, Arial, sans-serif, &#x27;Apple Color Emoji&#x27;, &#x27;Segoe UI Emoji&#x27;\">At the end of the user’s Activations, they have a 30% chance of being cured of one @Trait[major-affliction], one @Trait[minor-affliction], and one negative @Trait[stage-change] effect, with the highest Stack value effects being cured first.</span></p>",
+    "slug": "fractalised-contingency",
+    "description": "<p>At the end of the user’s Activations, they have a 30% chance of being cured of one @Trait[major-affliction], one @Trait[minor-affliction], and one negative @Trait[stage-change] effect, with the highest Stack value effects being cured first.</p>",
     "traits": [
       "gestalt"
     ],
@@ -27,27 +27,30 @@
     ],
     "autoUnlock": [],
     "cost": 1,
-    "originSlug": null,
     "design": {
       "arena": "mental",
       "approach": "resilience",
       "archetype": null
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [
       {
         "x": 138,
         "y": 145,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "hit-run",
           "psycher",
           "minor-buff-2"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ]

--- a/packs/core-perks/generalizer.json
+++ b/packs/core-perks/generalizer.json
@@ -43,13 +43,64 @@
         "tier": null
       }
     ],
-    "slug": "generalizer",
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "slug": "generalizer"
   },
   "img": "systems/ptr2e/img/svg/normal_icon.svg",
-  "effects": [],
-  "flags": {},
+  "effects": [
+    {
+      "name": "Generalizer",
+      "type": "passive",
+      "_id": "G466FwH3i0bP5hj1",
+      "img": "systems/ptr2e/img/svg/normal_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "generalizer",
+            "predicate": [],
+            "priority": null,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>You gain the @Trait[generalizer] trait.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.vgrtXLOiip6DrtUb.ActiveEffect.9sPoZxBVcS4lYsy5",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754229141780,
+        "modifiedTime": 1754229169199,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "_id": "gcwFUDVtTB7xq9Cn"
 }

--- a/packs/core-perks/grendelian-tribute.json
+++ b/packs/core-perks/grendelian-tribute.json
@@ -16,7 +16,7 @@
     },
     "actions": [],
     "slug": "grendelian-tribute",
-    "description": "<p>The user gains Man-Eater as a Tutored Ability.</p>",
+    "description": "<p>The user gains @UUID[Compendium.ptr2e.core-abilities.Snb3Kp9qOy8aqQuc]{Man-Eater} as a Tutored Ability.</p>",
     "traits": [],
     "prerequisites": [
       "trait:dragon"
@@ -36,20 +36,23 @@
       {
         "x": 146,
         "y": 82,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "draconic-presence",
           "fighting-momentum",
           "acceptance",
           "logicians-wisdom"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
-    ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    ]
   },
   "img": "systems/ptr2e/img/svg/dragon_icon.svg",
   "effects": [
@@ -57,7 +60,7 @@
       "name": "Grendalian Tribute",
       "type": "passive",
       "_id": "gCfpSFhaeHW8DjnQ",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/dragon_icon.svg",
       "system": {
         "changes": [
           {
@@ -84,7 +87,9 @@
         "traits": [],
         "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -96,7 +101,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>The user gains @UUID[Compendium.ptr2e.core-abilities.Snb3Kp9qOy8aqQuc]{Man-Eater} as a Tutored Ability.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -106,16 +111,15 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
         "systemVersion": "1.2.1.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
+        "modifiedTime": 1754229642891,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }
   ],
-  "flags": {},
   "_id": "3O2EsUn3CVrHtWBE"
 }

--- a/packs/core-perks/grim-haunt.json
+++ b/packs/core-perks/grim-haunt.json
@@ -8,7 +8,7 @@
       "previous": null
     },
     "actions": [],
-    "description": "<p>Passive: Your Ghost-Type attacks gain a 20% chance to inflict Cursed. If they would already inflict Cursed, the chance is instead increased by 20%.</p>",
+    "description": "<p>Your @Trait[ghost] Type attacks gain a 20% chance to inflict @Affliction[cursed]. If they would already inflict @Affliction[cursed], the chance is instead increased by 20%.</p>",
     "traits": [],
     "prerequisites": [
       "trait:ghost"
@@ -17,6 +17,10 @@
     "slug": "grim-haunt",
     "nodes": [
       {
+        "x": 168,
+        "y": 110,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "walking-dead",
           "spectral-stalker",
@@ -27,25 +31,15 @@
           "morgul-blade"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/ghost_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/ghost_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 168,
-        "y": 110,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -67,7 +61,7 @@
       "name": "Grim Haunt",
       "type": "passive",
       "_id": "n34mHl9XfmL0XK15",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/ghost_icon.svg",
       "system": {
         "changes": [
           {
@@ -81,14 +75,17 @@
             "priority": null,
             "ignored": false,
             "alterations": [],
-            "dontMerge": false
+            "dontMerge": false,
+            "isFixedChance": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -100,7 +97,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Your @Trait[ghost] Type attacks gain a 20% chance to inflict @Affliction[cursed]. If they would already inflict @Affliction[cursed], the chance is instead increased by 20%.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -110,12 +107,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.0.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
+        "modifiedTime": 1754226044963,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/guerilla-radio.json
+++ b/packs/core-perks/guerilla-radio.json
@@ -49,10 +49,7 @@
         "tier": null
       }
     ],
-    "slug": "guerilla-radio",
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "slug": "guerilla-radio"
   },
   "img": "systems/ptr2e/img/perk-icons/Musician.svg",
   "effects": [
@@ -60,7 +57,7 @@
       "name": "Guerilla Radio",
       "type": "passive",
       "_id": "TkJC1FA2Nw0lNigO",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Musician.svg",
       "system": {
         "changes": [
           {
@@ -85,9 +82,11 @@
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -99,7 +98,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.LVKlym7cP5CTEF26]{Punk Rock} as a Tutored Ability.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -109,16 +108,15 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "1.2.1.beta",
+        "systemVersion": "1.4.2.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
+        "modifiedTime": 1754226979437,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }
   ],
-  "flags": {},
   "_id": "74H8ZsuebIkG27aJ"
 }

--- a/packs/core-perks/hesitation.json
+++ b/packs/core-perks/hesitation.json
@@ -11,42 +11,42 @@
       }
     ],
     "cost": 3,
-    "description": "<p>When the user hits a creature with a [Social] Action,they may spend 2 PP to cause to the target to be Flinched 3. For multiple targets, you must spend 2 PP to affect each target</p>",
+    "description": "<p>When the user hits a creature with a @Trait[social] Action,they may spend 2 PP to afflict the target with @Affliction[delay 30]. For multiple targets, you must spend 2 PP to affect each target</p>",
     "actions": [
       {
         "name": "Hesitation",
         "slug": "hesitation",
-        "description": "<p>Trigger: The user's hits a creature with a [Social] Action.</p><p>Effect: The target is Flinched.</p>",
+        "description": "<p>Trigger: The user's hits a creature with a @Trait[social] Action.</p><p>Effect: The target is afflicted with @Affliction[delay 30].</p>",
         "cost": {
           "activation": "free",
           "powerPoints": 2,
-          "trigger": "The user's hits a creature with a [Social] Action.",
-          "delay": null,
-          "priority": null
+          "trigger": "The user's hits a creature with a @Trait[social] Action."
         },
         "type": "generic",
         "traits": [
-          "social",
-          "flinch-3"
+          "social"
         ],
-        "img": "systems/ptr2e/img/icons/feat_icon.webp",
+        "img": "systems/ptr2e/img/perk-icons/Socialite.svg",
         "range": {
           "target": "creature",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "hesitation",
-    "traits": [],
+    "traits": [
+      "social"
+    ],
     "_migration": {
       "version": null,
       "previous": null
     },
     "nodes": [
       {
+        "x": 160,
+        "y": 140,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "condemn",
           "stat-iv-booster-1-2",
@@ -55,25 +55,15 @@
           "agitator"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#8000ff",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Socialite.svg",
-          "tint": "#ffffff",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 160,
-        "y": 140,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/hexcraft.json
+++ b/packs/core-perks/hexcraft.json
@@ -7,7 +7,7 @@
   "system": {
     "actions": [],
     "slug": "hexcraft",
-    "description": "<p>You gain access to the [Hexcraft] trait and Tutor List, and you learn Spite, Grudge, and Night Shade.</p>",
+    "description": "<p>You gain access to the @Trait[hexcraft] trait and Tutor List, and you learn @UUID[Compendium.ptr2e.core-moves.K2lzFMHQ5Ey3bnzZ]{Spite}, @UUID[Compendium.ptr2e.core-moves.fUiCzF9ucUhoJLBq]{Grudge}, and @UUID[Compendium.ptr2e.core-moves.9ajTWumV2CHLWvWK]{Night Shade}.</p>",
     "traits": [],
     "prerequisites": [
       {
@@ -43,18 +43,17 @@
           "dimensional-scream"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#0080ff",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Occultism.svg",
-          "tint": null,
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
         "tier": null
       }
     ],
-    "autoUnlock": [],
+    "autoUnlock": [
+      "trait:hexcraft"
+    ],
     "global": true,
     "webs": [],
     "design": {
@@ -68,26 +67,23 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "effects": [
     {
       "name": "Hexcraft",
       "type": "passive",
       "_id": "UB67uCqqsYfDQocu",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
       "system": {
         "changes": [
           {
             "type": "add-trait",
             "key": "",
-            "value": "Hexcraft",
+            "value": "hexcraft",
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           },
           {
@@ -95,64 +91,66 @@
             "key": "",
             "value": "Compendium.ptr2e.core-moves.Item.K2lzFMHQ5Ey3bnzZ",
             "predicate": [],
-            "mode": 2,
             "priority": null,
-            "ignored": false,
-            "reevaluateOnUpdate": false,
-            "inMemoryOnly": false,
-            "allowDuplicate": true,
             "alterations": [],
-            "track": false,
-            "replaceSelf": false,
             "onDeleteActions": {
               "grantee": "detach",
               "granter": "cascade"
-            }
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
           },
           {
             "type": "grant-item",
             "key": "",
             "value": "Compendium.ptr2e.core-moves.Item.fUiCzF9ucUhoJLBq",
             "predicate": [],
-            "mode": 2,
             "priority": null,
-            "ignored": false,
-            "reevaluateOnUpdate": false,
-            "inMemoryOnly": false,
-            "allowDuplicate": true,
             "alterations": [],
-            "track": false,
-            "replaceSelf": false,
             "onDeleteActions": {
               "grantee": "detach",
               "granter": "cascade"
-            }
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
           },
           {
             "type": "grant-item",
             "key": "",
             "value": "Compendium.ptr2e.core-moves.Item.9ajTWumV2CHLWvWK",
             "predicate": [],
-            "mode": 2,
             "priority": null,
-            "ignored": false,
-            "reevaluateOnUpdate": false,
-            "inMemoryOnly": false,
-            "allowDuplicate": true,
             "alterations": [],
-            "track": false,
-            "replaceSelf": false,
             "onDeleteActions": {
               "grantee": "detach",
               "granter": "cascade"
-            }
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -164,7 +162,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "<p>You gain access to the [Hexcraft] trait and Tutor List, and you learn Spite, Grudge, and Night Shade.</p>",
+      "description": "<p>You gain access to the @Trait[hexcraft] trait and Tutor List, and you learn @UUID[Compendium.ptr2e.core-moves.K2lzFMHQ5Ey3bnzZ]{Spite}, @UUID[Compendium.ptr2e.core-moves.fUiCzF9ucUhoJLBq]{Grudge}, and @UUID[Compendium.ptr2e.core-moves.9ajTWumV2CHLWvWK]{Night Shade}.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -174,12 +172,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.5",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1732231964521,
-        "modifiedTime": 1737392158961,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1754231321061,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/incorporeal.json
+++ b/packs/core-perks/incorporeal.json
@@ -3,7 +3,62 @@
   "_id": "lmZT5Z1Oto8qt4jh",
   "type": "perk",
   "img": "icons/creatures/magical/spirit-mischief-fire-blue.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Incorporeal",
+      "type": "passive",
+      "_id": "eYhfQfaYEn9ZwWV2",
+      "img": "icons/creatures/magical/spirit-mischief-fire-blue.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "phasing",
+            "predicate": [],
+            "priority": null,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>You gain the @Trait[phasing] trait.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.vgrtXLOiip6DrtUb.ActiveEffect.9sPoZxBVcS4lYsy5",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754225846252,
+        "modifiedTime": 1754225870911,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -17,7 +72,7 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
+    "slug": "incorporeal",
     "description": "<p>Effect: Grants the @Trait[phasing] trait.</p>",
     "traits": [
       "ghost"
@@ -25,28 +80,33 @@
     "prerequisites": [
       "trait:ghost"
     ],
-    "autoUnlock": [],
+    "autoUnlock": [
+      "trait:phasing"
+    ],
     "cost": 3,
-    "originSlug": null,
     "design": {
       "arena": "mental",
       "approach": "finesse",
       "archetype": "ghost"
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [
       {
         "x": 174,
         "y": 109,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "spectral-stalker",
           "walking-dead"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ]

--- a/packs/core-perks/inner-warmth.json
+++ b/packs/core-perks/inner-warmth.json
@@ -6,29 +6,22 @@
       "trait:fire"
     ],
     "cost": 1,
-    "description": "<p>You gain the [Heater] trait.</p>",
+    "description": "<p>You gain the @Trait[heater] trait.</p>",
     "actions": [
       {
         "name": "Inner Warmth",
         "slug": "inner-warmth",
         "description": "<p>You gain the [Heater] trait.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "inner-warmth",
@@ -39,6 +32,10 @@
     },
     "nodes": [
       {
+        "x": 169,
+        "y": 91,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "intense-heat",
           "midnight-oil",
@@ -46,27 +43,17 @@
           "flare-ignition"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/fire_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/fire_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 169,
-        "y": 91,
         "tier": null
       }
     ],
     "autoUnlock": [
       "trait:heater"
     ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -89,7 +76,7 @@
       "name": "Inner Warmth",
       "type": "passive",
       "_id": "9sPoZxBVcS4lYsy5",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/fire_icon.svg",
       "system": {
         "changes": [
           {
@@ -104,9 +91,11 @@
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -118,7 +107,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>You gain the @Trait[heater] trait.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -128,12 +117,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1733019363144,
-        "modifiedTime": 1733019373225,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1754225562149,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/insidious-wounds.json
+++ b/packs/core-perks/insidious-wounds.json
@@ -7,9 +7,9 @@
   "system": {
     "actions": [
       {
-        "name": "Insidious Wounds Action",
+        "name": "Insidious Wounds",
         "slug": "insidious-wounds",
-        "description": "<p>Effect: The user can spend 3 PP as a Complex Action to trigger the End of Activation effects of all [DoT] Afflictions the target possesses, with their Stack Counts being decreased by -1 each upon this Action's resolution.</p>",
+        "description": "<p>Effect: The user can spend 3 PP as a Complex Action to trigger the End of Activation effects of all @Trait[dot] Afflictions the target possesses, with their Duration/Stack Counts being decreased by -1 each upon this Action's resolution.</p>",
         "traits": [
           "interrupt-1"
         ],
@@ -21,18 +21,13 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "trigger": "",
-          "delay": null,
-          "priority": null
+          "powerPoints": 3
         },
-        "img": "systems/ptr2e/img/perk-icons/Ninja.svg",
-        "variant": null,
-        "ephemeralVariant": false
+        "img": "systems/ptr2e/img/perk-icons/Ninja.svg"
       }
     ],
     "slug": "insidious-wounds",
-    "description": "<p>Effect: The user can spend 3 PP as a Complex Action to trigger the End of Activation effects of all [DoT] Afflictions the target possesses, with their Stack Counts being decreased by -1 each upon this Action's resolution.</p>",
+    "description": "<p>Effect: The user can spend 3 PP as a Complex Action to trigger the End of Activation effects of all @Trait[dot] Afflictions the target possesses, with their Duration/Stack Counts being decreased by -1 each upon this Action's resolution.</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 2,
@@ -61,9 +56,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/intense-heat.json
+++ b/packs/core-perks/intense-heat.json
@@ -7,41 +7,36 @@
       "trait:fire"
     ],
     "cost": 2,
-    "description": "<p>Your Fire-Type moves gain a 20% chance to @Affliction[burn], or increase that chance by +20%.</p>",
+    "description": "<p>Your @Trait[fire] Type moves gain a 20% chance to @Affliction[burn 5], or increase that chance by +20%.</p>",
     "actions": [
       {
         "name": "Intense Heat",
         "slug": "intense-heat",
         "description": "<p>Your Fire-Type moves gain a 20% chance to @Affliction[burn], or increase that chance by +20%.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "intense-heat",
-    "traits": [
-      "partial-automation"
-    ],
+    "traits": [],
     "_migration": {
       "version": null,
       "previous": null
     },
     "nodes": [
       {
+        "x": 162,
+        "y": 89,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "inner-warmth",
           "firefly",
@@ -51,25 +46,15 @@
           "flare-ignition"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/fire_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/fire_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 162,
-        "y": 89,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -92,7 +77,7 @@
       "name": "Intense Heat",
       "type": "passive",
       "_id": "r2W7KKw3xAibk4h4",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/fire_icon.svg",
       "system": {
         "changes": [
           {
@@ -106,14 +91,17 @@
             "priority": null,
             "ignored": false,
             "alterations": [],
-            "dontMerge": false
+            "dontMerge": false,
+            "isFixedChance": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -125,7 +113,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Your @Trait[fire] Type moves gain a 20% chance to @Affliction[burn 5], or increase that chance by +20%.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -135,12 +123,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.0.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1729380480086,
-        "modifiedTime": 1729380508700,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS",
+        "modifiedTime": 1754225518896,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/lasting-harm.json
+++ b/packs/core-perks/lasting-harm.json
@@ -8,28 +8,21 @@
       {
         "name": "Lasting Harm",
         "slug": "lasting-harm",
-        "description": "<p>Your created [Major Affliction]s and [Minor Affliction]s that inflict effect damage start with +2 Stacks.</p>",
+        "description": "<p>Whenever you apply a @Trait[major-affliction] or @Trait[minor-affliction], their Duration (or Stack amount) is increased by 2 turns.</p>",
         "traits": [],
         "type": "passive",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
-        "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
+        "img": "systems/ptr2e/img/perk-icons/Arcana.svg"
       }
     ],
     "slug": "lasting-harm",
-    "description": "<p>Your created [Major Affliction]s and [Minor Affliction]s that inflict effect damage start with +2 Stacks.</p>",
+    "description": "<p>Whenever you apply a @Trait[major-affliction] or @Trait[minor-affliction], their Duration (or Stack amount) is increased by 2 turns.</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 4,
@@ -39,6 +32,10 @@
     },
     "nodes": [
       {
+        "x": 157,
+        "y": 74,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "hexcraft",
           "acceptance",
@@ -49,25 +46,15 @@
           "cultivate-weakness"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#000000",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Arcana.svg",
-          "tint": null,
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 157,
-        "y": 74,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/master-mindscanner.json
+++ b/packs/core-perks/master-mindscanner.json
@@ -8,7 +8,7 @@
       "name": "Master Mindscanner",
       "type": "passive",
       "_id": "YOk3gVp5BozfkZD3",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "icons/magic/perception/third-eye-blue-red.webp",
       "system": {
         "changes": [
           {
@@ -32,16 +32,18 @@
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "startTime": null,
         "combat": null
       },
-      "description": "",
+      "description": "<p>You gain @UUID[Compendium.ptr2e.core-abilities.Item.in60hH6GWMZ3vqqs]{Telepathy} as a tutored ability.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -52,12 +54,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "1.3.1.beta",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1751550659801,
-        "modifiedTime": 1751550678741,
-        "lastModifiedBy": "dL9m14FoxNtwHs5T"
+        "modifiedTime": 1754228219478,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
       }
     }
   ],
@@ -74,7 +76,7 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
+    "slug": "master-mindscanner",
     "description": "<p>You gain @UUID[Compendium.ptr2e.core-abilities.Item.in60hH6GWMZ3vqqs]{Telepathy} as a tutored ability.</p>",
     "traits": [],
     "prerequisites": [
@@ -82,14 +84,11 @@
     ],
     "autoUnlock": [],
     "cost": 2,
-    "originSlug": null,
     "design": {
       "arena": "mental",
       "approach": "resilience",
       "archetype": "psychic"
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [

--- a/packs/core-perks/midnight-oil.json
+++ b/packs/core-perks/midnight-oil.json
@@ -7,8 +7,10 @@
       "previous": null
     },
     "actions": [],
-    "description": "<p>As a free action, you may spend @Tick[-4] to become @Affliction[stoked] 1.</p>",
-    "traits": [],
+    "description": "<p>As a free action, you may spend @Tick[-4] to become @UUID[Compendium.ptr2e.core-effects.Item.stokedcondititem].</p>",
+    "traits": [
+      "fire"
+    ],
     "prerequisites": [
       "trait:fire"
     ],
@@ -16,24 +18,21 @@
     "slug": "midnight-oil",
     "nodes": [
       {
+        "x": 166,
+        "y": 92,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "firefly",
           "inner-warmth",
           "intense-heat"
         ],
         "config": {
-          "alpha": null,
+          "texture": null,
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": null,
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 166,
-        "y": 92,
         "tier": null
       }
     ],
@@ -51,10 +50,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "img": "systems/ptr2e/img/svg/fire_icon.svg",
   "effects": [],

--- a/packs/core-perks/mindscramble.json
+++ b/packs/core-perks/mindscramble.json
@@ -8,7 +8,7 @@
       "previous": null
     },
     "actions": [],
-    "description": "<p>Passive: Your Psychic-type attacks gain a 20% chance to inflict Confused 5. If they would already have a chance to inflict Confused, they increase that chance by 20%.</p>",
+    "description": "<p>Passive: Your @Trait[psychic] Type attacks gain a 20% chance to inflict @Affliction[confused 5]. If they would already have a chance to inflict @Affliction[confused], they increase that chance by 20%.</p>",
     "traits": [],
     "prerequisites": [
       "trait:psychic"
@@ -17,6 +17,10 @@
     "slug": "mindscramble",
     "nodes": [
       {
+        "x": 159,
+        "y": 113,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "firefly",
           "psychoportation",
@@ -27,18 +31,11 @@
           "manifest-psionic-power"
         ],
         "config": {
-          "alpha": null,
+          "texture": null,
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": null,
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 159,
-        "y": 113,
         "tier": null
       }
     ],
@@ -56,10 +53,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
   "effects": [
@@ -67,7 +61,7 @@
       "name": "Mindscramble",
       "type": "passive",
       "_id": "uAo2AehNmS7TiEH5",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/psychic_icon.svg",
       "system": {
         "changes": [
           {
@@ -81,14 +75,17 @@
             "priority": null,
             "ignored": false,
             "alterations": [],
-            "dontMerge": false
+            "dontMerge": false,
+            "isFixedChance": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -100,7 +97,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Passive: Your @Trait[psychic] Type attacks gain a 20% chance to inflict @Affliction[confused 5]. If they would already have a chance to inflict @Affliction[confused], they increase that chance by 20%.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -110,12 +107,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.0.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
+        "modifiedTime": 1754226463125,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/mudrunner.json
+++ b/packs/core-perks/mudrunner.json
@@ -3,7 +3,56 @@
   "_id": "CPI0fLxCQkvDZ1St",
   "type": "perk",
   "img": "systems/ptr2e/img/svg/ground_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Mudrunner",
+      "type": "passive",
+      "_id": "DKEtnlWBofTgvaHB",
+      "img": "systems/ptr2e/img/svg/ground_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "mud-runner",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>Grants the @Trait[mud-runner] trait.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754225157712,
+        "modifiedTime": 1754225189855,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -17,7 +66,7 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
+    "slug": "mudrunner",
     "description": "<p>Grants the @Trait[mud-runner] trait.</p>",
     "traits": [
       "ground",
@@ -35,14 +84,11 @@
     ],
     "autoUnlock": [],
     "cost": 1,
-    "originSlug": null,
     "design": {
       "arena": "physical",
       "approach": "resilience",
       "archetype": null
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [

--- a/packs/core-perks/nock-shot.json
+++ b/packs/core-perks/nock-shot.json
@@ -3,7 +3,66 @@
   "_id": "5WFNYRPn6z0GBL6C",
   "type": "perk",
   "img": "icons/weapons/ammunition/arrows-barbed-white.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Nock & Shot",
+      "type": "passive",
+      "_id": "sXXvbSqpJbsSDwZf",
+      "img": "icons/weapons/ammunition/arrows-barbed-white.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.qgENOMqdeuKBs47a",
+            "predicate": [],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.qgENOMqdeuKBs47a]{Ballistic} as a Tutored Ability.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754224199355,
+        "modifiedTime": 1754224350157,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -17,8 +76,8 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
-    "description": "<p>Effect: The user gains Ballistic as a Tutored Ability.</p>",
+    "slug": "nock-shot",
+    "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.qgENOMqdeuKBs47a]{Ballistic} as a Tutored Ability.</p>",
     "traits": [],
     "prerequisites": [
       "trait:humanoid",
@@ -26,26 +85,29 @@
     ],
     "autoUnlock": [],
     "cost": 3,
-    "originSlug": null,
     "design": {
       "arena": "physical",
       "approach": "finesse",
       "archetype": null
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [
       {
         "x": 192,
         "y": 63,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "dual-wielder",
           "harry"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ]

--- a/packs/core-perks/pack-alpha.json
+++ b/packs/core-perks/pack-alpha.json
@@ -21,27 +21,22 @@
       }
     ],
     "cost": 1,
-    "description": "<p>You gain the [Pack Leader] trait, and may designate consenting creatures with the [Pack Mon] trait as members of your pack.</p>",
+    "description": "<p>You gain the @Trait[pack-leader] Trait, and may designate consenting creatures with the @Trait[pack-mon] Trait as members of your pack.</p>",
     "actions": [
       {
         "name": "Pack Alpha",
         "slug": "pack-alpha",
         "description": "<p>You gain the [Pack Leader] trait, and may designate consenting creatures with the [Pack Mon] trait as members of your pack.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "pack-alpha",
@@ -65,13 +60,10 @@
           "yousa-bad-bombin"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/perk-icons/Tactician.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/perk-icons/Tactician.svg",
-          "tint": "#ffffff",
-          "scale": null
+          "tint": null
         },
         "tier": null
       }
@@ -92,10 +84,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "_id": "ee07hyZxFObQ5emn",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
@@ -104,24 +93,26 @@
       "name": "Pack Alpha",
       "type": "passive",
       "_id": "m46h0r03OspDM45U",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
       "system": {
         "changes": [
           {
             "type": "add-trait",
             "key": "",
-            "value": "Pack Leader",
+            "value": "pack-leader",
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -133,7 +124,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>You gain the @Trait[pack-leader] Trait, and may designate consenting creatures with the @Trait[pack-mon] Trait as members of your pack.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -143,12 +134,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "1.0.1.beta",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1739314032552,
-        "modifiedTime": 1739314051765,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "modifiedTime": 1754227264436,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/packmarked.json
+++ b/packs/core-perks/packmarked.json
@@ -10,27 +10,22 @@
     "actions": [
       {
         "name": "Mark Prey",
-        "slug": "packmarked-action-1",
-        "description": "<p>The user gains the Action Mark Prey.</p><p>As a Complex Action, a target enemy. The enemy receives Marked 5 and -1 Defense and Special Defense Stages for 5 activations.</p><p>NOTE: create generic action. Check if duplicate already exists?</p>",
+        "slug": "packmarked",
+        "description": "<p>As a Complex Action, a target enemy. The enemy receives @Affliction[marked 5] and @UUID[Compendium.ptr2e.core-effects.bdYCJcqjMNqTpJJQ]{-1 Defense Stage} and @UUID[Compendium.ptr2e.core-effects.qe5aLBJuwb9eYqvv]{-1 Special Defense Stage} for 5 activations.</p>",
         "traits": [],
         "type": "generic",
         "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "delay": null,
-          "priority": null
-        },
-        "variant": null,
-        "ephemeralVariant": false
+          "powerPoints": 3
+        }
       }
     ],
-    "description": "<p>The user gains the Action Mark Prey.</p><p>As a Complex Action, a target enemy. The enemy receives Marked 5 and -1 Defense and Special Defense Stages for 5 activations.</p>",
+    "description": "<p>The user gains @UUID[Compendium.ptr2e.core-perks.Item.d9NvBytgPiTxyW1z.Actions.packmarked].</p><p>As a Complex Action, a target enemy. The enemy receives @Affliction[marked 5] and @UUID[Compendium.ptr2e.core-effects.bdYCJcqjMNqTpJJQ]{-1 Defense Stage} and @UUID[Compendium.ptr2e.core-effects.qe5aLBJuwb9eYqvv]{-1 Special Defense Stage} for 5 activations.</p>",
     "traits": [],
     "prerequisites": [
       "trait:pack-leader"
@@ -39,31 +34,25 @@
     "slug": "packmarked",
     "nodes": [
       {
+        "x": 149,
+        "y": 176,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "pack-alpha",
           "pile-on",
           "you-belong-to-me"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/perk-icons/Tactician.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/perk-icons/Tactician.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 149,
-        "y": 176,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/plate-dynamic.json
+++ b/packs/core-perks/plate-dynamic.json
@@ -14,7 +14,7 @@
     },
     "actions": [],
     "slug": "plate-dynamic",
-    "description": "<p>Effect: The user gains +40 to Breach or Rush rolls if they are utilizing their Burrow Movement before using the Action.</p>",
+    "description": "<p>Effect: The user gains +40 to @UUID[Compendium.ptr2e.core-moves.LnlmVe81MaQAdVWd]{Breach} or @UUID[Compendium.ptr2e.core-moves.JgLLve8pmeAQFVcV]{Rush} rolls if they are utilizing their Burrow Movement before using the Action.</p>",
     "traits": [],
     "prerequisites": [
       "trait:ground"
@@ -46,13 +46,9 @@
         },
         "tier": null
       }
-    ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    ]
   },
   "img": "systems/ptr2e/img/svg/ground_icon.svg",
   "effects": [],
-  "flags": {},
   "_id": "dOdvgBBAhY50KQZr"
 }

--- a/packs/core-perks/potent-afflictions.json
+++ b/packs/core-perks/potent-afflictions.json
@@ -14,19 +14,12 @@
         "type": "passive",
         "range": {
           "target": "creature",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "simple",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
-        "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
+        "img": "systems/ptr2e/img/perk-icons/Arcana.svg"
       }
     ],
     "slug": "potent-afflictions",
@@ -81,9 +74,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/potent-venom.json
+++ b/packs/core-perks/potent-venom.json
@@ -7,7 +7,7 @@
       "trait:poison"
     ],
     "cost": 2,
-    "description": "<p>Your Poison-Type Attacks gain +20% chance to inflict @Affliction[poison] 5.</p>",
+    "description": "<p>Your @Trait[poison] Type Attacks gain +20% chance to inflict @Affliction[poison 5].</p>",
     "actions": [],
     "slug": "potent-venom",
     "traits": [],
@@ -17,6 +17,10 @@
     },
     "nodes": [
       {
+        "x": 167,
+        "y": 85,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "venomous",
           "acceptance",
@@ -24,25 +28,15 @@
           "flare-ignition"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/poison_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/poison_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 167,
-        "y": 85,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -65,7 +59,7 @@
       "name": "Potent Venom",
       "type": "passive",
       "_id": "cR1z4vapujM8EJUC",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/poison_icon.svg",
       "system": {
         "changes": [
           {
@@ -79,14 +73,17 @@
             "priority": null,
             "ignored": false,
             "alterations": [],
-            "dontMerge": false
+            "dontMerge": false,
+            "isFixedChance": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -98,7 +95,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Your @Trait[poison] Type Attacks gain +20% chance to inflict @Affliction[poison 5].</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -108,12 +105,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.0.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1732569045186,
-        "modifiedTime": 1732569067521,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "modifiedTime": 1754225441916,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/psycher.json
+++ b/packs/core-perks/psycher.json
@@ -46,13 +46,64 @@
         "tier": null
       }
     ],
-    "slug": "psycher",
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "slug": "psycher"
   },
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
-  "effects": [],
-  "flags": {},
+  "effects": [
+    {
+      "name": "Telepathic Potential",
+      "type": "passive",
+      "_id": "6laA7fKIAdWMl7UP",
+      "img": "systems/ptr2e/img/svg/psychic_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "psycher",
+            "predicate": [],
+            "priority": null,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>You gain the @Trait[psycher] trait.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.4n06ljZtbCqy6lEC.ActiveEffect.2JtWtzy2Slq3HfIT",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754228049729,
+        "modifiedTime": 1754228061710,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "_id": "KpNl1wepbpQDYmJf"
 }

--- a/packs/core-perks/psychoportation.json
+++ b/packs/core-perks/psychoportation.json
@@ -6,29 +6,22 @@
       "trait:psychic"
     ],
     "cost": 2,
-    "description": "<p>You gain the [Teleporter] trait. Additionally, you gain a Teleport Movement Allowance equal to that of your highest Primary Movement Score.</p>",
+    "description": "<p>You gain the @Trait[teleporter] Trait. Additionally, you gain a Teleport Movement Allowance equal to that of your highest Primary Movement Score.</p>",
     "actions": [
       {
         "name": "Psychoportation",
         "slug": "psychoportation",
         "description": "<p>You gain the [Teleporter] trait. Additionally, you gain a Teleport Movement Allowance equal to that of your highest Primary Movement Score.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "psychoportation",
@@ -39,6 +32,10 @@
     },
     "nodes": [
       {
+        "x": 160,
+        "y": 124,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "hypnotic-suggestion",
           "long-range-psychoportation",
@@ -52,27 +49,17 @@
           "away-with-you"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/psychic_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/psychic_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 160,
-        "y": 124,
         "tier": null
       }
     ],
     "autoUnlock": [
       "trait:teleporter"
     ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -90,6 +77,55 @@
   },
   "_id": "362jA0jsfgTgKKiE",
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Psychoportation",
+      "type": "passive",
+      "_id": "tpnRys47NtWywgrs",
+      "img": "systems/ptr2e/img/svg/psychic_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "teleporter",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>You gain the @Trait[teleporter] Trait. Additionally, you gain a Teleport Movement Allowance equal to that of your highest Primary Movement Score.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754226537724,
+        "modifiedTime": 1754226557576,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "folder": "F4b52L00KrAtdPu5"
 }

--- a/packs/core-perks/sadism.json
+++ b/packs/core-perks/sadism.json
@@ -9,7 +9,7 @@
       {
         "name": "Sadism",
         "slug": "sadism",
-        "description": "<p>Trigger: A creature within 5m of you suffers loses a Tick(s) of HP as effect damage from an Affliction.<br><br>Effect: You heal a number of Ticks of HP equal to the number of Ticks the triggering creature lost.</p>",
+        "description": "<p>Trigger: A creature within 5m of you suffers a Tick(s) of HP as effect damage from an Affliction.<br><br>Effect: You heal a number of @Tick[1]s of HP equal to the number of Ticks the triggering creature lost.</p>",
         "traits": [
           "healing",
           "interrupt-2"
@@ -17,23 +17,18 @@
         "type": "generic",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "free",
           "powerPoints": 3,
-          "trigger": "A creature within 5m of you suffers loses a Tick(s) of HP as effect damage from an Affliction.",
-          "delay": null,
-          "priority": null
+          "trigger": "A creature within 5m of you suffers loses a Tick(s) of HP as effect damage from an Affliction."
         },
-        "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "ephemeralVariant": false
+        "img": "systems/ptr2e/img/perk-icons/Taskmaster.svg"
       }
     ],
     "slug": "sadism",
-    "description": "<p>Trigger: A creature within 5m of you suffers loses a Tick(s) of HP as effect damage from an Affliction.<br><br>Effect: You heal a number of Ticks of HP equal to the number of Ticks the triggering creature lost.</p>",
+    "description": "<p>Trigger: A creature within 5m of you suffers a Tick(s) of HP as effect damage from an Affliction.<br><br>Effect: You heal a number of @Tick[1]s of HP equal to the number of Ticks the triggering creature lost.</p>",
     "traits": [],
     "prerequisites": [
       {
@@ -50,31 +45,25 @@
     },
     "nodes": [
       {
+        "x": 147,
+        "y": 70,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "stage-vampirism",
           "cultivate-weakness",
           "insidious-wounds"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#004040",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Taskmaster.svg",
-          "tint": null,
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 147,
-        "y": 70,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/screen-setter.json
+++ b/packs/core-perks/screen-setter.json
@@ -7,26 +7,23 @@
       "item:move:reflect"
     ],
     "cost": 4,
-    "description": "<p>When using either Light Screen or Reflect, you may spend 3PP to also use the other one as a Free Action at [Interrupt 2].<br><br>Connection: Light Screen, Reflect.</p>",
+    "description": "<p>When using either @UUID[Compendium.ptr2e.core-moves.gSRNdRZt5vRCzqwM]{Light Screen} or @UUID[Compendium.ptr2e.core-moves.1Fj2tpYLzmm6bnIN]{Reflect}, you may spend 3PP to also use the other one as a Free Action at @Trait[interrupt-2].<br><br>Connection: @UUID[Compendium.ptr2e.core-moves.gSRNdRZt5vRCzqwM]{Light Screen}, @UUID[Compendium.ptr2e.core-moves.1Fj2tpYLzmm6bnIN]{Reflect}.</p>",
     "actions": [
       {
         "name": "Screen Setter",
         "slug": "screen-setter",
-        "description": "<p>When using either Light Screen or Reflect, you may spend 3PP to also use the other one as a Free Action at [Interrupt 2].</p>",
+        "description": "<p>When using either @UUID[Compendium.ptr2e.core-moves.gSRNdRZt5vRCzqwM]{Light Screen} or @UUID[Compendium.ptr2e.core-moves.1Fj2tpYLzmm6bnIN]{Reflect}, you may spend 3PP to also use the other one as a Free Action at @Trait[interrupt-2].</p>",
         "cost": {
           "activation": "complex",
           "powerPoints": 3
         },
         "type": "generic",
         "traits": [],
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "screen-setter",
@@ -58,12 +55,9 @@
         ],
         "config": {
           "texture": "systems/ptr2e/img/perk-icons/Occultism.svg",
-          "alpha": null,
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "tint": null,
-          "scale": null
+          "tint": null
         },
         "tier": null
       }
@@ -81,83 +75,11 @@
       "authors": [
         "PTR 2e Team"
       ],
-      "notes": "undefined"
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+      "notes": ""
+    }
   },
   "_id": "cnTPWqYXmGaFZfBd",
   "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
-  "effects": [
-    {
-      "name": "Screen Setter",
-      "type": "passive",
-      "_id": "32yj5ObQZdmyiwFN",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
-      "system": {
-        "changes": [
-          {
-            "type": "grant-item",
-            "key": "",
-            "value": "Compendium.ptr2e.core-moves.Item.gSRNdRZt5vRCzqwM",
-            "predicate": [],
-            "alterations": [
-              {
-                "mode": 5,
-                "property": "system.actions.0.free",
-                "value": "true"
-              }
-            ],
-            "mode": 2,
-            "priority": null,
-            "ignored": false,
-            "reevaluateOnUpdate": false,
-            "inMemoryOnly": false,
-            "allowDuplicate": true,
-            "track": false,
-            "replaceSelf": false,
-            "onDeleteActions": {
-              "grantee": "detach",
-              "granter": "cascade"
-            }
-          }
-        ],
-        "slug": null,
-        "traits": [],
-        "removeAfterCombat": true,
-        "removeOnRecall": false,
-        "stacks": 0
-      },
-      "disabled": false,
-      "duration": {
-        "startTime": null,
-        "seconds": null,
-        "combat": null,
-        "rounds": null,
-        "turns": null,
-        "startRound": null,
-        "startTurn": null
-      },
-      "description": "",
-      "origin": null,
-      "tint": "#ffffff",
-      "transfer": true,
-      "statuses": [],
-      "sort": 0,
-      "flags": {},
-      "_stats": {
-        "compendiumSource": null,
-        "duplicateSource": null,
-        "coreVersion": "13.342",
-        "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.5",
-        "createdTime": 1737391538266,
-        "modifiedTime": 1737391569234,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
-        "exportSource": null
-      }
-    }
-  ],
+  "effects": [],
   "folder": "KcpEanpX82Cu6Dqh"
 }

--- a/packs/core-perks/spectral-stalker.json
+++ b/packs/core-perks/spectral-stalker.json
@@ -6,29 +6,22 @@
       "trait:ghost"
     ],
     "cost": 3,
-    "description": "<p>Gain the [Shadow Meld] trait.</p>",
+    "description": "<p>Gain the @Trait[shadow-meld] trait.</p>",
     "actions": [
       {
         "name": "Spectral Stalker",
         "slug": "spectral-stalker",
         "description": "<p>Gain the [Shadow Meld] trait.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "spectral-stalker",
@@ -39,6 +32,10 @@
     },
     "nodes": [
       {
+        "x": 172,
+        "y": 114,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "walking-dead",
           "grim-haunt",
@@ -48,27 +45,17 @@
           "incorporeal"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/ghost_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/ghost_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 172,
-        "y": 114,
         "tier": null
       }
     ],
     "autoUnlock": [
       "trait:shadow-meld"
     ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -91,24 +78,26 @@
       "name": "Spectral Stalker",
       "type": "passive",
       "_id": "RNigtm9NFQa7ATOz",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/ghost_icon.svg",
       "system": {
         "changes": [
           {
             "type": "add-trait",
             "key": "",
-            "value": "Shadow Meld",
+            "value": "shadow-meld",
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -120,7 +109,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Gain the @Trait[shadow-meld] trait.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -130,12 +119,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1733069550484,
-        "modifiedTime": 1733069563720,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1754225927283,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/spooky.json
+++ b/packs/core-perks/spooky.json
@@ -46,13 +46,64 @@
         "tier": null
       }
     ],
-    "slug": "spooky",
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "slug": "spooky"
   },
   "img": "systems/ptr2e/img/svg/ghost_icon.svg",
-  "effects": [],
-  "flags": {},
+  "effects": [
+    {
+      "name": "Spooky",
+      "type": "passive",
+      "_id": "HfEqMR7XBiF8JJYH",
+      "img": "systems/ptr2e/img/svg/ghost_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "key": "",
+            "value": "spooky",
+            "predicate": [],
+            "priority": null,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "<p>Gain the @Trait[spooky] trait.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.fdBGG8e0iPzaYfbD.ActiveEffect.RNigtm9NFQa7ATOz",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754226090747,
+        "modifiedTime": 1754226110896,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "_id": "PeupEOfxAEvYLoFV"
 }

--- a/packs/core-perks/stage-vampirism.json
+++ b/packs/core-perks/stage-vampirism.json
@@ -5,9 +5,25 @@
   "_id": "2eXQ3mabu1Ljq4z6",
   "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
   "system": {
-    "actions": [],
+    "actions": [
+      {
+        "name": "Stage Vampirism",
+        "slug": "stage-vampirism",
+        "description": "<p>At a cost of 3PP per target, when you inflict a negative @Trait[stage-change] effects on a creature, you may gain those Combat Stages as positive stages. The PP cost is paid in addition to the PP cost of the original move.</p>",
+        "traits": [],
+        "type": "generic",
+        "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
+        "cost": {
+          "activation": "free"
+        },
+        "range": {
+          "target": "self",
+          "unit": "m"
+        }
+      }
+    ],
     "slug": "stage-vampirism",
-    "description": "<p>At a cost of 3PP per target, when you inflict negative [Stage Change] effects on a creature, you may gain those Combat Stages as positive stages. The PP cost is paid in addition to the PP cost of the original move.</p>",
+    "description": "<p>At a cost of 3PP per target, when you inflict a negative @Trait[stage-change] effects on a creature, you may gain those Combat Stages as positive stages. The PP cost is paid in addition to the PP cost of the original move.</p>",
     "traits": [],
     "prerequisites": [
       {
@@ -24,6 +40,10 @@
     },
     "nodes": [
       {
+        "x": 144,
+        "y": 72,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "thug",
           "sadism",
@@ -31,27 +51,17 @@
           "cultivate-weakness"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#800000",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Occultism.svg",
-          "tint": null,
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 144,
-        "y": 72,
         "tier": null
       }
     ],
     "autoUnlock": [],
     "global": true,
     "webs": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "design": {
       "arena": "mental",
       "approach": "power",

--- a/packs/core-perks/subsidence.json
+++ b/packs/core-perks/subsidence.json
@@ -7,7 +7,7 @@
       "previous": null
     },
     "actions": [],
-    "description": "<p>Passive: Your ground-type moves gain a +20% chance to inflict the Grounded condition.</p>",
+    "description": "<p>Passive: Your @Trait[ground] Type moves gain a +20% chance to inflict the @Affliction[grounded] Affliction.</p>",
     "traits": [],
     "prerequisites": [
       "trait:ground"
@@ -16,6 +16,10 @@
     "slug": "subsidence",
     "nodes": [
       {
+        "x": 167,
+        "y": 80,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "acceptance",
           "improved-burrow-1",
@@ -24,25 +28,15 @@
           "plate-dynamic"
         ],
         "config": {
-          "alpha": null,
+          "texture": null,
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": null,
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 167,
-        "y": 80,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -64,7 +58,7 @@
       "name": "Subsidence",
       "type": "passive",
       "_id": "zuqTiAf1XZcKz73D",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/ground_icon.svg",
       "system": {
         "changes": [
           {
@@ -78,14 +72,17 @@
             "priority": null,
             "ignored": false,
             "alterations": [],
-            "dontMerge": false
+            "dontMerge": false,
+            "isFixedChance": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -97,7 +94,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Passive: Your @Trait[ground] Type moves gain a +20% chance to inflict the @Affliction[grounded] Affliction.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -107,12 +104,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.1.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
+        "modifiedTime": 1754224650159,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/suspicious-minds.json
+++ b/packs/core-perks/suspicious-minds.json
@@ -9,7 +9,7 @@
       {
         "name": "Suspicious Minds",
         "slug": "suspicious-minds",
-        "description": "<p>Trigger: A creature in range suffers damage or an effect from the End of Activation effect of a [DoT] Affliction.<br><br>Effect: For each End of Activation effect Affliction that was triggered on the target, the target loses @Tick[-1]. The affected creature is protected from further instances of this perk until their next activation commences.</p>",
+        "description": "<p>Trigger: A creature in range suffers damage or an effect from the End of Activation effect of a @Trait[dot] Affliction.<br><br>Effect: For each End of Activation @Trait[dot] effect that was triggered on the target, the target loses an additional @Tick[-1]. The affected creature is protected from further instances of this perk until their next activation commences.</p>",
         "traits": [
           "interrupt-3"
         ],
@@ -22,17 +22,13 @@
         "cost": {
           "activation": "free",
           "powerPoints": 3,
-          "trigger": "A creature in range suffers effect damage from an Affliction due to a Stack being removed.",
-          "delay": null,
-          "priority": null
+          "trigger": "A creature in range suffers effect damage from an Affliction due to a Stack being removed."
         },
-        "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
-        "variant": null,
-        "ephemeralVariant": false
+        "img": "systems/ptr2e/img/perk-icons/Occultism.svg"
       }
     ],
     "slug": "suspicious-minds",
-    "description": "<p>Trigger: A creature in range suffers damage or an effect from the End of Activation effect of a [DoT] Affliction.<br><br>Effect: For each End of Activation effect Affliction that was triggered on the target, the target loses @Tick[-1]. The affected creature is protected from further instances of this perk until their next activation commences.</p>",
+    "description": "<p>Trigger: A creature in range suffers damage or an effect from the End of Activation effect of a @Trait[dot] Affliction.<br><br>Effect: For each End of Activation @Trait[dot] effect that was triggered on the target, the target loses an additional @Tick[-1]. The affected creature is protected from further instances of this perk until their next activation commences.</p>",
     "traits": [
       "interrupt-3"
     ],
@@ -88,9 +84,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/tainted-blades.json
+++ b/packs/core-perks/tainted-blades.json
@@ -7,7 +7,7 @@
       "previous": null
     },
     "actions": [],
-    "description": "<p>You may add the Poison type as a second typing to your [Weapon] attacks as a passive benefit.</p>",
+    "description": "<p>You may add the @Trait[poison] type as a second typing to your @Trait[weapon] attacks as a passive benefit.</p>",
     "traits": [
       "weapon",
       "poison"
@@ -19,6 +19,10 @@
     "slug": "tainted-blades",
     "nodes": [
       {
+        "x": 177,
+        "y": 81,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "covering-fire",
           "harry",
@@ -28,25 +32,15 @@
           "clodsire-flesh"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/poison_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/poison_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 177,
-        "y": 81,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/telepathic-potential.json
+++ b/packs/core-perks/telepathic-potential.json
@@ -6,31 +6,8 @@
       "trait:psychic"
     ],
     "cost": 2,
-    "description": "<p>You gain the [Telepath] trait.</p>",
-    "actions": [
-      {
-        "name": "Telepathic Potential",
-        "slug": "telepathic-potential",
-        "description": "<p>You gain the [Telepath] trait.</p>",
-        "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
-        },
-        "type": "passive",
-        "traits": [],
-        "img": "icons/svg/explosion.svg",
-        "range": {
-          "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
-      }
-    ],
+    "description": "<p>You gain the @Trait[telepath] trait.</p>",
+    "actions": [],
     "slug": "telepathic-potential",
     "traits": [],
     "_migration": {
@@ -39,6 +16,10 @@
     },
     "nodes": [
       {
+        "x": 141,
+        "y": 138,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "hypnotic-suggestion",
           "hesitation",
@@ -56,27 +37,17 @@
           "psycher"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/psychic_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/psychic_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 141,
-        "y": 138,
         "tier": null
       }
     ],
     "autoUnlock": [
       "trait:telepath"
     ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -99,33 +70,26 @@
       "name": "Telepathic Potential",
       "type": "passive",
       "_id": "2JtWtzy2Slq3HfIT",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/psychic_icon.svg",
       "system": {
         "changes": [
           {
             "type": "add-trait",
             "key": "",
-            "value": "Telepath",
+            "value": "telepath",
             "predicate": [],
-            "mode": 2,
             "priority": null,
-            "ignored": false
-          },
-          {
-            "type": "basic",
-            "key": "",
-            "value": 0,
             "mode": 2,
-            "priority": null,
-            "predicate": [],
             "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -137,7 +101,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>You gain the @Trait[telepath] trait.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -147,12 +111,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.4.1",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1732233454404,
-        "modifiedTime": 1732233461512,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS",
+        "modifiedTime": 1754227903493,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/the-unassessably-terrible.json
+++ b/packs/core-perks/the-unassessably-terrible.json
@@ -16,7 +16,7 @@
     },
     "actions": [],
     "slug": "the-unassessably-terrible",
-    "description": "<p>The user gains +20 on rolls to coerce or intimidate other creatures, and takes 20% less damage from [Pack Mon] creatures.</p>",
+    "description": "<p>The user gains +20 on rolls to coerce or intimidate other creatures, and takes 20% less damage from @Trait[pack-mon] creatures.</p>",
     "traits": [],
     "prerequisites": [
       "trait:dragon",
@@ -35,23 +35,25 @@
       {
         "x": 133,
         "y": 83,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "drakelike",
           "draconic-presence",
           "kinetic-dispersion",
           "bladesworn-scion"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
-    ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    ]
   },
   "img": "systems/ptr2e/img/svg/dragon_icon.svg",
   "effects": [],
-  "flags": {},
   "_id": "0ipu4RDGb6d5Lign"
 }

--- a/packs/core-perks/type-domain.json
+++ b/packs/core-perks/type-domain.json
@@ -13,29 +13,24 @@
       "item:perk:type-specialist"
     ],
     "cost": 2,
-    "description": "<p>You are able to tutor [Domain] abilities associated to your chosen &lt;Type&gt; . Only yourself, and creatures that have your chosen Type can learn these abilties. This perk may be purchased multiple times, once per Type Specialty you possess.</p>",
+    "description": "<p>You are able to tutor @Trait[domain] abilities associated to your chosen &lt;Type&gt; . Only yourself, and creatures that have your chosen Type can learn these abilties. This perk may be purchased multiple times, once per Type Specialty you possess.</p>",
     "actions": [
       {
         "name": "<Type> Domain",
         "slug": "type-domain",
-        "description": "<p>You are able to tutor [Domain] abilities associated to your chosen &lt;Type&gt;. Only creatures that have your chosen <Type> can learn these abilties.</p>",
+        "description": "<p>You are able to tutor @Trait[domain] abilities associated to your chosen &lt;Type&gt;. Only creatures that have your chosen can learn these abilties.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0
+          "activation": "free"
         },
         "type": "passive",
         "traits": [
           "type"
         ],
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/perk-icons/Trainer.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "type-domain",
@@ -48,6 +43,10 @@
     },
     "nodes": [
       {
+        "x": 141,
+        "y": 98,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "type-desperation",
           "type-tutoring",
@@ -60,18 +59,11 @@
           "dastardly-planner"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/perk-icons/Trainer.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/perk-icons/Trainer.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 141,
-        "y": 98,
         "tier": null
       }
     ],
@@ -89,10 +81,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "_id": "aMMwSJntCErBGbQZ",
   "img": "systems/ptr2e/img/perk-icons/Trainer.svg",

--- a/packs/core-perks/venomous.json
+++ b/packs/core-perks/venomous.json
@@ -13,20 +13,15 @@
         "slug": "venomous",
         "description": "<p>You gain the [Venomous] Trait.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "venomous",
@@ -75,10 +70,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "_id": "hvuakkloMFHGmBMe",
   "img": "systems/ptr2e/img/svg/poison_icon.svg",
@@ -87,24 +79,26 @@
       "name": "Venomous",
       "type": "passive",
       "_id": "IrKbdTOohqeeUv7w",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/poison_icon.svg",
       "system": {
         "changes": [
           {
             "type": "add-trait",
             "key": "",
-            "value": "Venomous",
+            "value": "venomous",
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -116,7 +110,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>You gain the @Trait[venomous] Trait.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -126,12 +120,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.0.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1732563827501,
-        "modifiedTime": 1732563840313,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "modifiedTime": 1754225348008,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/walking-dead.json
+++ b/packs/core-perks/walking-dead.json
@@ -6,29 +6,22 @@
       "trait:ghost"
     ],
     "cost": 2,
-    "description": "<p>Gain the [Silent], [Breathless] & [Lifesense 10] traits, and your Diet changes to Auravore.</p>",
+    "description": "<p>Gain the @Trait[silent], @Trait[breathless] & @Trait[lifesense-10] traits, and your Diet changes to Auravore.</p>",
     "actions": [
       {
         "name": "Walking Dead",
         "slug": "walking-dead",
         "description": "Gain the [Silent], [Breathless] & [Lifesense 10] traits, and your Diet changes to Auravore.",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "walking-dead",
@@ -39,6 +32,10 @@
     },
     "nodes": [
       {
+        "x": 167,
+        "y": 116,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "spectral-stalker",
           "grim-haunt",
@@ -49,25 +46,23 @@
           "incorporeal"
         ],
         "config": {
-          "alpha": null,
+          "texture": "systems/ptr2e/img/svg/ghost_icon.svg",
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/svg/ghost_icon.svg",
-          "tint": null,
-          "scale": null
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 167,
-        "y": 116,
         "tier": null
       }
     ],
-    "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
+    "autoUnlock": [
+      {
+        "and": [
+          "trait:silent",
+          "trait:breathless",
+          "trait:lifesense"
+        ]
+      }
+    ],
     "global": true,
     "webs": [],
     "design": {
@@ -90,42 +85,44 @@
       "name": "Walking Dead",
       "type": "passive",
       "_id": "tcWdZIRx8LXL4o5w",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/ghost_icon.svg",
       "system": {
         "changes": [
           {
             "type": "add-trait",
             "key": "",
-            "value": "Silent",
+            "value": "silent",
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           },
           {
             "type": "add-trait",
             "key": "",
-            "value": "Breathless",
+            "value": "breathless",
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           },
           {
             "type": "add-trait",
             "key": "",
-            "value": "Lifesense 10",
+            "value": "lifesense-10",
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -137,7 +134,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Gain the @Trait[silent], @Trait[breathless] &amp; @Trait[lifesense-10] traits, and your Diet changes to Auravore.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -147,12 +144,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1733069737375,
-        "modifiedTime": 1733069772921,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1754226174912,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z",
         "exportSource": null
       }
     }

--- a/packs/core-perks/wound-spring.json
+++ b/packs/core-perks/wound-spring.json
@@ -3,7 +3,73 @@
   "_id": "ymvgqlFIvWJHs0hD",
   "type": "perk",
   "img": "icons/creatures/reptiles/serpent-horned-green.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Wound Spring",
+      "type": "passive",
+      "_id": "ZfiCISJQLPjjD70u",
+      "img": "icons/creatures/reptiles/serpent-horned-green.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.7r57DxIctmNSW2oV",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "priority": null,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>Grants @UUID[Compendium.ptr2e.core-moves.7r57DxIctmNSW2oV]{Coil}</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754227681749,
+        "modifiedTime": 1754227717141,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -17,35 +83,38 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
-    "description": "<p>Connection: Coil<br><br>Effect: When the user uses Brace or Coil, they gain +30 to the relevant skill check the next time they use Rush, Jump, Leap, or Breach.</p>",
+    "slug": "wound-spring",
+    "description": "<p>Connection: @UUID[Compendium.ptr2e.core-moves.7r57DxIctmNSW2oV]{Coil}<br><br>Effect: When the user uses @UUID[Compendium.ptr2e.core-moves.SxFXgSCqw5vnRzon]{Brace} or @UUID[Compendium.ptr2e.core-moves.7r57DxIctmNSW2oV]{Coil}, they gain +30 to the relevant skill check the next time they use @UUID[Compendium.ptr2e.core-moves.JgLLve8pmeAQFVcV]{Rush}, @UUID[Compendium.ptr2e.core-moves.JKlLve9aMaQAdVcZ]{Jump}, @UUID[Compendium.ptr2e.core-moves.JKlLve9aMaQAdVcW]{Leap}, or @UUID[Compendium.ptr2e.core-moves.LnlmVe81MaQAdVWd]{Breach}.</p>",
     "traits": [],
     "prerequisites": [
       "trait:serpentine"
     ],
     "autoUnlock": [],
     "cost": 2,
-    "originSlug": null,
     "design": {
       "arena": "physical",
       "approach": "power",
       "archetype": "serpentine"
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [
       {
         "x": 133,
         "y": 170,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "minor-buff-15",
           "dance-partner",
           "metamove-target-split"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ]

--- a/packs/core-perks/yeomanry.json
+++ b/packs/core-perks/yeomanry.json
@@ -17,8 +17,8 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
-    "description": "<p>The user’s non-[Firearm] [Missile] [Weapon] attacks deal +40% more damage, and the user’s Struggle has +20 Power when they are holding a non-[Firearm] [Missile] [Weapon].</p>",
+    "slug": "yeomanry",
+    "description": "<p>The user’s non-@Trait[firearm] @Trait[missile] @Trait[weapon] attacks deal +40% more damage, and the user’s Struggle has +20 Power when they are holding a non-@Trait[firearm] @Trait[missile] @Trait[weapon].</p>",
     "traits": [],
     "prerequisites": [
       "trait:wielder",
@@ -49,20 +49,19 @@
     ],
     "autoUnlock": [],
     "cost": 3,
-    "originSlug": null,
     "design": {
       "arena": "physical",
       "approach": "finesse",
       "archetype": null
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [
       {
         "x": 187,
         "y": 63,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "dual-wielder",
           "down-the-sights",
@@ -70,8 +69,12 @@
           "arms-race",
           "needle-threader"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ]

--- a/packs/core-perks/yousa-bad-bombin.json
+++ b/packs/core-perks/yousa-bad-bombin.json
@@ -8,7 +8,7 @@
       "name": "Yousa Bad Bombin",
       "type": "passive",
       "_id": "85I31g9iGHNjMVlI",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "icons/weapons/thrown/bomb-fuse-black-grey.webp",
       "system": {
         "changes": [
           {
@@ -32,16 +32,18 @@
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "startTime": null,
         "combat": null
       },
-      "description": "",
+      "description": "<p>You gain @UUID[Compendium.ptr2e.core-abilities.Item.gubM49aBQUdUKGQv]{Aftermath} as a tutored ability.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -52,12 +54,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "1.3.1.beta",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1751554474606,
-        "modifiedTime": 1751554489208,
-        "lastModifiedBy": "dL9m14FoxNtwHs5T"
+        "modifiedTime": 1754227129481,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
       }
     }
   ],
@@ -74,7 +76,7 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
+    "slug": "yousa-bad-bombin",
     "description": "<p>You gain @UUID[Compendium.ptr2e.core-abilities.Item.gubM49aBQUdUKGQv]{Aftermath} as a tutored ability.</p>",
     "traits": [],
     "prerequisites": [
@@ -84,14 +86,11 @@
       "item:ability:aftermath"
     ],
     "cost": 3,
-    "originSlug": null,
     "design": {
       "arena": "physical",
       "approach": "power",
       "archetype": null
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Perk: Nock & Shot
- Update Perk: Yeomanry
- Update Perk: Down The Sights
- Update Perk: Covering Fire
- Update Perk: Arms Race
- Update Perk: Tainted Blades
- Update Perk: Down to Earth
- Update Perk: Subsidence
- Update Perk: Plate Dynamic
- Update Perk: Clodsire Flesh
- Update Perk: Mudrunner
- Update Perk: Fictile
- Update Perk: Venomous
- Update Perk: Potent Venom
- Update Perk: Intense Heat
- Update Perk: Inner Warmth
- Update Effect: Stoked
- Update Perk: Midnight Oil
- Update Perk: Firefly
- Update Perk: Incorporeal
- Update Perk: Spectral Stalker
- Update Perk: Grim Haunt
- Update Perk: Spooky
- Update Perk: Walking Dead
- Update Perk: Mindscramble
- Update Perk: Psychoportation
- Update Perk: Agitator
- Update Perk: Hesitation
- Update Perk: Guerilla Radio
- Update Perk: Cover Artist
- Update Perk: Yousa Bad Bombin'
- Update Perk: Pack Alpha
- Update Perk: Packmarked
- Update Perk: Wound Spring
- Update Perk: Fractalised Contingency
- Update Perk: Telepathic Potential
- Update Perk: Psycher
- Update Perk: Conceal Mind
- Update Perk: Master Mindscanner
- Update Perk: <Type> Domain
- Update Perk: Screen Setter
- Update Perk: Common Capability
- Update Perk: Generalizer
- Update Perk: Firestarter
- Update Perk: Acceptance
- Update Perk: Fighting Momentum
- Update Perk: Grendelian Tribute
- Update Perk: Draconic Presence
- Update Perk: Drakelike
- Update Perk: The Unassessably Terrible
- Update Perk: Lasting Harm
- Update Perk: Potent Afflictions
- Update Perk: Suspicious Minds
- Update Perk: Insidious Wounds
- Update Perk: Sadism
- Update Perk: Stage Vampirism
- Update Perk: Hexcraft