### PR TITLE
Foundry Data Sync - Fix for Full IV Booster for Bosses Providing Special Defense Twice

### DIFF
--- a/packs/core-effects/full-iv-booster-for-bosses.json
+++ b/packs/core-effects/full-iv-booster-for-bosses.json
@@ -12,7 +12,14 @@
     },
     "slug": "full-iv-booster-for-bosses",
     "description": "<p>Add 30 IVs in all stats. Meant for Bosses.</p>",
-    "traits": []
+    "traits": [],
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    }
   },
   "_id": "cwnxDKZUoQdmE4lP",
   "img": "systems/ptr2e/img/icons/class_feat_icon.webp",
@@ -29,8 +36,8 @@
             "key": "system.attributes.atk.ivs",
             "value": 30,
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           },
           {
@@ -38,8 +45,8 @@
             "key": "system.attributes.def.ivs",
             "value": 30,
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           },
           {
@@ -47,8 +54,8 @@
             "key": "system.attributes.hp.ivs",
             "value": 30,
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           },
           {
@@ -56,8 +63,8 @@
             "key": "system.attributes.spa.ivs",
             "value": 30,
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           },
           {
@@ -65,17 +72,17 @@
             "key": "system.attributes.spd.ivs",
             "value": 30,
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           },
           {
             "type": "basic",
-            "key": "system.attributes.spd.ivs",
+            "key": "system.attributes.spe.ivs",
             "value": 30,
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           }
         ],
@@ -83,7 +90,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -105,13 +114,15 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.0.0",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1729379191134,
-        "modifiedTime": 1739308054757,
-        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
+        "modifiedTime": 1754255303961,
+        "lastModifiedBy": "QT9RUSVuyZd4bDWO",
+        "exportSource": null
       }
     }
-  ]
+  ],
+  "folder": "QUgx4S1LlBbCXWnX"
 }


### PR DESCRIPTION
Fixed a typo in the effect causing the IV Booster to add to Special Defense a second time instead of into Speed.
Discovered by ThatOneGeek
- Update Effect: Full IV Booster for Bosses