### PR TITLE
Foundry Data Sync - Max Potion Automation, Mind Games Move Automation, Type Embodiment Fix

### DIFF
--- a/packs/core-gear/max-potion.json
+++ b/packs/core-gear/max-potion.json
@@ -53,9 +53,94 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "actions": [
+      {
+        "name": "Max Potion Action",
+        "slug": "max-potion",
+        "description": "<p>The target is healed by @Tick[16].</p>",
+        "traits": [
+          "stack-3",
+          "combat",
+          "held",
+          "restorative",
+          "consumable",
+          "healing"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/item-icons/max potion.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "KGi1w0yNFhoyvdpE",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Max Potion",
+      "type": "passive",
+      "_id": "DoM6uayXLIz1GOqL",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "max-potion-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.4DlXFTVooz07YcDm",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.value",
+                "value": 16
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.347",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1755354545421,
+        "modifiedTime": 1755354579716,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "srQci2ThhRKdmC6g"
 }

--- a/packs/core-moves/mind-games.json
+++ b/packs/core-moves/mind-games.json
@@ -4,13 +4,13 @@
   "_id": "K3uox37rgUbs2xwq",
   "img": "systems/ptr2e/img/svg/psychic_icon.svg",
   "system": {
-    "slug": null,
+    "slug": "mind-games",
     "actions": [
       {
         "name": "Mind Games",
         "slug": "mind-games",
         "type": "attack",
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/psychic_icon.svg",
         "traits": [
           "social"
         ],
@@ -24,22 +24,94 @@
           "powerPoints": 6
         },
         "types": [
-          "untyped"
+          "psychic"
         ],
         "category": "special",
         "accuracy": 100,
-        "description": "<p>Effect: All valid targets lose -1 SPATK Stages for 5 Activations,  and user gains +1 SPDEF Stage for 5 Activations.</p>",
+        "description": "<p>Effect: All valid targets lose -1 SPATK Stages for 5 Activations, and user gains +1 SPDEF Stage for 5 Activations.</p>",
         "predicate": []
       }
     ],
-    "container": null,
     "grade": "A",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Mind Games",
+      "type": "passive",
+      "_id": "rkHy8WKP8xuKfFXu",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "mind-games-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.1JXumQz0QqthT9Iv",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "mind-games-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.jEX7s3GbbAtzgyS3",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.347",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.2.beta",
+        "createdTime": 1755354657520,
+        "modifiedTime": 1755354711757,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/type-embodiment-type-2.json
+++ b/packs/core-perks/type-embodiment-type-2.json
@@ -12,20 +12,15 @@
         "slug": "type-embodiment-type-2",
         "description": "<p>You gain a &lt;Type&gt; trait, from the baseline 18 &lt;Type&gt;s (at default).</p><p>Additionally, you may instantly add 2 E-Grade moves from that &lt;Type&gt;'s Tutor List to your 'Known Attacks' list.</p><blockquote>A recommended limit on &lt;Type&gt; traits is 3 total, but this can be revised at GM discretion. May replace an existing &lt;Type&gt;.</blockquote>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
-        "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "ephemeralVariant": false,
-        "hidden": false
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "slug": "type-embodiment-type-2",
@@ -73,10 +68,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "_id": "Ele0eTIzN2GUFQD7",
   "img": "systems/ptr2e/img/perk-icons/Touched.svg",
@@ -191,8 +183,16 @@
             "key": "system.type.types",
             "value": "{effect|flags.ptr2e.choiceSelections.te-add}",
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "remove-trait",
+            "key": "",
+            "value": "untyped",
+            "predicate": [],
+            "mode": 2,
             "ignored": false
           }
         ],
@@ -200,7 +200,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -222,12 +224,12 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-perks.Item.3hmeZeafNkHeCKvi.ActiveEffect.GE0TilBXs6WMXRph",
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.347",
         "systemId": "ptr2e",
-        "systemVersion": "1.0.3.beta",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1739730444929,
-        "modifiedTime": 1739730444929,
-        "lastModifiedBy": "tXAZ3QUgjuwX4gdV",
+        "modifiedTime": 1755359333133,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf",
         "exportSource": null
       }
     }

--- a/packs/core-perks/type-embodiment-type.json
+++ b/packs/core-perks/type-embodiment-type.json
@@ -12,20 +12,15 @@
         "slug": "type-embodiment-type",
         "description": "<p>You gain a &lt;Type&gt; trait, from the baseline 18 &lt;Type&gt;s (at default).</p><p>Additionally, you may instantly add 2 E-Grade moves from that &lt;Type&gt;'s Tutor List to your 'Known Attacks' list.</p><blockquote>A recommended limit on &lt;Type&gt; traits is 3 total, but this can be revised at GM discretion. May replace an existing &lt;Type&gt;.</blockquote>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false,
-        "hidden": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "type-embodiment-type",
@@ -101,8 +96,7 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null
+    }
   },
   "_id": "3hmeZeafNkHeCKvi",
   "img": "systems/ptr2e/img/perk-icons/Touched.svg",
@@ -217,8 +211,16 @@
             "key": "system.type.types",
             "value": "{effect|flags.ptr2e.choiceSelections.te-add}",
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "remove-trait",
+            "key": "",
+            "value": "untyped",
+            "predicate": [],
+            "mode": 2,
             "ignored": false
           }
         ],
@@ -226,7 +228,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -248,12 +252,12 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-perks.Item.3hmeZeafNkHeCKvi.ActiveEffect.GE0TilBXs6WMXRph",
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.347",
         "systemId": "ptr2e",
-        "systemVersion": "1.0.3.beta",
+        "systemVersion": "1.4.2.beta",
         "createdTime": 1739729859793,
-        "modifiedTime": 1739730392053,
-        "lastModifiedBy": "tXAZ3QUgjuwX4gdV",
+        "modifiedTime": 1755359312051,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf",
         "exportSource": null
       }
     }


### PR DESCRIPTION
Addresses the perk still displaying Untyped on human actors.
- Update Consumable: Max Potion
- Update Move: Mind Games
- Update Perk: Type Embodiment <Type>
- Update Perk: Type Embodiment <Type> 2