### PR TITLE
Foundry Data Sync - Z-Crystals

### DIFF
--- a/packs/core-gear/adrenaline-orb.json
+++ b/packs/core-gear/adrenaline-orb.json
@@ -1,0 +1,129 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Adrenaline Orb",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [
+      {
+        "name": "Adrenaline Orb",
+        "slug": "adrenaline-orb",
+        "description": "<p>Trigger: The user gains @Affliction[fear] or falls below the @Trait[desperation-1-3] threshold.<br><br>Effect: The user gains @UUID[Compendium.ptr2e.core-effects.XeiSuS3APUcN0MLM]{+1 Speed Stage} for 5 activations.</p>",
+        "traits": [
+          "consumable",
+          "combat"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+        "cost": {
+          "activation": "free"
+        },
+        "range": {
+          "target": "self",
+          "unit": "m",
+          "distance": 10
+        }
+      }
+    ],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "slug": "adrenaline-orb-rework",
+    "description": "<p>Trigger: The user gains @Affliction[fear] or falls below the @Trait[desperation-1-3] threshold.<br><br>Effect: The user gains @UUID[Compendium.ptr2e.core-effects.XeiSuS3APUcN0MLM]{+1 Speed Stage} for 5 activations.</p>",
+    "traits": [
+      "consumable",
+      "combat"
+    ],
+    "consumableType": "other",
+    "stack": 1,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "effects": [
+    {
+      "name": "Adrenaline Orb",
+      "type": "passive",
+      "_id": "KnEdZ2Jb07zGGAj5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "adrenaline-orb-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLM",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.5.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "_id": "HyFQWSAl5NQIGjs5"
+}

--- a/packs/core-gear/aloraichium-z.json
+++ b/packs/core-gear/aloraichium-z.json
@@ -1,0 +1,81 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Aloraichium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "alolan",
+      "raichu"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows an @UUID[Compendium.ptr2e.core-species.BlbbyuA65PZ5YUUE]{Alolan Raichu} to use @UUID[Compendium.ptr2e.core-moves.wlHWup7MYL88PcGg]{Stoked Sparksurfer}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "Tm2aL3ii7waQUdWj",
+  "img": "systems/ptr2e/img/item-icons/Dream_Aloraichium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679798499,
+    "modifiedTime": 1759679881652,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/buginium-z.json
+++ b/packs/core-gear/buginium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Buginium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "bug"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.BMFf51pRcmhOmBbO]{Savage Spinout}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "59D3PPkOgps7xnTk",
+  "img": "systems/ptr2e/img/item-icons/Dream_Buginium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759678441147,
+    "modifiedTime": 1759678650716,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/darkinium-z.json
+++ b/packs/core-gear/darkinium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Darkinium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "dark"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.xSlpc2zrEMwrb4oZ]{Black Hole Eclipse}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "u8OhX7HtTdPLpnxR",
+  "img": "systems/ptr2e/img/item-icons/Dream_Darkinium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759678593579,
+    "modifiedTime": 1759678676630,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/decidium-z.json
+++ b/packs/core-gear/decidium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Decidium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "decidueye"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.O1Trhms4pDq6GKyT]{decidueye} user to use @UUID[Compendium.ptr2e.core-moves.RcdLjcL0pcamAGQs]{Sinister Arrow Raid}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "Jpn8P5lRk654K7V4",
+  "img": "systems/ptr2e/img/item-icons/Dream_Decidium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679901492,
+    "modifiedTime": 1759679983491,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/dragonium-z.json
+++ b/packs/core-gear/dragonium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Dragonium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "dragon"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.sY14kmyNGtCQGTrN]{Devastating Drake}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "zzoyYYTxES7EMOJL",
+  "img": "systems/ptr2e/img/item-icons/Dream_Dragonium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759678692118,
+    "modifiedTime": 1759678748267,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/eevium-z.json
+++ b/packs/core-gear/eevium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Eevium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "eevee"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows an @UUID[Compendium.ptr2e.core-species.GLVg67j2hGGz2ksx]{Eevee} or a @Trait[pokemon] evolved from an @UUID[Compendium.ptr2e.core-species.GLVg67j2hGGz2ksx]{Eevee} to use @UUID[Compendium.ptr2e.core-moves.BlNt2Lh9xW0hCuZq]{Extreme Evoboost}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "pOY64sPM2ccX05aP",
+  "img": "systems/ptr2e/img/item-icons/Dream_Eevium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679996435,
+    "modifiedTime": 1759680222274,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/electrium-z.json
+++ b/packs/core-gear/electrium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Electrium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "electric"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.XgUqQZ4AhjbG9slp]{Gigavolt Havoc}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "nql26eBoZKm85P9Q",
+  "img": "systems/ptr2e/img/item-icons/Dream_Electrium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759678761820,
+    "modifiedTime": 1759678818867,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/fairium-z.json
+++ b/packs/core-gear/fairium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Fairium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "fairy"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.R6hvW3x0BNEBwZle]{Twinkle Tackle}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "cfaV3KzuioexzKWk",
+  "img": "systems/ptr2e/img/item-icons/Dream_Fairium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759678833288,
+    "modifiedTime": 1759678884482,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/fightinium-z.json
+++ b/packs/core-gear/fightinium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Fightinium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "fighting"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.zhXoVFlDkekjcNru]{All-Out Pummeling}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "jOIlPqJLL3Z7uabV",
+  "img": "systems/ptr2e/img/item-icons/Dream_Fightinium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759678900219,
+    "modifiedTime": 1759678956133,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/firium-z.json
+++ b/packs/core-gear/firium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Firium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "fire"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.5zopm1vVcu9IdfMb]{Inferno Overdrive}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "kVVSvVwV9W96WN8g",
+  "img": "systems/ptr2e/img/item-icons/Dream_Firium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759678980947,
+    "modifiedTime": 1759679032257,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/flyinium-z.json
+++ b/packs/core-gear/flyinium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Flyinium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "flying"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.quBFkj8fptxA0lcN]{Supersonic Skystrike}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "QFRxN9Lu0TtjNSnL",
+  "img": "systems/ptr2e/img/item-icons/Dream_Flyinium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679047520,
+    "modifiedTime": 1759679099916,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/ghostium-z.json
+++ b/packs/core-gear/ghostium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Ghostium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "ghost"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.5AvHrV7Vy4cr5HVn]{Neverending Nightmare}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "zWFUq7mkoCpOph0s",
+  "img": "systems/ptr2e/img/item-icons/Dream_Ghostium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679123856,
+    "modifiedTime": 1759679173755,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/grassium-z.json
+++ b/packs/core-gear/grassium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Grassium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "grass"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.PIcqvw3lxOj7p6hj]{Bloom Doom}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "vnEr1rEMA3zz2mJd",
+  "img": "systems/ptr2e/img/item-icons/Dream_Grassium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679192350,
+    "modifiedTime": 1759679236932,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/groundium-z.json
+++ b/packs/core-gear/groundium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Groundium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "ground"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.AOaJZd6W5vJTCuFQ]{Tectonic Rage}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "djdOE9ImtfaR6sAC",
+  "img": "systems/ptr2e/img/item-icons/Dream_Groundium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679262228,
+    "modifiedTime": 1759679307046,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/icium-z.json
+++ b/packs/core-gear/icium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Icium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "ice"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.7iD8RvIbxnUNUPRM]{Subzero Slammer}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "lzVUL8P9MT0KE45q",
+  "img": "systems/ptr2e/img/item-icons/Dream_Icium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679322819,
+    "modifiedTime": 1759679367862,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/incinium-z.json
+++ b/packs/core-gear/incinium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Incinium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "incineroar"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows an @UUID[Compendium.ptr2e.core-species.fU6D6xRQzJIhFxHr]{Incineroar} to use @UUID[Compendium.ptr2e.core-moves.e55bzYPcP88YLxce]{Malicious Moonsault}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "a0pXyyVIWtB6ZSLS",
+  "img": "systems/ptr2e/img/item-icons/Dream_Incinium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759680172703,
+    "modifiedTime": 1759680243495,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/kommonium-z.json
+++ b/packs/core-gear/kommonium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Kommonium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "kommo-o"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.qfjAigi9m2LsgFzf]{Kommo-O} user to use @UUID[Compendium.ptr2e.core-moves.8oRKjmSuk6rgXg7e]{Clangorous Soulblaze}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "yzV5ySx4Tnf6wzpL",
+  "img": "systems/ptr2e/img/item-icons/Kommonium_Z_artwork.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759680261479,
+    "modifiedTime": 1759680325846,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/lasso-orb.json
+++ b/packs/core-gear/lasso-orb.json
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
@@ -30,7 +35,7 @@
       "held",
       "fling"
     ],
-    "description": "All allies of the target on the Floor are teleported to the target. The target and its allies gain @Affliction[bound] 5.",
+    "description": "<p>All allies of the target on the Floor are teleported to the target. The target and its allies gain @Affliction[bound] 5. This can be broken out of with a -30 Lift Check or  -10 Thaumaturgy check.</p>",
     "quantity": 1,
     "slug": "lasso-orb",
     "stack": 1,
@@ -42,8 +47,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": []
   },
   "_id": "j4ovHYdNWAAAHvHM",
   "effects": [],

--- a/packs/core-gear/lunalium-z.json
+++ b/packs/core-gear/lunalium-z.json
@@ -1,0 +1,84 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Lunalium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "lunala",
+      "legendary",
+      "necrozma"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.hpsUcuamiebvodm7]{Lunala} or @UUID[Compendium.ptr2e.core-species.MQhx5vJC024bSmD5]{Necrozma} user to use @UUID[Compendium.ptr2e.core-moves.AgMQAxU9bUQjCVO6]{Menacing Moonraze Maelstrom}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "S",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "g33cgDzooBPxsthx",
+  "img": "systems/ptr2e/img/item-icons/Ultra_Sun_Ultra_Moon_Lunalium_Z.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759680345679,
+    "modifiedTime": 1759681296685,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/lycanium-z.json
+++ b/packs/core-gear/lycanium-z.json
@@ -1,0 +1,80 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Lycanium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "lycanroc"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a Lycanroc (any form) user to use @UUID[Compendium.ptr2e.core-moves.arnnhoFXG3WGE9cW]{Splintered Stormshards}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "eI4Bhbz46umiqVM6",
+  "img": "systems/ptr2e/img/item-icons/Lycanium_Z_artwork.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759680465001,
+    "modifiedTime": 1759680538239,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/marshadium-z.json
+++ b/packs/core-gear/marshadium-z.json
@@ -1,0 +1,83 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Marshadium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "marshadow",
+      "legendary"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.MKxiHySaICGSkNtN]{Marshadow} user to use @UUID[Compendium.ptr2e.core-moves.t7W4SjYwc260Pnz8]{Soul-Stealing 7-Star Strike}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "NouOTmKzCGEZpxVz",
+  "img": "systems/ptr2e/img/item-icons/Dream_Marshadium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759680568737,
+    "modifiedTime": 1759680647604,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/mewnium-z.json
+++ b/packs/core-gear/mewnium-z.json
@@ -1,0 +1,83 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Mewnium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "mew",
+      "legendary"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.2uS0hQKnIRRFc7da]{Mew} user to use @UUID[Compendium.ptr2e.core-moves.QoaABhSyDya7Kyo4]{Genesis Supernova}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "SoH2wciLnjv9cmj6",
+  "img": "systems/ptr2e/img/item-icons/Dream_Mewnium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759680668607,
+    "modifiedTime": 1759680727527,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/mimikium-z.json
+++ b/packs/core-gear/mimikium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Mimikium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "mimikyu"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.DETGbLSVmqOkgjuS]{Mimikyu} user to use @UUID[Compendium.ptr2e.core-moves.mA0SLZHiOeAgX9fa]{Let's Snuggle Forever}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "uYQBUeJjzMljY7Kr",
+  "img": "systems/ptr2e/img/item-icons/Mimikium_Z_artwork.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759680744162,
+    "modifiedTime": 1759680862412,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/normalium-z.json
+++ b/packs/core-gear/normalium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Normalium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "normal"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.bouXpPaFHB9PIChX]{Breakneck Blitz}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "THga6a1QGmzz2NQC",
+  "img": "systems/ptr2e/img/item-icons/Dream_Normalium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679388356,
+    "modifiedTime": 1759679429860,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/pikanium-z.json
+++ b/packs/core-gear/pikanium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Pikanium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "pikachu"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.MAv2rjhIQxHSBtaS]{Pikachu} user to use @UUID[Compendium.ptr2e.core-moves.ui0FcmgZ0hxCSZCO]{Catastropika}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "zh9IFqzRorBSsLKp",
+  "img": "systems/ptr2e/img/item-icons/Dream_Pikanium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759680878474,
+    "modifiedTime": 1759681004497,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/pikashunium-z.json
+++ b/packs/core-gear/pikashunium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Pikashunium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "pikachu"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.MAv2rjhIQxHSBtaS]{Pikachu} user to use @UUID[Compendium.ptr2e.core-moves.B7VMNV4TBnipzq6W]{10,000,000 Volt Thunderbolt}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "b8HLtp6VTJpcofrC",
+  "img": "systems/ptr2e/img/item-icons/Pikashunium_Z_artwork.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759681016900,
+    "modifiedTime": 1759681095154,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/poisonium-z.json
+++ b/packs/core-gear/poisonium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Poisonium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "poison"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.sa3BXQkz6DnQXTYW]{Acid Downpour}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "JkakZjPxpqSiG0I5",
+  "img": "systems/ptr2e/img/item-icons/Dream_Poisonium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679443777,
+    "modifiedTime": 1759679519308,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/primarium-z.json
+++ b/packs/core-gear/primarium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Primarium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "primarina"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.gWO2o4myQ9NAlR4Y]{Primarina} user to use @UUID[Compendium.ptr2e.core-moves.QlvmbOkzMwys6B7v]{Oceanic Operetta}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "Hv7DcjgR66MCHofg",
+  "img": "systems/ptr2e/img/item-icons/Dream_Primarium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759681108811,
+    "modifiedTime": 1759681169177,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/psychium-z.json
+++ b/packs/core-gear/psychium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Psychium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "psychic"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.6O8J8tV8HLrdH1tP]{Shattered Psyche}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "dOqPEeDFIEH71yNB",
+  "img": "systems/ptr2e/img/item-icons/Dream_Psychium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679542136,
+    "modifiedTime": 1759679590029,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/rockium-z.json
+++ b/packs/core-gear/rockium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Rockium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "rock"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.KrdS6QktcRdJaWVZ]{Continental Crush}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "m8QnpIdXsZcZnvq2",
+  "img": "systems/ptr2e/img/item-icons/Dream_Rockium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679604605,
+    "modifiedTime": 1759679648021,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/snorlium-z.json
+++ b/packs/core-gear/snorlium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Snorlium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "snorlax"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.dT1OJHNewsT7XKpm]{Snorlax} to use @UUID[Compendium.ptr2e.core-moves.cx9q7nGDUItDoZd9]{Pulverizing Pancake}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "aCcZD3cbae3omREn",
+  "img": "systems/ptr2e/img/item-icons/Dream_Snorlium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759681188174,
+    "modifiedTime": 1759681236559,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/solganium-z.json
+++ b/packs/core-gear/solganium-z.json
@@ -1,0 +1,84 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Solganium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "solgaleo",
+      "necrozma",
+      "legendary"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.KCaLP0tjvwK3Fqjs]{Solgaleo} or @UUID[Compendium.ptr2e.core-species.MQhx5vJC024bSmD5]{Necrozma} user to use @UUID[Compendium.ptr2e.core-moves.dYMCAbnAPDc75PiZ]{Searing Sunraze Smash}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "UakTFf49tmqo8PbK",
+  "img": "systems/ptr2e/img/item-icons/Ultra_Sun_Ultra_Moon_Solganium_Z.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759681269805,
+    "modifiedTime": 1759681379875,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/steelium-z.json
+++ b/packs/core-gear/steelium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Steelium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "steel"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.BxxoEwKgAE00h93e]{Corkscrew Crash}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "oGuI05JOv8oRHE6P",
+  "img": "systems/ptr2e/img/item-icons/Dream_Steelium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679664856,
+    "modifiedTime": 1759679712098,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/tapunium-z.json
+++ b/packs/core-gear/tapunium-z.json
@@ -1,0 +1,81 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Tapunium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "legendary",
+      "1000-handed"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.ifWtcVCDjPuihV22]{Tapu-Bulu}, @UUID[Compendium.ptr2e.core-species.Zpd5t9MeOHI40FkG]{Tapu-Koko}, @UUID[Compendium.ptr2e.core-species.qnWjGnHPagUH74mh]{Tapu-Lele} or @UUID[Compendium.ptr2e.core-species.LVqJm1vADguOfMjf]{Tapu-Fini} user to use @UUID[Compendium.ptr2e.core-moves.M4FWMgoYfsXcskD0]{Guardian of Alola}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "DsKKzLnDn3rmlwtR",
+  "img": "systems/ptr2e/img/item-icons/Dream_Tapunium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759681400101,
+    "modifiedTime": 1759681541259,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/ultranecrozmium-z.json
+++ b/packs/core-gear/ultranecrozmium-z.json
@@ -1,0 +1,83 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Ultranecrozmium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "ultra",
+      "necrozma"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows a @UUID[Compendium.ptr2e.core-species.MQhx5vJC024bSmD5]{Necrozma} user to use @UUID[Compendium.ptr2e.core-moves.lHPuYUfaERFAG3Ln]{Light that Burn the Sky}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "S",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "dh0uh5gVEZkggW9H",
+  "img": "systems/ptr2e/img/item-icons/Ultra_Sun_Ultra_Moon_Ultranecrozium_Z.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759681597143,
+    "modifiedTime": 1759681713545,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-gear/waterium-z.json
+++ b/packs/core-gear/waterium-z.json
@@ -1,0 +1,82 @@
+{
+  "folder": "Nyv6uTBBdpzjWA2Z",
+  "name": "Waterium-Z",
+  "type": "equipment",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": null,
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "combat",
+      "accessory",
+      "zenith",
+      "phenomenon",
+      "water"
+    ],
+    "actions": [],
+    "description": "<p>Effect: Allows the user to use @UUID[Compendium.ptr2e.core-moves.UtC6ziCa1j37uNKK]{Hydro Vortex}.</p>",
+    "container": null,
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "accessory",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "untyped",
+      "power": null,
+      "accuracy": 100,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "pJz2ssfjRa2RqfmC",
+  "img": "systems/ptr2e/img/item-icons/Dream_Waterium_Z_Sprite.png",
+  "effects": [],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mK35yvCqCgiTUvKf": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.350",
+    "systemId": "ptr2e",
+    "systemVersion": "1.4.6.beta",
+    "createdTime": 1759679724664,
+    "modifiedTime": 1759679772444,
+    "lastModifiedBy": "mK35yvCqCgiTUvKf"
+  }
+}

--- a/packs/core-moves/splintered-stormshards.json
+++ b/packs/core-moves/splintered-stormshards.json
@@ -1,0 +1,55 @@
+{
+  "name": "Splintered Stormshards",
+  "type": "move",
+  "img": "systems/ptr2e/img/svg/rock_icon.svg",
+  "system": {
+    "slug": "spintered-stormshards",
+    "actions": [
+      {
+        "slug": "spintered-stormshards",
+        "name": "Spintered Stormshards",
+        "type": "attack",
+        "traits": [
+          "zenith",
+          "move-locked",
+          "missile",
+          "crit-1"
+        ],
+        "range": {
+          "target": "cone",
+          "distance": 7,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "trigger": "<p>User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p>"
+        },
+        "category": "physical",
+        "power": 190,
+        "accuracy": 100,
+        "types": [
+          "rock"
+        ],
+        "description": "<p>Trigger: User's partner uses Z-Pose! and triggers the appropriate Z-Power-Crystal.</p><p>Effect: All [Terrain] effects on the Field are cleared.</p><p>Requirement: [Lycanroc] Z-Power-Crystal as an Accessory Item and Stone Edge on the user's Active List.</p>",
+        "free": true,
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
+      }
+    ],
+    "grade": "S",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
+    }
+  },
+  "_id": "arnnhoFXG3WGE9cW",
+  "effects": []
+}


### PR DESCRIPTION
Adds individual Z-Crystals to the compendium.
- Update Consumable: Lasso Orb
- Update Consumable: Adrenaline Orb
- Update Move: Splintered Stormshards
- Create Equipment: Aloraichium-Z
- Create Equipment: Buginium-Z
- Create Equipment: Darkinium-Z
- Create Equipment: Decidium-Z
- Create Equipment: Dragonium-Z
- Create Equipment: Eevium-Z
- Create Equipment: Electrium-Z
- Create Equipment: Fairium-Z
- Create Equipment: Fightinium-Z
- Create Equipment: Firium-Z
- Create Equipment: Flyinium-Z
- Create Equipment: Ghostium-Z
- Create Equipment: Grassium-Z
- Create Equipment: Groundium-Z
- Create Equipment: Icium-Z
- Create Equipment: Incinium-Z
- Create Equipment: Kommonium-Z
- Create Equipment: Lunalium-Z
- Create Equipment: Lycanium-Z
- Create Equipment: Marshadium-Z
- Create Equipment: Mewnium-Z
- Create Equipment: Mimikium-Z
- Create Equipment: Normalium-Z
- Create Equipment: Pikanium-Z
- Create Equipment: Pikashunium-Z
- Create Equipment: Poisonium-Z
- Create Equipment: Primarium-Z
- Create Equipment: Psychium-Z
- Create Equipment: Rockium-Z
- Create Equipment: Snorlium-Z
- Create Equipment: Solganium-Z
- Create Equipment: Steelium-Z
- Create Equipment: Tapunium-Z
- Create Equipment: Ultranecrozmium-Z
- Create Equipment: Waterium-Z