### PR TITLE
Foundry Data Sync - Psychic Move Automation Fix AGAIN

### DIFF
--- a/packs/core-moves/psychic.json
+++ b/packs/core-moves/psychic.json
@@ -6,7 +6,7 @@
     "slug": "psychic-attack",
     "actions": [
       {
-        "slug": "psychic",
+        "slug": "psychic-attack",
         "name": "Psychic",
         "type": "attack",
         "traits": [
@@ -98,7 +98,11 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "exportSource": null
+        "exportSource": null,
+        "coreVersion": "13.347",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.3.beta",
+        "lastModifiedBy": null
       }
     }
   ]


### PR DESCRIPTION
I have literally no idea how this fucking thing defaulted it's slug yet again.
- Update Move: Psychic