### PR TITLE
Foundry Data Sync - Gear Review - Batch 5

### DIFF
--- a/packs/core-gear/air-ball.json
+++ b/packs/core-gear/air-ball.json
@@ -22,18 +22,24 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
-    "rarity": "common",
+    "rarity": "uncommon",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
       "fling",
-      "type-ball"
+      "type-ball",
+      "ball"
     ],
-    "description": "4x Catch Rate modifier if used on a Flying- or Ice-Type creature. 1x Catch Rate modifier otherwise.",
-    "modifier": 4,
+    "description": "<p>3x Catch Rate modifier if used on a Flying- or Ice-Type creature. 1x Catch Rate modifier otherwise.</p>",
+    "modifier": 3,
     "quantity": 1,
     "slug": "air-ball",
     "stack": 5,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "Y1dSMzWwPG9gKM6v",
   "effects": [],

--- a/packs/core-gear/allure-seed.json
+++ b/packs/core-gear/allure-seed.json
@@ -1,11 +1,11 @@
 {
   "name": "Allure Seed",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
   "type": "consumable",
   "system": {
     "cost": 2,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 90,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "other",
@@ -27,13 +32,10 @@
       "combat",
       "consumable",
       "natural",
-      "fling",
       "seed",
-      "held",
-      "stack-3",
-      "fling"
+      "stack-3"
     ],
-    "description": "On hit, the target becomes @Affliction[charmed] 3.",
+    "description": "<p>On hit, the target becomes @Affliction[charmed 3].</p>",
     "quantity": 1,
     "slug": "allure-seed",
     "stack": 1,
@@ -45,10 +47,106 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Allure Seed",
+        "slug": "allure-seed",
+        "description": "<p>On hit, the target becomes @Affliction[charmed 3].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "natural",
+          "seed",
+          "stack-3"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "accuracy": 90
+      }
+    ]
   },
   "_id": "NG21NQ4pLdiBAwYQ",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Allure Seed",
+      "type": "passive",
+      "_id": "jgVmTgV5CS60lNKk",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "allure-seed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.charmedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758758656250,
+        "modifiedTime": 1758758682632,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/ban-seed.json
+++ b/packs/core-gear/ban-seed.json
@@ -1,11 +1,11 @@
 {
   "name": "Ban Seed",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
   "type": "consumable",
   "system": {
     "cost": 3,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 90,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "other",
@@ -27,13 +32,10 @@
       "combat",
       "consumable",
       "natural",
-      "fling",
       "seed",
-      "held",
-      "stack-3",
-      "fling"
+      "stack-3"
     ],
-    "description": "On hit, the target becomes @Affliction[disabled] 5.",
+    "description": "<p>On hit, the target becomes @Affliction[disabled 5].</p>",
     "quantity": 1,
     "slug": "ban-seed",
     "stack": 1,
@@ -45,10 +47,100 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Ban Seed",
+        "slug": "ban-seed",
+        "description": "<p>On hit, the target becomes @Affliction[disabled 5].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "natural",
+          "seed",
+          "stack-3"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": [],
+        "accuracy": 90
+      }
+    ]
   },
   "_id": "Pt9qUWpZlKGBztlq",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Ban Seed",
+      "type": "passive",
+      "_id": "tW5Qe45vRcCQ1HfE",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "ban-seed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.disabledconditem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758758793858,
+        "modifiedTime": 1758758809829,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/basic-ball.json
+++ b/packs/core-gear/basic-ball.json
@@ -22,14 +22,20 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
     "description": "A basic PokeBall for capturing Pokemon. Gives no bonuses on capture checks.",
     "modifier": 1,
@@ -44,8 +50,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "RmxpPT0msnrx1mv4",
   "effects": [],

--- a/packs/core-gear/beacon-ball.json
+++ b/packs/core-gear/beacon-ball.json
@@ -22,7 +22,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -30,10 +35,11 @@
       "stack-5",
       "belt",
       "fling",
-      "environ-ball"
+      "environ-ball",
+      "ball"
     ],
-    "description": "5x Catch Rate modifier with Foggy Weather present. 2.5x Catch Rate modifier if only natural fog is present. 1x Catch Rate modifier otherwise.",
-    "modifier": 2.5,
+    "description": "<p>3.5x Catch Rate during Foggy Weather. 1x Catch Rate modifier otherwise.</p>",
+    "modifier": 3.5,
     "quantity": 1,
     "slug": "beacon-ball",
     "stack": 5,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "JBPkoTh8GFAL1u3P",
   "effects": [],

--- a/packs/core-gear/beast-ball.json
+++ b/packs/core-gear/beast-ball.json
@@ -19,19 +19,25 @@
     "grade": "A",
     "fling": {
       "type": "untyped",
-      "power": 0,
+      "power": 70,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "rare",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
-    "description": "12x Catch Rate modifer if used on a [Ultra Beast] creature. 1x Catch Rate modifer otherwise.",
-    "modifier": 12,
+    "description": "<p>5x Catch Rate modifer if used on a [Ultra Beast] creature. 1x Catch Rate modifer otherwise.</p>",
+    "modifier": 5,
     "quantity": 1,
     "slug": "beast-ball",
     "stack": 5,
@@ -43,8 +49,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "iEBm80ZVOLR1CiKc",
   "effects": [],

--- a/packs/core-gear/burn-drive.json
+++ b/packs/core-gear/burn-drive.json
@@ -18,7 +18,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "rare",
     "traits": [
@@ -39,7 +44,8 @@
         ],
         "range": {
           "target": "creature",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "cost": {
           "activation": "complex"
@@ -47,7 +53,7 @@
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "Effect: This item does not use an Accessory slot when equipped by a [Genesect].",
+    "description": "<p>Effect: This accessory allows you to either add the @Trait[fire] type to @UUID[Compendium.ptr2e.core-moves.gWjoYU30cvj8Vu4L]{Techno Blast} or replace Techno Blast's existing typing with @Trait[fire]</p>",
     "slug": "burn-drive",
     "quantity": 1,
     "identification": {
@@ -67,7 +73,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "eOrOr2QMZMtWvVYu",

--- a/packs/core-gear/cherish-ball.json
+++ b/packs/core-gear/cherish-ball.json
@@ -4,7 +4,7 @@
   "type": "consumable",
   "system": {
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -13,22 +13,28 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "S",
+    "grade": "A",
     "fling": {
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 8,
+        "unit": "m"
+      }
     },
-    "rarity": "unique",
+    "rarity": "rare",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
-    "description": "A fancy, eye-catching ball given out during promotional events. Gives no bonuses on capture checks.",
-    "modifier": 1,
+    "description": "<p>A fancy, eye-catching ball given out during promotional events. 2x Capture Rate and +25 Critical Capture Chance.</p>",
+    "modifier": 2,
     "quantity": 1,
     "slug": "cherish-ball",
     "stack": 5,
@@ -40,8 +46,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "tTsIjyrNL20afchW",
   "effects": [],

--- a/packs/core-gear/chill-drive.json
+++ b/packs/core-gear/chill-drive.json
@@ -4,7 +4,7 @@
   "type": "equipment",
   "system": {
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -18,7 +18,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "rare",
     "traits": [
@@ -39,7 +44,8 @@
         ],
         "range": {
           "target": "creature",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "cost": {
           "activation": "complex"
@@ -47,7 +53,7 @@
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "Effect: This item does not use an Accessory slot when equipped by a [Genesect].",
+    "description": "<p>Effect: This accessory allows you to either add the @Trait[ice] type to @UUID[Compendium.ptr2e.core-moves.gWjoYU30cvj8Vu4L]{Techno Blast} or replace Techno Blast's existing typing with @Trait[ice]</p>",
     "slug": "chill-drive",
     "quantity": 1,
     "identification": {
@@ -67,7 +73,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "3EeNyrEgiLRBwp4b",

--- a/packs/core-gear/clear-amulet.json
+++ b/packs/core-gear/clear-amulet.json
@@ -16,10 +16,10 @@
     },
     "traits": [
       "combat",
-      "held"
+      "accessory"
     ],
     "actions": [],
-    "description": "<p>Effect: The user is unaffected by negative @Trait[stage-change] effects originating from other creatures.</p>",
+    "description": "<p>Connected Ability: @UUID[Compendium.ptr2e.core-abilities.mPXwSVDLwuQlSIoH]{Clear Body}</p>",
     "crafting": {
       "skill": "",
       "spans": null,
@@ -35,7 +35,12 @@
       "type": "rock",
       "power": 45,
       "accuracy": 90,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "rare",
@@ -52,6 +57,5 @@
   "img": "systems/ptr2e/img/icons/equipment_icon.webp",
   "effects": [],
   "folder": "6VDJBcrqVDh5bYtA",
-  "flags": {},
   "_id": "yhhLPmBzlk5SJWwH"
 }

--- a/packs/core-gear/coolant-ball.json
+++ b/packs/core-gear/coolant-ball.json
@@ -22,19 +22,25 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
-    "rarity": "rare",
+    "rarity": "uncommon",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
       "fling",
       "environ-ball",
-      "type-ball"
+      "type-ball",
+      "ball"
     ],
-    "description": "4x Catch Rate modifier on a Nuclear-Type creature, plus 5x Catch Rate with Glowy Weather present. 1x Catch Rate modifer otherwise.",
-    "modifier": 4,
+    "description": "<p>3.5x Catch Rate modifier on a Nuclear-Type creature or with Glowy Weather present. 1x Catch Rate modifer otherwise.</p>",
+    "modifier": 3.5,
     "quantity": 1,
     "slug": "coolant-ball",
     "stack": 5,
@@ -46,8 +52,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "ilpg3PzmA3HCvVzq",
   "effects": [],

--- a/packs/core-gear/dark-ball.json
+++ b/packs/core-gear/dark-ball.json
@@ -16,22 +16,28 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "A",
+    "grade": "B",
     "fling": {
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "rare",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
-    "description": "8x Catch Rate modifer if used on a [Shadow Pokemon] creature. 1x Catch Rate modifer otherwise.",
-    "modifier": 8,
+    "description": "<p>5x Catch Rate modifer if used on a @Trait[closed-heart] creature. 1x Catch Rate modifer otherwise.</p>",
+    "modifier": 5,
     "quantity": 1,
     "slug": "dark-ball",
     "stack": 5,
@@ -43,8 +49,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "rLHED5VHbPkaEqrw",
   "effects": [],

--- a/packs/core-gear/decoy-seed.json
+++ b/packs/core-gear/decoy-seed.json
@@ -1,11 +1,11 @@
 {
   "name": "Decoy Seed",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
   "type": "consumable",
   "system": {
     "cost": 2,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 90,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "other",
@@ -27,13 +32,10 @@
       "combat",
       "consumable",
       "natural",
-      "fling",
       "seed",
-      "held",
-      "stack-3",
-      "fling"
+      "stack-3"
     ],
-    "description": "On hit, the target gains @Affliction[marked] 5.",
+    "description": "<p>On hit, the target gains @Affliction[marked 5].</p>",
     "quantity": 1,
     "slug": "decoy-seed",
     "stack": 1,
@@ -45,10 +47,99 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Decoy Seed",
+        "slug": "decoy-seed",
+        "description": "<p>On hit, the target gains @Affliction[marked 5].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "natural",
+          "seed",
+          "stack-3"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": []
+      }
+    ]
   },
   "_id": "G0GD0LJiLOiIiq9G",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Decoy Seed",
+      "type": "passive",
+      "_id": "FIzWRnScCHjucMuL",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "decoy-seed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.markedcondititem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758794561848,
+        "modifiedTime": 1758794638396,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/dive-ball.json
+++ b/packs/core-gear/dive-ball.json
@@ -22,7 +22,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -30,10 +35,11 @@
       "stack-5",
       "belt",
       "fling",
-      "training-ball"
+      "training-ball",
+      "ball"
     ],
-    "description": "8x Catch Rate modifer if used on a target that is Swimming. 1x Catch Rate modifer otherwise. This Ball can target creatures 4m underwater from the user.",
-    "modifier": 8,
+    "description": "<p>3.5x Catch Rate modifer if used on a target that is Swimming. 1x Catch Rate modifer otherwise. Water can't provide Cover against Dive Balls.</p>",
+    "modifier": 3.5,
     "quantity": 1,
     "slug": "dive-ball",
     "stack": 5,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "1RAmn9H3LSZCk4X2",
   "effects": [],

--- a/packs/core-gear/doom-seed.json
+++ b/packs/core-gear/doom-seed.json
@@ -5,7 +5,7 @@
   "system": {
     "cost": 5,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 90,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "rare",
     "consumableType": "other",
@@ -27,13 +32,9 @@
       "combat",
       "consumable",
       "natural",
-      "fling",
-      "seed",
-      "held",
-      "fling",
-      "fling"
+      "seed"
     ],
-    "description": "On hit, the target gains @Affliction[perish] 3.",
+    "description": "<p>On hit, the target gains @Affliction[perish 3].</p>",
     "quantity": 1,
     "slug": "doom-seed",
     "stack": 1,
@@ -45,10 +46,105 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Doom Seed",
+        "slug": "doom-seed",
+        "description": "<p>On hit, the target gains @Affliction[perish 3].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "natural",
+          "seed"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": [],
+        "accuracy": 100
+      }
+    ]
   },
   "_id": "JNZt5DJdNlQQseWb",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Doom Seed",
+      "type": "passive",
+      "_id": "u4rflaWuRuBpahhT",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "doom-seed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.perishcondititem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758794760411,
+        "modifiedTime": 1758794791223,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/douse-drive.json
+++ b/packs/core-gear/douse-drive.json
@@ -18,7 +18,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "rare",
     "traits": [
@@ -39,7 +44,8 @@
         ],
         "range": {
           "target": "creature",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "cost": {
           "activation": "complex"
@@ -47,7 +53,7 @@
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "Effect: This item does not use an Accessory slot when equipped by a [Genesect].",
+    "description": "<p>Effect: This accessory allows you to either add the @Trait[water] type to @UUID[Compendium.ptr2e.core-moves.gWjoYU30cvj8Vu4L]{Techno Blast} or replace Techno Blast's existing typing with @Trait[water]</p>",
     "slug": "douse-drive",
     "quantity": 1,
     "identification": {
@@ -67,7 +73,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "OK6XEVOpqHgrSk5X",

--- a/packs/core-gear/dream-ball.json
+++ b/packs/core-gear/dream-ball.json
@@ -22,7 +22,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -30,10 +35,11 @@
       "stack-5",
       "belt",
       "fling",
-      "training-ball"
+      "training-ball",
+      "ball"
     ],
-    "description": "6x Catch Rate modifer if used on a target that has @Affliction[drowsy], @Affliction[nightmares], or is sleeping. 1x Catch Rate modifer otherwise.",
-    "modifier": 6,
+    "description": "<p>4x Catch Rate modifer if used on a target that has @Affliction[drowsy], @Affliction[nightmares], or is sleeping. 1x Catch Rate modifer otherwise.</p>",
+    "modifier": 4,
     "quantity": 1,
     "slug": "dream-ball",
     "stack": 5,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "ECMaMJtCh6TyWCOl",
   "effects": [],

--- a/packs/core-gear/dusk-ball.json
+++ b/packs/core-gear/dusk-ball.json
@@ -3,7 +3,7 @@
   "img": "systems/ptr2e/img/item-icons/dusk ball.webp",
   "type": "consumable",
   "system": {
-    "cost": 4,
+    "cost": 3,
     "crafting": {
       "skill": "electronics",
       "spans": 2,
@@ -22,7 +22,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -30,10 +35,11 @@
       "stack-5",
       "belt",
       "fling",
-      "environ-ball"
+      "environ-ball",
+      "ball"
     ],
-    "description": "5x Catch Rate modifier with Gloomy Weather present. 2x Catch Rate modifier if it is only nighttime or otherwise dark. 1x Catch Rate modifier otherwise.",
-    "modifier": 2,
+    "description": "<p>3x Catch Rate modifier with Gloomy Weather present or at night. 1x Catch Rate modifier otherwise.</p>",
+    "modifier": 3,
     "quantity": 1,
     "slug": "dusk-ball",
     "stack": 5,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "Tf7l91f61dumDDyG",
   "effects": [],

--- a/packs/core-gear/earth-ball.json
+++ b/packs/core-gear/earth-ball.json
@@ -22,18 +22,24 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
-    "rarity": "common",
+    "rarity": "uncommon",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
       "fling",
-      "type-ball"
+      "type-ball",
+      "ball"
     ],
-    "description": "4x Catch Rate modifier if used on a Grass- or Ground-Type creature. 1x Catch Rate modifier otherwise.",
-    "modifier": 4,
+    "description": "<p>3x Catch Rate modifier if used on a Grass- or Ground-Type creature. 1x Catch Rate modifier otherwise.</p>",
+    "modifier": 3,
     "quantity": 1,
     "slug": "earth-ball",
     "stack": 5,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "J0x8IYmTQtENBjCK",
   "effects": [],

--- a/packs/core-gear/empowerment-seed.json
+++ b/packs/core-gear/empowerment-seed.json
@@ -1,11 +1,11 @@
 {
   "name": "Empowerment Seed",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
   "type": "consumable",
   "system": {
     "cost": 5,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 90,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "rare",
     "consumableType": "other",
     "traits": [
-      "restorative",
       "consumable",
       "natural",
-      "seed",
-      "held"
+      "seed"
     ],
-    "description": "When used, the target gains @Affliction[boosted] 3 for 3 activations.",
+    "description": "<p>When used, the target gains @Affliction[boosted 3].</p>",
     "quantity": 1,
     "slug": "empowerment-seed",
     "stack": 1,
@@ -42,10 +45,97 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Empowerment Seed",
+        "slug": "empowerment-seed",
+        "description": "<p>When used, the target gains @Affliction[boosted 3].</p>",
+        "traits": [
+          "consumable",
+          "natural",
+          "seed"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "VzoEKSYvRtfOBmcB",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Empowerment Seed",
+      "type": "passive",
+      "_id": "KRk50xyystmtcYDN",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "empowerment-seed-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.boostedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758795781001,
+        "modifiedTime": 1758795853145,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/energy-seed.json
+++ b/packs/core-gear/energy-seed.json
@@ -1,11 +1,11 @@
 {
   "name": "Energy Seed",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
   "type": "consumable",
   "system": {
-    "cost": 6,
+    "cost": 3,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -14,24 +14,28 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "A",
+    "grade": "B",
     "fling": {
       "type": "untyped",
       "power": 0,
       "accuracy": 90,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
-    "rarity": "rare",
+    "rarity": "uncommon",
     "consumableType": "other",
     "traits": [
       "restorative",
       "consumable",
       "natural",
       "healing",
-      "seed",
-      "held"
+      "seed"
     ],
-    "description": "The target heals 200 HP and 30 PP.",
+    "description": "<p>The target heals @HP[200].</p>",
     "quantity": 1,
     "slug": "energy-seed",
     "stack": 1,
@@ -43,10 +47,104 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Energy Seed",
+        "slug": "energy-seed",
+        "description": "<p>The target heals @HP[200].</p>",
+        "traits": [
+          "restorative",
+          "consumable",
+          "natural",
+          "healing",
+          "seed"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "f2pbaFdu1qLSZkfi",
-  "effects": [],
+  "effects": [
+    {
+      "name": "energy seed",
+      "type": "passive",
+      "_id": "RgfWG6OEqOQ664OX",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "energy-seed-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.4DlXFTVooz07YcDm",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.isFlat",
+                "value": "true"
+              },
+              {
+                "mode": 5,
+                "property": "system.changes.0.value",
+                "value": 200
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.jfGzfe3pG69kJ6Bx.ActiveEffect.G4cA5qHnxsI2Yegr",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758796005618,
+        "modifiedTime": 1758796018478,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/fast-ball.json
+++ b/packs/core-gear/fast-ball.json
@@ -22,7 +22,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -30,7 +35,8 @@
       "stack-5",
       "belt",
       "fling",
-      "hunting-ball"
+      "hunting-ball",
+      "ball"
     ],
     "description": "4x Catch Rate modifier if the target's base speed is greater than 100. 1x Catch Rate modifier otherwise.",
     "modifier": 4,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "8YGA6mOsuB2s0pIz",
   "effects": [],

--- a/packs/core-gear/feather-ball.json
+++ b/packs/core-gear/feather-ball.json
@@ -22,17 +22,23 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
-    "description": "1x Catch Rate modifier. Catch Rate modifier increases by +2x vs creatures that are in Flight.",
-    "modifier": 3,
+    "description": "<p>1x Catch Rate modifier. Catch Rate modifier increases by +0.25x vs creatures that are in Flight.</p>",
+    "modifier": 1.25,
     "quantity": 1,
     "slug": "feather-ball",
     "stack": 5,
@@ -44,8 +50,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "OshRvOSAkRGET7Au",
   "effects": [],

--- a/packs/core-gear/flippers.json
+++ b/packs/core-gear/flippers.json
@@ -1,0 +1,123 @@
+{
+  "folder": "6VDJBcrqVDh5bYtA",
+  "name": "Flippers",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e - Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "accessory"
+    ],
+    "actions": [],
+    "description": "<p>These shoes are particularly good for running in. Wearing them grants a +4 to your existing Swim Movement Allowance, and grants a +20 to Swimming checks made to Rush.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": 0,
+      "slot": "accessory"
+    },
+    "grade": "D",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    },
+    "slug": "flippers"
+  },
+  "img": "icons/equipment/feet/shoes-simple-leaf-green.webp",
+  "effects": [
+    {
+      "name": "Flippers",
+      "type": "passive",
+      "_id": "DT3Q72g2SH7PsrD1",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "swimming-check",
+            "value": 20,
+            "predicate": [],
+            "label": "Rushing?",
+            "priority": null,
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.swim.value",
+            "value": 4,
+            "predicate": [],
+            "priority": null,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "rounds": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "_id": "OBV05k7GB6uKssw4"
+}

--- a/packs/core-gear/foe-fear-orb.json
+++ b/packs/core-gear/foe-fear-orb.json
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "All foes in the Room gain @Affliction[fear] 3.",
+    "description": "<p>All foes in the Room gain @Affliction[fear 3].</p>",
     "quantity": 1,
     "slug": "foe-fear-orb",
     "stack": 1,
@@ -42,10 +45,98 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Foe-Fear Orb",
+        "slug": "foe-fear-orb",
+        "description": "<p>All foes in the Room gain @Affliction[fear 3].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb",
+          "held",
+          "fling"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "complex"
+        },
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "k9gR62byZczNuTYj",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Foe-Fear Orb",
+      "type": "passive",
+      "_id": "TquMpRFAdU3GTxRA",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "foe-fear-orb-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.fearconditioitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758756513648,
+        "modifiedTime": 1758756542135,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/foe-hold-orb.json
+++ b/packs/core-gear/foe-hold-orb.json
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "All foes in the Room gain @Affliction[bound] 5.",
+    "description": "<p>All foes in the Room gain @Affliction[bound 3].</p>",
     "quantity": 1,
     "slug": "foe-hold-orb",
     "stack": 1,
@@ -42,10 +45,96 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Foe-Hold Orb",
+        "slug": "foe-hold-orb-action-1",
+        "description": "<p>All foes in the Room gain @Affliction[bound 3].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "complex"
+        },
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "hZn5dGH90gSnvcCG",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Foe-Hold Orb",
+      "type": "passive",
+      "_id": "Am6gBPtZNwyOxK2h",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "foe-hold-orb-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.boundconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758756637951,
+        "modifiedTime": 1758756666289,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/foe-seal-orb.json
+++ b/packs/core-gear/foe-seal-orb.json
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "field",
+        "distance": null,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "All foes in Room gain @Affliction[disabled] 5 (the affected attack is selected at random).",
+    "description": "<p>All foes in Room gain @Affliction[disabled 5]  (the affected attack is selected at random).</p>",
     "quantity": 1,
     "slug": "foe-seal-orb",
     "stack": 1,
@@ -42,10 +45,91 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Foe-Seal Orb",
+        "slug": "foe-seal-orb",
+        "description": "<p>All foes in Room gain @Affliction[disabled 5] (the affected attack is selected at random).</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "HzwvMLZJ17RvBUrg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Foe-Seal Orb",
+      "type": "passive",
+      "_id": "dmYlwbcSdd409AAM",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "foe-seal-orb-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.disabledconditem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758756791277,
+        "modifiedTime": 1758756818213,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/gigaton-ball.json
+++ b/packs/core-gear/gigaton-ball.json
@@ -20,19 +20,24 @@
     "grade": "C",
     "fling": {
       "type": "untyped",
-      "power": 50,
-      "accuracy": 85,
-      "hide": null
+      "power": 90,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 4,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "pokeball",
     "traits": [
-      "stack-5",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
-    "description": "5x Catch Rate modifier.",
-    "modifier": 5,
+    "description": "<p>2.75x Catch Rate modifier.</p>",
+    "modifier": 2.75,
     "quantity": 1,
     "slug": "gigaton-ball",
     "stack": 3,
@@ -44,8 +49,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "HC12vQhqD7gZ5hGc",
   "effects": [],

--- a/packs/core-gear/gossamer-ball.json
+++ b/packs/core-gear/gossamer-ball.json
@@ -22,18 +22,24 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
-    "rarity": "common",
+    "rarity": "uncommon",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
       "fling",
-      "type-ball"
+      "type-ball",
+      "ball"
     ],
-    "description": "4x Catch Rate modifier if used on a Normal- or Fairy-Type creature. 1x Catch Rate modifier otherwise.",
-    "modifier": 4,
+    "description": "<p>3x Catch Rate modifier if used on a Normal- or Fairy-Type creature. 1x Catch Rate modifier otherwise.</p>",
+    "modifier": 3,
     "quantity": 1,
     "slug": "gossamer-ball",
     "stack": 5,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "vtwlgqMb7fBvSdZw",
   "effects": [],

--- a/packs/core-gear/great-ball.json
+++ b/packs/core-gear/great-ball.json
@@ -22,17 +22,23 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
-    "description": "1.75x Catch Rate modifier.",
-    "modifier": 1.75,
+    "description": "<p>1.5x Catch Rate modifier.</p>",
+    "modifier": 1.5,
     "quantity": 1,
     "slug": "great-ball",
     "stack": 5,
@@ -44,8 +50,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "dQNf6C22Bxd2xSK0",
   "effects": [],

--- a/packs/core-gear/hail-ball.json
+++ b/packs/core-gear/hail-ball.json
@@ -22,7 +22,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -30,10 +35,11 @@
       "stack-5",
       "belt",
       "fling",
-      "environ-ball"
+      "environ-ball",
+      "ball"
     ],
-    "description": "5x Catch Rate modifier with Snowy Weather present. 2.5x Catch Rate modifier if natural snowfall is present. 1x Catch Rate modifier otherwise.",
-    "modifier": 2.5,
+    "description": "<p>3.5x Catch Rate modifier with Snowy Weather present. 1x Catch Rate modifier otherwise.</p>",
+    "modifier": 3.5,
     "quantity": 1,
     "slug": "hail-ball",
     "stack": 5,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "og6QFbXvO5aHdLHd",
   "effects": [],

--- a/packs/core-gear/hail-orb.json
+++ b/packs/core-gear/hail-orb.json
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "other",
@@ -27,11 +32,9 @@
       "combat",
       "consumable",
       "weather",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "The Weather is set to Snowy on the current Floor.",
+    "description": "<p>The Weather is set to @UUID[Compendium.ptr2e.core-summons.8EVtue4CUOjddZIP]{Snowy Weather} for 3 rounds.</p>",
     "quantity": 1,
     "slug": "hail-orb",
     "stack": 1,
@@ -43,8 +46,32 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Hail Orb",
+        "slug": "hail-orb",
+        "description": "<p>The Weather is set to Snowy on the current Floor.</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "weather",
+          "wonder-orb"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "ouc4BKMdEhOfBH0o",
   "effects": [],

--- a/packs/core-gear/haunt-ball.json
+++ b/packs/core-gear/haunt-ball.json
@@ -22,18 +22,24 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
-    "rarity": "common",
+    "rarity": "uncommon",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
       "fling",
-      "type-ball"
+      "type-ball",
+      "ball"
     ],
-    "description": "4x Catch Rate modifier if used on a Ghost- or Dark-Type creature. 1x Catch Rate modifier otherwise.",
-    "modifier": 4,
+    "description": "<p>3x Catch Rate modifier if used on a Ghost- or Dark-Type creature. 1x Catch Rate modifier otherwise.</p>",
+    "modifier": 3,
     "quantity": 1,
     "slug": "haunt-ball",
     "stack": 5,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "azAEQjHVZjf4VcI3",
   "effects": [],

--- a/packs/core-gear/heal-ball.json
+++ b/packs/core-gear/heal-ball.json
@@ -22,7 +22,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "pokeball",
@@ -30,7 +35,8 @@
       "stack-5",
       "belt",
       "fling",
-      "training-ball"
+      "training-ball",
+      "ball"
     ],
     "description": "1x Catch Rate modifier. Upon capture, heals the captured creature's HP, PP, and removes all of its Status Afflictions.",
     "modifier": 1,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "4A4CPITprvVAVOkM",
   "effects": [],

--- a/packs/core-gear/heat-ball.json
+++ b/packs/core-gear/heat-ball.json
@@ -22,18 +22,24 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
-    "rarity": "common",
+    "rarity": "uncommon",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
       "fling",
-      "type-ball"
+      "type-ball",
+      "ball"
     ],
-    "description": "4x Catch Rate modifier if used on a Fire- or Electric-Type creature. 1x Catch Rate modifier otherwise.",
-    "modifier": 4,
+    "description": "<p>3x Catch Rate modifier if used on a Fire- or Electric-Type creature. 1x Catch Rate modifier otherwise.</p>",
+    "modifier": 3,
     "quantity": 1,
     "slug": "heat-ball",
     "stack": 5,
@@ -45,8 +51,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "wR10qXM6v9rQ8sqq",
   "effects": [],

--- a/packs/core-gear/hefty-ball.json
+++ b/packs/core-gear/hefty-ball.json
@@ -22,17 +22,23 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 85,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 6,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "pokeball",
     "traits": [
       "stack-3",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
-    "description": "2x Catch Rate modifier.",
-    "modifier": 2,
+    "description": "<p>1.5x Catch Rate modifier.</p>",
+    "modifier": 1.5,
     "quantity": 1,
     "slug": "hefty-ball",
     "stack": 3,
@@ -44,8 +50,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "79EKurPbRzXPOCR5",
   "effects": [],

--- a/packs/core-gear/identify-orb.json
+++ b/packs/core-gear/identify-orb.json
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "The user rolls Spot with a +50.",
+    "description": "<p>The user gains @Affliction[true-sight 5].</p>",
     "quantity": 1,
     "slug": "identify-orb",
     "stack": 1,
@@ -42,10 +45,90 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Identify Orb",
+        "slug": "identify-orb",
+        "description": "<p>The user gains @Affliction[true-sight 5].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "self",
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "7gyAnJ4CTxtpw0Ta",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Identify Orb",
+      "type": "passive",
+      "_id": "kR60S0i3fXyNpYyF",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "identify-orb-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.truesightconitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758757090473,
+        "modifiedTime": 1758757114476,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/invisify-orb.json
+++ b/packs/core-gear/invisify-orb.json
@@ -18,48 +18,118 @@
     "fling": {
       "type": "untyped",
       "power": 40,
-      "accuracy": 100
+      "accuracy": 100,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "The user gains @Affliction[invisible] 5.",
+    "description": "<p>The user gains @Affliction[invisible 5].</p>",
     "quantity": 1,
-    "container": null,
-    "slug": null,
-    "modifier": null,
+    "slug": "invisify-orb",
     "stack": 1,
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Invisify Orb",
+        "slug": "invisify-orb",
+        "description": "<p>The user gains @Affliction[invisible 5].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "E3ChEh9YkAe7P3d5",
-  "effects": [],
-  "folder": "4MbEHvhwmG5DYTkB",
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "tXAZ3QUgjuwX4gdV": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.327",
-    "systemId": "ptr2e",
-    "systemVersion": "0.0.0-alpha.1.0",
-    "createdTime": 1717878484297,
-    "modifiedTime": 1717878484297,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "_key": "!items!E3ChEh9YkAe7P3d5"
+  "effects": [
+    {
+      "name": "Invisify Orb",
+      "type": "passive",
+      "_id": "zzN8cSwnWjgKLtTt",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "invisify-orb-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.invisibleconitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758757217666,
+        "modifiedTime": 1758757236432,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
+  "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/jet-ball.json
+++ b/packs/core-gear/jet-ball.json
@@ -22,17 +22,23 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "pokeball",
     "traits": [
       "stack-5",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
-    "description": "2.5x Catch Rate modifier. Catch Rate modifier increases by +2.5x vs creatures that are in Flight.",
-    "modifier": 5,
+    "description": "<p>3x Catch Rate modifier vs targets in the Flying or Teleportation movement states.</p>",
+    "modifier": 3,
     "quantity": 1,
     "slug": "jet-ball",
     "stack": 5,
@@ -44,8 +50,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "g74RkfDpUI6xZAy7",
   "effects": [],

--- a/packs/core-gear/leaden-ball.json
+++ b/packs/core-gear/leaden-ball.json
@@ -20,19 +20,25 @@
     "grade": "D",
     "fling": {
       "type": "untyped",
-      "power": 45,
-      "accuracy": 85,
-      "hide": null
+      "power": 65,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 5,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "pokeball",
     "traits": [
       "stack-3",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
-    "description": "3.5x Catch Rate modifier.",
-    "modifier": 3.5,
+    "description": "<p>2x Catch Rate modifier.</p>",
+    "modifier": 2,
     "quantity": 1,
     "slug": "leaden-ball",
     "stack": 3,
@@ -44,8 +50,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "iWcPq9fyjji5ZUge",
   "effects": [],

--- a/packs/core-gear/nullify-orb.json
+++ b/packs/core-gear/nullify-orb.json
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "All foes gain @Affliction[nullified] 5. (The affected Ability is selected at random)",
+    "description": "<p>All foes gain @Affliction[nullified 5] (The affected Ability is selected at random, select another option if the ability cannot be nullified).</p>",
     "quantity": 1,
     "slug": "nullify-orb",
     "stack": 1,
@@ -42,10 +45,90 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Nullify Orb",
+        "slug": "nullify-orb",
+        "description": "<p>All foes gain @Affliction[nullified 5] (The affected Ability is selected at random, select another option if the ability cannot be nullified).</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "complex"
+        },
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "hGMpvSdKjZ0Zq7lj",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Nullify Orb",
+      "type": "passive",
+      "_id": "GJV7WCX6pdXmJcEm",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "nullify-orb-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.nullifiedconitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758757514809,
+        "modifiedTime": 1758757535672,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/rainy-orb.json
+++ b/packs/core-gear/rainy-orb.json
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "The Weather is set to Rainy on the current Floor.",
+    "description": "<p>The Weather is set to @UUID[Compendium.ptr2e.core-summons.IkeVGMx2xjpkphtA]{Rainy Weather} for 3 rounds.</p>",
     "quantity": 1,
     "slug": "rainy-orb",
     "stack": 1,
@@ -42,8 +45,31 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Rainy Orb",
+        "slug": "rainy-orb",
+        "description": "<p>The Weather is set to Rainy for 3 rounds.</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "X8zEz3NpNHamfOLb",
   "effects": [],

--- a/packs/core-gear/rocky-orb.json
+++ b/packs/core-gear/rocky-orb.json
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "The target gains @Affliction[splinter] 5.",
+    "description": "<p>The target gains @Affliction[splinter 5].</p>",
     "quantity": 1,
     "slug": "rocky-orb",
     "stack": 1,
@@ -42,10 +45,98 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Rocky Orb Action",
+        "slug": "rocky-orb",
+        "description": "<p>The target gains @Affliction[splinter 5].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": [],
+        "accuracy": 100
+      }
+    ]
   },
   "_id": "665IwJxoV31VfYXa",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Rocky Orb",
+      "type": "passive",
+      "_id": "bfDBamRmvlDUitDh",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "rocky-orb-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.splinterconditem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758757842237,
+        "modifiedTime": 1758757858646,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/sandy-orb.json
+++ b/packs/core-gear/sandy-orb.json
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "The Weather is set to Dusty on the current Floor.",
+    "description": "<p>The Weather is set to @UUID[Compendium.ptr2e.core-summons.2pDL6hkh4fjFIEAe]{Dusty Weather} for 3 rounds.</p>",
     "quantity": 1,
     "slug": "sandy-orb",
     "stack": 1,
@@ -42,8 +45,31 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Sandy Orb",
+        "slug": "sandy-orb",
+        "description": "<p>The Weather is set to Dusty for 3 rounds.</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "lnZCjMQGrOFHRgYm",
   "effects": [],

--- a/packs/core-gear/shock-drive.json
+++ b/packs/core-gear/shock-drive.json
@@ -4,7 +4,7 @@
   "type": "equipment",
   "system": {
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -18,7 +18,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "rare",
     "traits": [
@@ -39,7 +44,8 @@
         ],
         "range": {
           "target": "creature",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "cost": {
           "activation": "complex"
@@ -47,7 +53,7 @@
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "Effect: This item does not use an Accessory slot when equipped by a [Genesect].",
+    "description": "<p>Effect: This accessory allows you to either add the @Trait[electric] type to @UUID[Compendium.ptr2e.core-moves.gWjoYU30cvj8Vu4L]{Techno Blast} or replace Techno Blast's existing typing with @Trait[electric]</p>",
     "slug": "shock-drive",
     "quantity": 1,
     "identification": {
@@ -67,7 +73,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "s6Rc6ChDe8d6OB1Z",

--- a/packs/core-gear/shocker-orb.json
+++ b/packs/core-gear/shocker-orb.json
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "The target has @Affliction[paralysis] 5.",
+    "description": "<p>The target is inflicted with @Affliction[paralysis 5].</p>",
     "quantity": 1,
     "slug": "shocker-orb",
     "stack": 1,
@@ -42,10 +45,97 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Shocker Orb",
+        "slug": "shocker-orb",
+        "description": "<p>The target is inflicted with @Affliction[paralysis 5].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": []
+      }
+    ]
   },
   "_id": "j2o4rX391XWjpwrk",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Shocker Orb",
+      "type": "passive",
+      "_id": "djQ3hVrSpguWBDrG",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shocker-orb-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758758140048,
+        "modifiedTime": 1758758161879,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/sleep-seed.json
+++ b/packs/core-gear/sleep-seed.json
@@ -1,11 +1,11 @@
 {
   "name": "Sleep Seed",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
   "type": "consumable",
   "system": {
     "cost": 2,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 85,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "other",
@@ -27,13 +32,10 @@
       "combat",
       "consumable",
       "natural",
-      "fling",
       "seed",
-      "held",
-      "stack-3",
-      "fling"
+      "stack-3"
     ],
-    "description": "On hit, the target gains @Affliction[drowsy] 3.",
+    "description": "<p>On hit, the target gains @Affliction[drowsy 3].</p>",
     "quantity": 1,
     "slug": "sleep-seed",
     "stack": 1,
@@ -45,10 +47,106 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Sleep Seed",
+        "slug": "sleep-seed",
+        "description": "<p>On hit, the target gains @Affliction[drowsy 3].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "natural",
+          "seed",
+          "stack-3"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": [],
+        "accuracy": 100
+      }
+    ]
   },
   "_id": "De6GJ775H2ecUiJS",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Sleep Seed",
+      "type": "passive",
+      "_id": "44GMoo5wqXmpP73O",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "sleep-seed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.drowsycondititem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758796739560,
+        "modifiedTime": 1758796772343,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/slow-orb.json
+++ b/packs/core-gear/slow-orb.json
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "All foes in the Room gain @Affliction[slowed] 5.",
+    "description": "<p>All foes in the Room gain @Affliction[slowed 5].</p>",
     "quantity": 1,
     "slug": "slow-orb",
     "stack": 1,
@@ -42,10 +45,90 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Slow Orb",
+        "slug": "slow-orb",
+        "description": "<p>All foes in the Room gain @Affliction[slowed 5].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "complex"
+        },
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "jQaGwJVcHkNc8Jyj",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Slow Orb",
+      "type": "passive",
+      "_id": "bIvhasnfrxvLc5Jn",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "slow-orb-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.slowedcondititem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758758264084,
+        "modifiedTime": 1758758283510,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/stun-seed.json
+++ b/packs/core-gear/stun-seed.json
@@ -1,11 +1,11 @@
 {
   "name": "Stun Seed",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
   "type": "consumable",
   "system": {
     "cost": 2,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 85,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "other",
@@ -27,13 +32,10 @@
       "combat",
       "consumable",
       "natural",
-      "fling",
       "seed",
-      "held",
-      "stack-3",
-      "fling"
+      "stack-3"
     ],
-    "description": "On hit, the target gains @Affliction[paralysis] 3.",
+    "description": "<p>On hit, the target gains @Affliction[paralysis 3].</p>",
     "quantity": 1,
     "slug": "stun-seed",
     "stack": 1,
@@ -45,10 +47,106 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Stun Seed",
+        "slug": "stun-seed",
+        "description": "<p>On hit, the target gains @Affliction[paralysis 3].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "natural",
+          "seed",
+          "stack-3"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": [],
+        "accuracy": 100
+      }
+    ]
   },
   "_id": "zEC0WH0Jd6BBWtXW",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Stun Seed",
+      "type": "passive",
+      "_id": "nt3qw0n1cXcdmWBU",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "stun-seed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758796858157,
+        "modifiedTime": 1758796883596,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/sunny-orb.json
+++ b/packs/core-gear/sunny-orb.json
@@ -19,18 +19,21 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "other",
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb",
-      "held",
-      "fling"
+      "wonder-orb"
     ],
-    "description": "The Weather is set to Sunny on the current Floor.",
+    "description": "<p>The Weather is set to @UUID[Compendium.ptr2e.core-summons.9cgLo9qwotwZUqPT]{Sunny Weather} for 3 rounds.</p>",
     "quantity": 1,
     "slug": "sunny-orb",
     "stack": 1,
@@ -42,8 +45,31 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Sunny Orb",
+        "slug": "sunny-orb",
+        "description": "<p>The Weather is set to @UUID[Compendium.ptr2e.core-summons.9cgLo9qwotwZUqPT]{Sunny Weather} for 3 rounds.</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "wonder-orb"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "UcKAiTpysRPNJhmC",
   "effects": [],

--- a/packs/core-gear/totter-seed.json
+++ b/packs/core-gear/totter-seed.json
@@ -1,11 +1,11 @@
 {
   "name": "Totter Seed",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
   "type": "consumable",
   "system": {
     "cost": 2,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 85,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "other",
@@ -27,12 +32,10 @@
       "combat",
       "consumable",
       "natural",
-      "fling",
       "seed",
-      "held",
       "stack-3"
     ],
-    "description": "On hit, the target gains @Affliction[confused] 3.",
+    "description": "<p>On hit, the target gains @Affliction[confused 3].</p>",
     "quantity": 1,
     "slug": "totter-seed",
     "stack": 1,
@@ -44,10 +47,106 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Totter Seed",
+        "slug": "totter-seed",
+        "description": "<p>On hit, the target gains @Affliction[confused 3].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "natural",
+          "seed",
+          "stack-3"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": [],
+        "accuracy": 100
+      }
+    ]
   },
   "_id": "O7CJD3lkl7MWUsVk",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Totter Seed",
+      "type": "passive",
+      "_id": "PBzpBvfp4x5IilXv",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "totter-seed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758796994320,
+        "modifiedTime": 1758797121621,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/vanish-seed.json
+++ b/packs/core-gear/vanish-seed.json
@@ -1,11 +1,11 @@
 {
   "name": "Vanish Seed",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
   "type": "consumable",
   "system": {
     "cost": 3,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 90,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "rare",
     "consumableType": "other",
@@ -28,11 +33,9 @@
       "consumable",
       "natural",
       "seed",
-      "held",
-      "stack-3",
-      "fling"
+      "stack-3"
     ],
-    "description": "The target gains @Affliction[invisible] 3.",
+    "description": "<p>The target gains @Affliction[invisible 3].</p>",
     "quantity": 1,
     "slug": "vanish-seed",
     "stack": 1,
@@ -44,10 +47,99 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Vanish Seed Action (#1)",
+        "slug": "vanish-seed",
+        "description": "<p>The target gains @Affliction[invisible 3].</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "natural",
+          "seed",
+          "stack-3"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "eFAOLS83u74nIcN2",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Vanish Seed",
+      "type": "passive",
+      "_id": "KQfzvPBb1kZCRMU8",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "vanish-seed-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.invisibleconitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758797405269,
+        "modifiedTime": 1758797428505,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/vile-seed.json
+++ b/packs/core-gear/vile-seed.json
@@ -1,11 +1,11 @@
 {
   "name": "Vile Seed",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
   "type": "consumable",
   "system": {
     "cost": 5,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 80,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "rare",
     "consumableType": "other",
@@ -27,10 +32,7 @@
       "combat",
       "consumable",
       "natural",
-      "fling",
-      "seed",
-      "held",
-      "fling"
+      "seed"
     ],
     "description": "On hit, the target loses -3 DEF and SPDEF Stages for 3 activations.",
     "quantity": 1,
@@ -44,10 +46,126 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Vile Seed",
+        "slug": "vile-seed",
+        "description": "<p>On hit, the target loses -3 DEF and SPDEF Stages for 3 activations.</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "natural",
+          "fling",
+          "seed",
+          "held"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": [],
+        "accuracy": 100
+      }
+    ]
   },
   "_id": "D5SLAbrlvOZ06rsY",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Vile Seed",
+      "type": "passive",
+      "_id": "QAP7dAiCk1CbiV89",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "vile-seed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.IMkv0gbwXcgkXfCJ",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "vile-seed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.j1vZh1Oo54KdyJIR",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.D5SLAbrlvOZ06rsY.ActiveEffect.QAP7dAiCk1CbiV89",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758797615618,
+        "modifiedTime": 1758797680537,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }

--- a/packs/core-gear/violent-seed.json
+++ b/packs/core-gear/violent-seed.json
@@ -1,11 +1,11 @@
 {
   "name": "Violent Seed",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
   "type": "consumable",
   "system": {
     "cost": 5,
     "crafting": {
-      "skill": null,
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 90,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "rare",
     "consumableType": "other",
@@ -43,10 +48,119 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Violent Seed",
+        "slug": "violent-seed",
+        "description": "<p>The target gains +3 ATK and SPATK Stages, for 3 activations.</p>",
+        "traits": [
+          "combat",
+          "consumable",
+          "natural",
+          "seed",
+          "held",
+          "stack-3"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/item-icons/miracle%20seed.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ]
   },
   "_id": "Int0t3r1yUc3qNgh",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Violent Seed",
+      "type": "passive",
+      "_id": "cFIb240ojkbLvD3P",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "violent-seed-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.tH75RuGeGEDpXSah",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "violent-seed-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAz",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.348",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.4.beta",
+        "createdTime": 1758797991455,
+        "modifiedTime": 1758798046649,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "4MbEHvhwmG5DYTkB"
 }


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Consumable: Foe-Fear Orb
- Update Consumable: Foe-Hold Orb
- Update Consumable: Foe-Seal Orb
- Update Consumable: Hail Orb
- Update Consumable: Identify Orb
- Update Consumable: Invisify Orb
- Update Consumable: Nullify Orb
- Update Consumable: Rainy Orb
- Update Consumable: Rocky Orb
- Update Consumable: Sandy Orb
- Update Consumable: Shocker Orb
- Update Consumable: Slow Orb
- Update Consumable: Sunny Orb
- Update Consumable: Allure Seed
- Update Consumable: Ban Seed
- Update Consumable: Decoy Seed
- Update Consumable: Doom Seed
- Update Consumable: Empowerment Seed
- Update Consumable: Energy Seed
- Update Consumable: Sleep Seed
- Update Consumable: Stun Seed
- Update Consumable: Totter Seed
- Update Consumable: Vanish Seed
- Update Consumable: Vile Seed
- Update Consumable: Violent Seed
- Update Equipment: Burn Drive
- Update Equipment: Chill Drive
- Update Equipment: Douse Drive
- Update Equipment: Shock Drive
- Update Equipment: Clear Amulet
- Update Equipment: Flippers
- Update Consumable: Air Ball
- Update Consumable: Beacon Ball
- Update Consumable: Beast Ball
- Update Consumable: Cherish Ball
- Update Consumable: Coolant Ball
- Update Consumable: Dark Ball
- Update Consumable: Dive Ball
- Update Consumable: Dream Ball
- Update Consumable: Dusk Ball
- Update Consumable: Earth Ball
- Update Consumable: Feather Ball
- Update Consumable: Gigaton Ball
- Update Consumable: Gossamer Ball
- Update Consumable: Basic Ball
- Update Consumable: Fast Ball
- Update Consumable: Great Ball
- Update Consumable: Hail Ball
- Update Consumable: Haunt Ball
- Update Consumable: Heal Ball
- Update Consumable: Heat Ball
- Update Consumable: Hefty Ball
- Update Consumable: Jet Ball
- Update Consumable: Leaden Ball