### PR TITLE
Foundry Data Sync - wand of quarts didnt give the move

### DIFF
--- a/packs/core-gear/wand-of-quartz.json
+++ b/packs/core-gear/wand-of-quartz.json
@@ -4,8 +4,12 @@
   "type": "weapon",
   "system": {
     "_migration": {
-      "version": 0.11,
-      "previous": null
+      "version": 0.111,
+      "previous": {
+        "schema": 0.11,
+        "foundry": "13.347",
+        "system": "1.4.3.beta"
+      }
     },
     "traits": [
       "fantasy",
@@ -48,7 +52,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -69,7 +74,7 @@
               {
                 "mode": 5,
                 "property": "system.actions.0.free",
-                "value": 0
+                "value": "true"
               },
               {
                 "mode": 2,
@@ -77,25 +82,27 @@
                 "value": "weapon"
               }
             ],
-            "mode": 2,
             "priority": null,
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "mode": 2,
             "ignored": false,
             "reevaluateOnUpdate": false,
             "inMemoryOnly": false,
             "allowDuplicate": true,
             "track": false,
-            "replaceSelf": false,
-            "onDeleteActions": {
-              "grantee": "detach",
-              "granter": "cascade"
-            }
+            "replaceSelf": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -113,16 +120,20 @@
       "transfer": true,
       "statuses": [],
       "sort": 0,
-      "flags": {},
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "exportSource": null,
+        "coreVersion": "13.347",
         "systemId": "ptr2e",
-        "systemVersion": "1.0.0.beta-ready.2",
-        "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
+        "systemVersion": "1.4.3.beta",
+        "lastModifiedBy": "XNKN3zSF1KgrBp5u",
+        "modifiedTime": 1755850836126
       }
     }
   ],


### PR DESCRIPTION
old version never gave the move, adjusted it to auto add the move
- Create Weapon: Wand of Quartz