### PR TITLE
Foundry Data Sync - Perk Automation & Fixes 

### DIFF
--- a/packs/core-perks/aura-dampening.json
+++ b/packs/core-perks/aura-dampening.json
@@ -10,39 +10,42 @@
         ]
       }
     ],
-    "cost": 2,
-    "description": "<p>You are able to dampen your Aura, making it difficult to read your moods and intentions. You may spend the 2 PP cost as an [Interrupt 3] Free Action when someone attempts to probe your Aura using Aura Empathy to inflict a -20 penalty to any triggering Aura Sense check.</p>",
+    "cost": 1,
+    "description": "<p>You are able to dampen your Aura, making it difficult to read your moods and intentions.</p><p>Whenever someone attempts to probe your Aura using @UUID[Compendium.ptr2e.core-perks.0oopLlKDWl1rf2Sm]{Aura Empathy} they take a -20 penalty to any triggering Aura Sense check(s).</p><p>If they fail on any such checks, you become aware of their attempt to probe your Aura.</p>",
     "actions": [
       {
         "name": "Aura Dampening",
         "slug": "aura-dampening",
-        "description": "<p>You are able to dampen your Aura, making it difficult to read your moods and intentions. You may spend the 2 PP cost as an [Interrupt 3] Free Action when someone attempts to probe your Aura using Aura Empathy to inflict a -20 penalty to any triggering Aura Sense check.</p>",
+        "description": "<p>Whenever someone attempts to probe your Aura using @UUID[Compendium.ptr2e.core-perks.0oopLlKDWl1rf2Sm]{Aura Empathy} they take a -20 penalty to any triggering Aura Sense check(s).</p><p>If they fail on any such checks, you become aware of their attempt to probe your Aura.</p>",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
-        "type": "generic",
-        "traits": [],
-        "img": "icons/svg/explosion.svg",
+        "type": "passive",
+        "traits": [
+          "aura"
+        ],
+        "img": "systems/ptr2e/img/perk-icons/Aura.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "aura-dampening",
-    "traits": [],
+    "traits": [
+      "aura"
+    ],
     "_migration": {
       "version": null,
       "previous": null
     },
     "nodes": [
       {
+        "x": 179,
+        "y": 25,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "aura-projection",
           "aura-bonding",
@@ -50,25 +53,15 @@
           "shielding-aura"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#808000",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
-          "tint": "#ffffff",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 179,
-        "y": 25,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/aura-haze.json
+++ b/packs/core-perks/aura-haze.json
@@ -11,68 +11,52 @@
       }
     ],
     "cost": 2,
-    "description": "<p>Your skill at manipulating your own Aura allows you to create an indistinct haze about yourself. You gain +1 EVA stage for 5 Activations.</p>",
+    "description": "<p>Your skill at manipulating your own Aura allows you to create an indistinct haze about yourself.</p><p>You gain the @UUID[Compendium.ptr2e.core-perks.Item.UmbmjzRANft3PAxG.Actions.aura-haze]{Aura Haze} Action which you can use as a Simple Action, spending 2PP, to gain @UUID[Compendium.ptr2e.core-effects.OUBNweJOMjAEtAye]{+1 Evasion Stage}.</p>",
     "actions": [
       {
         "name": "Aura Haze",
         "slug": "aura-haze",
-        "description": "<p>Your skill at manipulating your own Aura allows you to create an indistinct haze about yourself. You gain +1 EVA stage for 5 Activations.</p>",
+        "description": "<p>You gain @UUID[Compendium.ptr2e.core-effects.OUBNweJOMjAEtAye]{+1 Evasion Stage}.</p>",
         "cost": {
           "activation": "simple",
           "powerPoints": 2
         },
-        "type": "attack",
-        "traits": [],
+        "type": "generic",
+        "traits": [
+          "aura"
+        ],
         "img": "systems/ptr2e/img/perk-icons/Aura.svg",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
-        },
-        "types": [
-          "untyped"
-        ],
-        "category": "status",
-        "free": true,
-        "predicate": [],
-        "variant": null,
-        "ephemeralVariant": false,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": "",
-        "offensiveStat": null,
-        "defensiveStat": null
+          "unit": "m"
+        }
       }
     ],
     "slug": "aura-haze",
-    "traits": [],
+    "traits": [
+      "aura"
+    ],
     "_migration": {
       "version": null,
       "previous": null
     },
     "nodes": [
       {
+        "x": 173,
+        "y": 25,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "aura-user",
           "shielding-aura",
           "chi-alignment"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#e4b9b9",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
-          "tint": "#da7777",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 173,
-        "y": 25,
         "tier": null
       }
     ],
@@ -90,10 +74,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "_id": "UmbmjzRANft3PAxG",
   "img": "systems/ptr2e/img/perk-icons/Aura.svg",
@@ -102,28 +83,33 @@
       "name": "Aura Haze",
       "type": "passive",
       "_id": "Uh6oIjyCAA77vnOT",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Aura.svg",
       "system": {
         "changes": [
           {
             "type": "roll-effect",
-            "key": "aura-haze-attack",
+            "key": "aura-haze-generic",
             "value": "Compendium.ptr2e.core-effects.Item.OUBNweJOMjAEtAye",
             "predicate": [],
             "chance": 100,
             "affects": "target",
-            "mode": 2,
             "priority": null,
-            "ignored": false,
             "alterations": [],
-            "dontMerge": false
+            "dontMerge": false,
+            "isFixedChance": false,
+            "mode": 2,
+            "ignored": false
           }
         ],
         "slug": null,
-        "traits": [],
-        "removeAfterCombat": true,
+        "traits": [
+          "aura"
+        ],
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -135,7 +121,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Your skill at manipulating your own Aura allows you to create an indistinct haze about yourself.</p><p>You gain the @UUID[Compendium.ptr2e.core-perks.Item.UmbmjzRANft3PAxG.Actions.aura-haze]{Aura Haze} Action which you can use as a Simple Action, spending 2PP, to gain @UUID[Compendium.ptr2e.core-effects.OUBNweJOMjAEtAye]{+1 Evasion Stage}.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -145,12 +131,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "1.0.0.beta-ready.2",
+        "systemVersion": "1.4.1.beta",
         "createdTime": 1736876041388,
-        "modifiedTime": 1739044383852,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS",
+        "modifiedTime": 1754302549761,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV",
         "exportSource": null
       }
     }

--- a/packs/core-perks/aura-projection.json
+++ b/packs/core-perks/aura-projection.json
@@ -18,32 +18,33 @@
         "slug": "aura-projection",
         "description": "<p>You are able to outwardly transmit surface thoughts and feelings through Aura.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
-        "traits": [],
-        "img": "icons/svg/explosion.svg",
+        "traits": [
+          "aura"
+        ],
+        "img": "systems/ptr2e/img/perk-icons/Aura.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "aura-projection",
-    "traits": [],
+    "traits": [
+      "aura"
+    ],
     "_migration": {
       "version": null,
       "previous": null
     },
     "nodes": [
       {
+        "x": 176,
+        "y": 27,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "aura-user",
           "aura-bonding",
@@ -51,25 +52,15 @@
           "shielding-aura"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#c9b5de",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
-          "tint": "#735393",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 176,
-        "y": 27,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {

--- a/packs/core-perks/aura-user.json
+++ b/packs/core-perks/aura-user.json
@@ -11,27 +11,22 @@
       }
     ],
     "cost": 1,
-    "description": "<p>You gain [Aura User].</p>",
+    "description": "<p>You gain the @Trait[aura-user] Trait.</p>",
     "actions": [
       {
         "name": "Aura User",
         "slug": "aura-user",
         "description": "<p>You gain [Aura User].</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "aura-user",
@@ -55,13 +50,10 @@
           "out-of-options"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#bcf0d8",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
-          "tint": "#18af68",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
         "tier": null
       }
@@ -82,10 +74,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "_id": "ft8sIBRLOGVjp70g",
   "img": "systems/ptr2e/img/perk-icons/Aura.svg",
@@ -94,24 +83,26 @@
       "name": "Aura User",
       "type": "passive",
       "_id": "dh14MmRV6bMSra3a",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Aura.svg",
       "system": {
         "changes": [
           {
             "type": "add-trait",
             "key": "",
-            "value": "Aura User",
+            "value": "aura-user",
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -123,7 +114,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>You gain the @Trait[aura-user] Trait.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -133,12 +124,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.4.1",
+        "systemVersion": "1.4.1.beta",
         "createdTime": 1732233165457,
-        "modifiedTime": 1732233176195,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS",
+        "modifiedTime": 1754301993588,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV",
         "exportSource": null
       }
     }

--- a/packs/core-perks/belt-expansion-1.json
+++ b/packs/core-perks/belt-expansion-1.json
@@ -5,29 +5,8 @@
   "system": {
     "prerequisites": [],
     "cost": 1,
-    "description": "<p>Add an additional Belt slot.</p>",
-    "actions": [
-      {
-        "name": "Belt Expansion 1",
-        "slug": "belt-expansion-1",
-        "description": "<p>Add an additional Belt slot.</p>",
-        "cost": {
-          "activation": "free",
-          "powerPoints": 0
-        },
-        "type": "passive",
-        "traits": [],
-        "img": "icons/svg/explosion.svg",
-        "range": {
-          "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false,
-        "hidden": false
-      }
-    ],
+    "description": "<p>Gain an additional Belt slot.</p>",
+    "actions": [],
     "slug": "belt-expansion-1",
     "traits": [],
     "_migration": {
@@ -54,13 +33,10 @@
           "uuid": null
         },
         "config": {
-          "alpha": null,
-          "backgroundColor": "#004080",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Tactician.svg",
-          "tint": null,
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         }
       },
       {
@@ -74,13 +50,10 @@
           "uuid": "Compendium.ptr2e.core-perks.Item.sJ1B6djHXWc4F5Ez"
         },
         "config": {
-          "alpha": null,
+          "texture": null,
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": null,
-          "tint": null,
-          "scale": null
+          "tint": null
         }
       },
       {
@@ -94,13 +67,10 @@
           "uuid": "Compendium.ptr2e.core-perks.Item.wWAAPsxfOC8nGPGm"
         },
         "config": {
-          "alpha": null,
+          "texture": null,
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "texture": null,
-          "tint": null,
-          "scale": null
+          "tint": null
         }
       }
     ],
@@ -118,8 +88,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null
+    }
   },
   "_id": "zAKTLdBrA5eeGCsX",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
@@ -128,7 +97,7 @@
       "name": "Belt Expansion",
       "type": "passive",
       "_id": "lVg2p1y5m9hhxAjN",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
       "system": {
         "changes": [
           {
@@ -143,9 +112,11 @@
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -157,7 +128,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>Gain an additional Belt slot.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -167,12 +138,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.2.1",
+        "systemVersion": "1.4.1.beta",
         "createdTime": 1737934804061,
-        "modifiedTime": 1737934814111,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1754299607462,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV",
         "exportSource": null
       }
     }

--- a/packs/core-perks/channeling-spirit.json
+++ b/packs/core-perks/channeling-spirit.json
@@ -38,30 +38,31 @@
       }
     ],
     "cost": 2,
-    "description": "<p>You have practiced the technique known as Channeling, and may use it to communicate with the spirits of the dead. You also gain +10 on Aura Sense skill checks pertaining to [Ghost][Pokemon].</p><p>(Should be relocated out of the Aura web, and moved nearby the other Occult stuff)</p>",
+    "description": "<p>You have practiced the technique known as Channeling, and may use it to communicate with the spirits of the dead. You also gain +10 on Aura Sense skill checks pertaining to @Trait[ghost] Creatures.</p>",
     "actions": [
       {
         "name": "Channeling Spirit",
-        "slug": "aura-channeling",
-        "description": "<p>Effect: You have become versed in the art of Channeling, whether through refining aura control, spiritual enlightenment, or being a general occult nut. You gain the [Medium] Trait and gain a +10 toward interactions with [Ghost] creatures.</p>",
+        "slug": "channeling-spirit",
+        "description": "<p>You have practiced the technique known as Channeling, and may use it to communicate with the spirits of the dead. You also gain +10 on Aura Sense skill checks pertaining to @Trait[ghost] Creatures.</p>",
         "cost": {
           "activation": "complex",
           "powerPoints": 3
         },
         "type": "exploration",
-        "traits": [],
+        "traits": [
+          "aura"
+        ],
         "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "channeling-spirit",
-    "traits": [],
+    "traits": [
+      "aura"
+    ],
     "_migration": {
       "version": 0.111,
       "previous": {
@@ -94,7 +95,7 @@
     "design": {
       "arena": "mental",
       "approach": "finesse",
-      "archetype": "occultism"
+      "archetype": "aura"
     },
     "publication": {
       "source": "PTR 2e Core",
@@ -102,18 +103,15 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
-  "img": "systems/ptr2e/img/perk-icons/Occultism.svg",
+  "img": "systems/ptr2e/img/perk-icons/Aura.svg",
   "effects": [
     {
       "name": "Channeling Spirit",
       "type": "passive",
       "_id": "2LNe30UmesAzva9h",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Aura.svg",
       "system": {
         "changes": [
           {
@@ -124,26 +122,19 @@
               "Manual"
             ],
             "label": "Ghost Pokemon?",
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false,
             "hideIfDisabled": false
-          },
-          {
-            "type": "add-trait",
-            "key": "",
-            "value": "medium",
-            "predicate": [],
-            "mode": 2,
-            "priority": null,
-            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -165,12 +156,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "1.2.1.beta",
+        "systemVersion": "1.4.1.beta",
         "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
+        "modifiedTime": 1754303758777,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV",
         "exportSource": null
       }
     }

--- a/packs/core-perks/chi-alignment.json
+++ b/packs/core-perks/chi-alignment.json
@@ -3,7 +3,74 @@
   "_id": "KUdOYcLgZDGRZq5F",
   "type": "perk",
   "img": "icons/skills/trades/academics-astronomy-navigation-purple.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Chi Alignment",
+      "type": "passive",
+      "_id": "muVuiDwHZPcoluJN",
+      "img": "icons/skills/trades/academics-astronomy-navigation-purple.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.B5u8TLbX10kgSB9d",
+            "predicate": [],
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [
+          "aura"
+        ],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>@Trait[connection]: @UUID[Compendium.ptr2e.core-moves.B5u8TLbX10kgSB9d]{Foresight}<br /><br />The user may activate the @UUID[Compendium.ptr2e.core-moves.B5u8TLbX10kgSB9d]{Foresight} move as a free action.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.1.beta",
+        "createdTime": 1754302181925,
+        "modifiedTime": 1754302233754,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -16,9 +83,27 @@
       ],
       "notes": ""
     },
-    "actions": [],
-    "slug": null,
-    "description": "<p>Connection: Foresight<br><br>The user may activate the @UUID[Compendium.ptr2e.core-moves.B5u8TLbX10kgSB9d]{Foresight} move as a free action.</p>",
+    "actions": [
+      {
+        "name": "Chi Alignment",
+        "slug": "chi-alignment",
+        "description": "<p>The user may activate the @UUID[Compendium.ptr2e.core-moves.B5u8TLbX10kgSB9d]{Foresight} move as a free action.</p>",
+        "traits": [
+          "aura"
+        ],
+        "type": "passive",
+        "img": "icons/skills/trades/academics-astronomy-navigation-purple.webp",
+        "cost": {
+          "activation": "free"
+        },
+        "range": {
+          "target": "self",
+          "unit": "m"
+        }
+      }
+    ],
+    "slug": "chi-alignment",
+    "description": "<p>@Trait[connection]: @UUID[Compendium.ptr2e.core-moves.B5u8TLbX10kgSB9d]{Foresight}<br><br>The user may activate the @UUID[Compendium.ptr2e.core-moves.B5u8TLbX10kgSB9d]{Foresight} move as a free action.</p>",
     "traits": [
       "aura"
     ],
@@ -32,26 +117,29 @@
     ],
     "autoUnlock": [],
     "cost": 2,
-    "originSlug": null,
     "design": {
       "arena": "physical",
       "approach": "finesse",
       "archetype": "aura"
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [
       {
         "x": 170,
         "y": 25,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "sight-beyond-sight",
           "aura-haze"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ]

--- a/packs/core-perks/dress-to-impress.json
+++ b/packs/core-perks/dress-to-impress.json
@@ -7,7 +7,7 @@
       "previous": null
     },
     "actions": [],
-    "description": "<p>You gain an additional [Accessory] slot. You may not equip more than one instance of the same [Accessory].</p>",
+    "description": "<p>You gain an additional Accessory slot. You may not equip more than one instance of the same Accessory.</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 3,
@@ -47,10 +47,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "img": "systems/ptr2e/img/icons/equipment_icon.webp",
   "effects": [
@@ -58,7 +55,7 @@
       "name": "Dress To Impress",
       "type": "passive",
       "_id": "6vToOC0fhANYGmEB",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/icons/equipment_icon.webp",
       "system": {
         "changes": [
           {
@@ -73,9 +70,11 @@
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -87,7 +86,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>You gain an additional Accessory slot. You may not equip more than one instance of the same Accessory.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -97,12 +96,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.2.1",
+        "systemVersion": "1.4.1.beta",
         "createdTime": 1737934863150,
-        "modifiedTime": 1737934882767,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1754299515151,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV",
         "exportSource": null
       }
     }

--- a/packs/core-perks/dual-wielder.json
+++ b/packs/core-perks/dual-wielder.json
@@ -7,28 +7,7 @@
     ],
     "cost": 4,
     "description": "<p>Gain a second Held Item slot.</p>",
-    "actions": [
-      {
-        "name": "Dual Wielder",
-        "slug": "dual-wielder",
-        "description": "<p>Gain a second Wielded Item Slot.</p>",
-        "cost": {
-          "activation": "free",
-          "powerPoints": 0
-        },
-        "type": "passive",
-        "traits": [],
-        "img": "icons/svg/explosion.svg",
-        "range": {
-          "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false,
-        "hidden": false
-      }
-    ],
+    "actions": [],
     "slug": "dual-wielder",
     "traits": [],
     "_migration": {
@@ -74,10 +53,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "_id": "QioUEl6UBFclZvzG",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
@@ -86,7 +62,7 @@
       "name": "Dual Wielder",
       "type": "passive",
       "_id": "KS2tYC5yodOQrCN2",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
       "system": {
         "changes": [
           {
@@ -101,9 +77,11 @@
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -125,11 +103,11 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.5",
+        "systemVersion": "1.4.1.beta",
         "createdTime": 1737566059443,
-        "modifiedTime": 1737566090456,
+        "modifiedTime": 1754299623416,
         "lastModifiedBy": "tXAZ3QUgjuwX4gdV",
         "exportSource": null
       }

--- a/packs/core-perks/edgerunner.json
+++ b/packs/core-perks/edgerunner.json
@@ -7,7 +7,7 @@
   "system": {
     "actions": [],
     "slug": "edgerunner",
-    "description": "<p>Your non-struggle moves gain a 1% Power increase per 4% of your Max PP that has been spent prior to the declaration of the move.</p>",
+    "description": "<p>For each 4% of Max PP you are missing, your non-@UUID[Compendium.ptr2e.core-moves.struggleattaitem]{Struggle} Attacks gain 1% Power.</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 2,
@@ -17,22 +17,19 @@
     },
     "nodes": [
       {
+        "x": 182,
+        "y": 40,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "out-of-options"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#000000",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
-          "tint": "#ff0000",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 182,
-        "y": 40,
         "tier": null
       }
     ],
@@ -50,10 +47,64 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Edgerunner",
+      "type": "passive",
+      "_id": "His0ifeBGm1t2IbQ",
+      "img": "systems/ptr2e/img/perk-icons/Aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "attack-power",
+            "value": "floor((100-@actor.system.powerPoints.percent)/4)",
+            "predicate": [
+              {
+                "nor": [
+                  "attack:slug:struggle",
+                  "attack:original:struggle"
+                ]
+              }
+            ],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": true
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>For each 4% of Max PP you are missing, your non-@UUID[Compendium.ptr2e.core-moves.struggleattaitem]{Struggle} Attacks gain 1% Power.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.1.beta",
+        "createdTime": 1754300144759,
+        "modifiedTime": 1754301768971,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/needle-threader.json
+++ b/packs/core-perks/needle-threader.json
@@ -3,7 +3,66 @@
   "_id": "r75WWb1fvsp00BrC",
   "type": "perk",
   "img": "icons/skills/targeting/crosshair-ringed-gray.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Needle-Threader",
+      "type": "passive",
+      "_id": "nxp3QMMdMDQfjEym",
+      "img": "icons/skills/targeting/crosshair-ringed-gray.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.JvEQgZGAANjyXwaM",
+            "predicate": [],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>The user gains @UUID[Compendium.ptr2e.core-abilities.JvEQgZGAANjyXwaM]{Deadeye} as a Tutored Ability.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.5WFNYRPn6z0GBL6C.ActiveEffect.sXXvbSqpJbsSDwZf",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.1.beta",
+        "createdTime": 1754299218782,
+        "modifiedTime": 1754299267303,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -17,8 +76,8 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
-    "description": "<p>The user gains Deadeye as a Tutored Ability.</p>",
+    "slug": "needle-threader",
+    "description": "<p>The user gains @UUID[Compendium.ptr2e.core-abilities.JvEQgZGAANjyXwaM]{Deadeye} as a Tutored Ability.</p>",
     "traits": [],
     "prerequisites": [
       "trait:wielder",
@@ -29,29 +88,34 @@
         ]
       }
     ],
-    "autoUnlock": [],
+    "autoUnlock": [
+      "item:ability:deadeye"
+    ],
     "cost": 3,
-    "originSlug": null,
     "design": {
       "arena": "physical",
       "approach": "finesse",
       "archetype": null
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [
       {
         "x": 183,
         "y": 61,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "trained-wielder",
           "yeomanry",
           "down-the-sights"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ]

--- a/packs/core-perks/nock-shot.json
+++ b/packs/core-perks/nock-shot.json
@@ -3,7 +3,66 @@
   "_id": "5WFNYRPn6z0GBL6C",
   "type": "perk",
   "img": "icons/weapons/ammunition/arrows-barbed-white.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Nock & Shot",
+      "type": "passive",
+      "_id": "sXXvbSqpJbsSDwZf",
+      "img": "icons/weapons/ammunition/arrows-barbed-white.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-abilities.Item.qgENOMqdeuKBs47a",
+            "predicate": [],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.qgENOMqdeuKBs47a]{Ballistic} as a Tutored Ability.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1754224199355,
+        "modifiedTime": 1754224350157,
+        "lastModifiedBy": "dCIq77b7AO2frs8Z"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -17,35 +76,40 @@
       "notes": ""
     },
     "actions": [],
-    "slug": null,
-    "description": "<p>Effect: The user gains Ballistic as a Tutored Ability.</p>",
+    "slug": "nock-shot",
+    "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.qgENOMqdeuKBs47a]{Ballistic} as a Tutored Ability.</p>",
     "traits": [],
     "prerequisites": [
       "trait:humanoid",
       "item:perk:dual-wielder"
     ],
-    "autoUnlock": [],
+    "autoUnlock": [
+      "item:ability:ballistic"
+    ],
     "cost": 3,
-    "originSlug": null,
     "design": {
       "arena": "physical",
       "approach": "finesse",
       "archetype": null
     },
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "nodes": [
       {
         "x": 192,
         "y": 63,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "dual-wielder",
           "harry"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ]

--- a/packs/core-perks/out-of-options.json
+++ b/packs/core-perks/out-of-options.json
@@ -38,9 +38,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -56,5 +53,62 @@
       "notes": ""
     }
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Out Of Options",
+      "type": "passive",
+      "_id": "mJCsLmVEMZClDEgD",
+      "img": "systems/ptr2e/img/perk-icons/Taskmaster.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "struggle-attack-power-flat",
+            "value": 20,
+            "predicate": [
+              {
+                "lte": [
+                  "{actor|system.powerPoints.percent}",
+                  10
+                ]
+              }
+            ],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "<p>Effect: When the user has 10% or less of their PP remaining, their Struggle Attacks gain +20 Power.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.346",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.1.beta",
+        "createdTime": 1754299744190,
+        "modifiedTime": 1754299990729,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/shielding-aura.json
+++ b/packs/core-perks/shielding-aura.json
@@ -11,68 +11,52 @@
       }
     ],
     "cost": 3,
-    "description": "<p>You harden your Aura about yourself. You gain @Affliction[resolved] 5.</p>",
+    "description": "<p>You gain the ability to harden your Aura around yourself.</p><p>You gain the @UUID[Compendium.ptr2e.core-perks.Item.D4mh3LuuSy0DDBj0.Actions.shielding-aura]{Shielding Aura} Action which you can use as a Complex Action, spending 4PP, to gain @Affliction[resolved 5].</p>",
     "actions": [
       {
         "name": "Shielding Aura",
         "slug": "shielding-aura",
-        "description": "<p>You harden your Aura about yourself. You gain @Affliction[resolved] 5.</p>",
+        "description": "<p>You gain @Affliction[resolved 5].</p>",
         "cost": {
           "activation": "complex",
           "powerPoints": 4
         },
-        "type": "attack",
-        "traits": [],
+        "type": "generic",
+        "traits": [
+          "aura"
+        ],
         "img": "systems/ptr2e/img/perk-icons/Aura.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "types": [
-          "untyped"
-        ],
-        "category": "status",
-        "free": true,
-        "predicate": [],
-        "variant": null,
-        "ephemeralVariant": false,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": "",
-        "offensiveStat": null,
-        "defensiveStat": null
+          "unit": "m"
+        }
       }
     ],
     "slug": "shielding-aura",
-    "traits": [],
+    "traits": [
+      "aura"
+    ],
     "_migration": {
       "version": null,
       "previous": null
     },
     "nodes": [
       {
+        "x": 176,
+        "y": 23,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "aura-dampening",
           "aura-haze",
           "aura-projection"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#8000ff",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
-          "tint": "#ffffff",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 176,
-        "y": 23,
         "tier": null
       }
     ],
@@ -90,10 +74,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "_id": "D4mh3LuuSy0DDBj0",
   "img": "systems/ptr2e/img/perk-icons/Aura.svg",
@@ -102,15 +83,15 @@
       "name": "Shielding Aura",
       "type": "passive",
       "_id": "ic5iLopjjgfGT61E",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Aura.svg",
       "system": {
         "changes": [
           {
             "type": "roll-effect",
-            "key": "shielding-aura-attack",
+            "key": "shielding-aura-generic",
             "value": "Compendium.ptr2e.core-effects.Item.resolvedconditem",
             "predicate": [],
-            "chance": 10,
+            "chance": 100,
             "affects": "self",
             "alterations": [
               {
@@ -119,17 +100,22 @@
                 "value": 5
               }
             ],
-            "mode": 2,
             "priority": null,
-            "ignored": false,
-            "dontMerge": false
+            "dontMerge": false,
+            "isFixedChance": false,
+            "mode": 2,
+            "ignored": false
           }
         ],
         "slug": null,
-        "traits": [],
-        "removeAfterCombat": true,
+        "traits": [
+          "aura"
+        ],
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -141,7 +127,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>You gain the ability to harden your Aura around yourself.</p><p>You gain the @UUID[Compendium.ptr2e.core-perks.Item.D4mh3LuuSy0DDBj0.Actions.shielding-aura]{Shielding Aura} Action which you can use as a Complex Action, spending 4PP, to gain @Affliction[resolved 5].</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -151,12 +137,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.2.1",
+        "systemVersion": "1.4.1.beta",
         "createdTime": 1737934380177,
-        "modifiedTime": 1737934406711,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1754302744125,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV",
         "exportSource": null
       }
     }

--- a/packs/core-perks/shift-consciousness.json
+++ b/packs/core-perks/shift-consciousness.json
@@ -1,0 +1,82 @@
+{
+  "name": "Shift Consciousness",
+  "type": "perk",
+  "system": {
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.aura-sense.mod}",
+          45
+        ]
+      }
+    ],
+    "cost": 4,
+    "description": "<p>You shift your consciousness into a consenting Creature.</p><p>Your body enters a helpless, catatonic state during this time and you instead control the host body, utilising it's skills and traits, with the addition of retained access to your @Trait[aura] perks. You can end this effect at any time using a Complex Action.</p><p>If the host is @Affliction[fainted] while your consciousness is present, your own body also gains a stack of @Affliction[weary]. If the user dies while shifted, this would typically sever the connection. GMs may wish to consider instead making the shift permanent.</p>",
+    "actions": [
+      {
+        "name": "Shift Consciousness",
+        "slug": "shift-consciousness",
+        "description": "<p>You shift your consciousness into a consenting Creature.</p><p>Your body enters a helpless, catatonic state during this time and you instead control the host body, utilising it's skills and traits, with the addition of retained access to your @Trait[aura] perks. You can end this effect at any time using a Complex Action.</p><p>If the host is @Affliction[fainted] while your consciousness is present, your own body also gains a stack of @Affliction[weary]. If the user dies while shifted, this would typically sever the connection. GMs may wish to consider instead making the shift permanent.</p>",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 5
+        },
+        "type": "exploration",
+        "traits": [
+          "aura"
+        ],
+        "img": "systems/ptr2e/img/perk-icons/Aura.svg",
+        "range": {
+          "target": "creature",
+          "unit": "m"
+        }
+      }
+    ],
+    "slug": "shift-consciousness",
+    "traits": [
+      "aura"
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
+    },
+    "nodes": [
+      {
+        "x": 182,
+        "y": 27,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "aura-dampening",
+          "aura-bonding"
+        ],
+        "config": {
+          "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ],
+    "autoUnlock": [],
+    "global": true,
+    "webs": [],
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "aura"
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    }
+  },
+  "_id": "zwEYbTMfJb44gxKC",
+  "img": "systems/ptr2e/img/perk-icons/Aura.svg",
+  "effects": [],
+  "folder": "I7ocNlZvZjyhwUcw"
+}

--- a/packs/core-perks/sight-beyond-sight.json
+++ b/packs/core-perks/sight-beyond-sight.json
@@ -12,29 +12,22 @@
       }
     ],
     "cost": 3,
-    "description": "<p>You are able to tap into your Aura powers to see without the use of your eyes. You gain the [Blindsense 10] trait.</p>",
+    "description": "<p>You are able to tap into your Aura powers to see without the use of your eyes. You gain the @Trait[blindsense-10] Trait.</p>",
     "actions": [
       {
         "name": "Sight Beyond Sight",
         "slug": "sight-beyond-sight",
-        "description": "<p>You are able to tap into your Aura powers to see without the use of your eyes. You gain the [Blindsense 10] trait.</p>",
+        "description": "<p>You are able to tap into your Aura powers to see without the use of your eyes. You gain the @Trait[blindsense-10] Trait.</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/perk-icons/Aura.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "sight-beyond-sight",
@@ -49,32 +42,26 @@
     },
     "nodes": [
       {
+        "x": 170,
+        "y": 27,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "aura-user",
           "chi-alignment"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#ffffff",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
-          "tint": "#8000ff",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 170,
-        "y": 27,
         "tier": null
       }
     ],
     "autoUnlock": [
       "trait:blindsense-10"
     ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -97,24 +84,26 @@
       "name": "Sight Beyond Sight",
       "type": "passive",
       "_id": "qrYlisqKU7CyEgKk",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/perk-icons/Aura.svg",
       "system": {
         "changes": [
           {
             "type": "add-trait",
             "key": "",
-            "value": "Blindsense 10",
+            "value": "blindsense-10",
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
-        "removeAfterCombat": true,
+        "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -126,7 +115,7 @@
         "startRound": null,
         "startTurn": null
       },
-      "description": "",
+      "description": "<p>You are able to tap into your Aura powers to see without the use of your eyes. You gain the @Trait[blindsense-10] Trait.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -136,12 +125,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.346",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.4.1",
+        "systemVersion": "1.4.1.beta",
         "createdTime": 1732233195168,
-        "modifiedTime": 1732233207504,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS",
+        "modifiedTime": 1754302094005,
+        "lastModifiedBy": "tXAZ3QUgjuwX4gdV",
         "exportSource": null
       }
     }

--- a/packs/core-perks/soothing-aura.json
+++ b/packs/core-perks/soothing-aura.json
@@ -12,28 +12,25 @@
       "item:perk:aura-bonding"
     ],
     "cost": 3,
-    "description": "<p>You may make a Hard (-20) Aura Sense check to try and assuage the aura of a hostile target and calm it, rendering it non-hostile unless provoked. Please note, this will not function on opponents who are hostile through cold indifference rather than anger or pain.</p>",
+    "description": "<p>You may make a Hard (-20) Aura Sense check to try and assuage the aura of a hostile target and calm it, rendering it non-hostile unless provoked.</p><blockquote><p>Please note, this will not function on opponents who are hostile through cold indifference rather than anger or pain.</p></blockquote>",
     "actions": [
       {
         "name": "Soothing Aura",
         "slug": "soothing-aura",
-        "description": "<p>You may make a Hard (-20) Aura Sense check to try and assuage the aura of a hostile target and calm it, rendering it non-hostile unless provoked. Please note, this will not function on opponents who are hostile through cold indifference rather than anger or pain.</p>",
+        "description": "<p>You may make a Hard (-20) Aura Sense check to try and assuage the aura of a hostile target and calm it, rendering it non-hostile unless provoked.</p><blockquote><p>Please note, this will not function on opponents who are hostile through cold indifference rather than anger or pain.</p></blockquote>",
         "cost": {
           "activation": "complex",
-          "powerPoints": 5,
-          "delay": null,
-          "priority": null
+          "powerPoints": 2
         },
         "type": "generic",
-        "traits": [],
-        "img": "icons/svg/explosion.svg",
+        "traits": [
+          "aura"
+        ],
+        "img": "systems/ptr2e/img/perk-icons/Aura.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "soothing-aura",
@@ -44,29 +41,23 @@
     },
     "nodes": [
       {
+        "x": 179,
+        "y": 32,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "aura-bonding"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#008000",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
-          "tint": "#151515",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 179,
-        "y": 32,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {


### PR DESCRIPTION
Primarily Aura perks, also has some small erratas.
- Update Perk: Nock & Shot
- Update Perk: Needle-Threader
- Update Perk: Dress To Impress
- Update Perk: Belt Expansion 1
- Update Perk: Dual Wielder
- Update Perk: Out Of Options
- Update Perk: Edgerunner
- Update Perk: Aura User
- Update Perk: Sight Beyond Sight
- Update Perk: Chi Alignment
- Update Perk: Aura Haze
- Update Perk: Shielding Aura
- Update Perk: Aura Dampening
- Update Perk: Aura Projection
- Update Perk: Shift Consciousness
- Update Perk: Channeling Spirit
- Update Perk: Soothing Aura