### PR TITLE
Foundry Data Sync - Pester Balls + Curveball Technique Rework

### DIFF
--- a/packs/core-gear/pester-ball-burn.json
+++ b/packs/core-gear/pester-ball-burn.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Burn)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.burnconditioitem]{Burn 5} on hit.<br><br>Must be on the Belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Burn)",
+      "type": "passive",
+      "_id": "CAFgsE9dmufDYWlP",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-burn-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.burnconditioitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "2yZO8Qriy8EINLfW"
+}

--- a/packs/core-gear/pester-ball-charmed.json
+++ b/packs/core-gear/pester-ball-charmed.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Charmed)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 100,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.charmedcondiitem]{Charmed 5} on hit.<br><br>Must be on the Belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Charmed)",
+      "type": "passive",
+      "_id": "evPRk5CsPhyXKV6I",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-charmed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.charmedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "uGzsmkmiPsDC58b0"
+}

--- a/packs/core-gear/pester-ball-confused.json
+++ b/packs/core-gear/pester-ball-confused.json
@@ -1,0 +1,112 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Confused)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.confusedconditem]{Confused 5} on hit.<br><br>Must be on the Belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Confused)",
+      "type": "passive",
+      "_id": "XXxU6LLKwZDU89Ar",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-confused-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "VSzF4zGoM1yokVpE"
+}

--- a/packs/core-gear/pester-ball-drowsy.json
+++ b/packs/core-gear/pester-ball-drowsy.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Drowsy)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.drowsycondititem]{Drowsy 5} on hit.<br><br>Must be on the belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Drowsy)",
+      "type": "passive",
+      "_id": "TljQ4WEQQvPd5NBw",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-drowsy-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.drowsycondititem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "AAVsI6kLqeKzSMHR"
+}

--- a/packs/core-gear/pester-ball-enraged.json
+++ b/packs/core-gear/pester-ball-enraged.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Enraged)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.enragedcondiitem]{Enraged 5} on hit.<br><br>Must be on the Belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Enraged)",
+      "type": "passive",
+      "_id": "lDMwhsmUPvhbGHbV",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-enraged-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.enragedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "dkYi9H2CBXoHBa2I"
+}

--- a/packs/core-gear/pester-ball-fear.json
+++ b/packs/core-gear/pester-ball-fear.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Fear)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.fearconditioitem]{Fear 5} on hit.<br><br>Must be on the Belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Fear)",
+      "type": "passive",
+      "_id": "TlqLa3QkzOWeaSnw",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-fear-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.fearconditioitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "YUUapwR8N88C6K6V"
+}

--- a/packs/core-gear/pester-ball-frostbite.json
+++ b/packs/core-gear/pester-ball-frostbite.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Frostbite)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.frostbiteconitem]{Frostbite 5} on hit.<br><br>Must be on the Belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Frostbite)",
+      "type": "passive",
+      "_id": "QEjg6UVNZmaRVPcB",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-frostbite-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.frostbiteconitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "SpRtKdyhGauixKWc"
+}

--- a/packs/core-gear/pester-ball-gagged.json
+++ b/packs/core-gear/pester-ball-gagged.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Gagged)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.V8CNzN148X1bYsSS]{Gagged 5} on hit.<br><br>Must be on the Belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Gagged)",
+      "type": "passive",
+      "_id": "aJSExgYNTDqMb2K2",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-gagged-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.V8CNzN148X1bYsSS",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "ejUwmIVz0wpzoYcf"
+}

--- a/packs/core-gear/pester-ball-grounded.json
+++ b/packs/core-gear/pester-ball-grounded.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Grounded)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.groundedconditem]{Grounded 5} on hit.<br><br>Must be on the Belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Grounded)",
+      "type": "passive",
+      "_id": "tuojWS3hVnXOtHe2",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-grounded-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.groundedconditem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "EwCNVHf5NkuQ5c2K"
+}

--- a/packs/core-gear/pester-ball-infested.json
+++ b/packs/core-gear/pester-ball-infested.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Infested)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.infestedconditem]{Infested 5} on hit.<br><br>Must be on the Belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Infested)",
+      "type": "passive",
+      "_id": "s6GDxnUGvkCoK5J5",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-infested-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.infestedconditem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "UFpjnnkrtYBy9g7R"
+}

--- a/packs/core-gear/pester-ball-paralysis.json
+++ b/packs/core-gear/pester-ball-paralysis.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Paralysis)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.paralysisconitem]{Paralysis 5} on hit.<br><br>Must be on the Belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Paralysis)",
+      "type": "passive",
+      "_id": "IG1lm19YEEOpxyvg",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-paralysis-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.paralysisconitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "aR5KmCS2urQW8Uft"
+}

--- a/packs/core-gear/pester-ball-poison.json
+++ b/packs/core-gear/pester-ball-poison.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Poison)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.poisoncondititem]{Poison 5} on hit.<br><br>Must be on the Belt for automation to function correctly.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Poison)",
+      "type": "passive",
+      "_id": "gwZCiCZOF6I1IoRM",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-poison-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.poisoncondititem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "xnZdZL823A5YmaxC"
+}

--- a/packs/core-gear/pester-ball-powder.json
+++ b/packs/core-gear/pester-ball-powder.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Powder)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This type of Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.NUba7VJbIYn7MpEh]{Powder} on hit.<br><br>Must be on the Belt for automation to function.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Powder)",
+      "type": "passive",
+      "_id": "9WM6DwRp9Ml2tv1F",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-powder-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.NUba7VJbIYn7MpEh",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "gGoOQ0TeRF6TDpsj"
+}

--- a/packs/core-gear/pester-ball-slow.json
+++ b/packs/core-gear/pester-ball-slow.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Slow)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.slowedcondititem]{Slowed 5} on hit.<br><br>Must be on the Belt for the automation to function.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Slow)",
+      "type": "passive",
+      "_id": "SFNUKfamzWWQ90P0",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-slow-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.slowedcondititem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "BNjs72NKLN9GjTyk"
+}

--- a/packs/core-gear/pester-ball-stunted.json
+++ b/packs/core-gear/pester-ball-stunted.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Stunted)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.stuntedcondiitem]{Stunted 5} on hit.<br><br>Must be on the Belt for the automation to function.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Stunted)",
+      "type": "passive",
+      "_id": "o7VgCLsAaAeg74vP",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-stunted-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.stuntedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "UZWQqsxAKDvCbq3W"
+}

--- a/packs/core-gear/pester-ball-suppressed.json
+++ b/packs/core-gear/pester-ball-suppressed.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Suppressed)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 100,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.suppressedcoitem]{Suppressed 5} on hit.<br><br>Must be on the Belt for automation to function.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Suppressed)",
+      "type": "passive",
+      "_id": "px5sglk8vXy0YGqp",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-suppressed-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.suppressedcoitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "g3sPCLllI23yMP6n"
+}

--- a/packs/core-gear/pester-ball-taunted.json
+++ b/packs/core-gear/pester-ball-taunted.json
@@ -1,0 +1,114 @@
+{
+  "folder": "V4skAU6G3OH5fXab",
+  "name": "Pester Ball (Taunted)",
+  "type": "consumable",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "actions": [],
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "belt",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 40,
+      "accuracy": 95,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This item is used through the Fling action.<br><br>This Pester Ball inflicts @UUID[Compendium.ptr2e.core-effects.tauntedcondiitem]{Taunted 5} on hit.<br><br>Must be on the Belt for the automation to work.</p>",
+    "traits": [
+      "belt",
+      "fling",
+      "concoction",
+      "ball",
+      "consumable"
+    ],
+    "consumableType": "other",
+    "stack": 5,
+    "cost": 3
+  },
+  "img": "systems/ptr2e/img/item-icons/pester%20ball.webp",
+  "effects": [
+    {
+      "name": "Pester Ball (Taunted)",
+      "type": "passive",
+      "_id": "oEk9iduRco29CZEe",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "fling-pester-ball-taunted-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.tauntedcondiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "7Jx6R0lri6gFfE3H"
+}

--- a/packs/core-perks/curveball-technique.json
+++ b/packs/core-perks/curveball-technique.json
@@ -4,71 +4,12 @@
   "system": {
     "prerequisites": [],
     "cost": 1,
-    "description": "<p>When using Fling with a [PokeBall] item, you may choose to set the Fling's base Power to 40.</p>",
-    "actions": [
-      {
-        "name": "Curveball Technique",
-        "slug": "curveball-technique",
-        "description": "<p>When using Fling with a [PokeBall] item, you may choose to set the Fling's base Power to 40.</p>",
-        "cost": {
-          "activation": "free",
-          "powerPoints": 0
-        },
-        "type": "passive",
-        "traits": [],
-        "img": "icons/svg/explosion.svg",
-        "range": {
-          "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false,
-        "hidden": false
-      },
-      {
-        "slug": "fling-curveball",
-        "name": "Fling (Curveball)",
-        "type": "attack",
-        "traits": [
-          "adaptable",
-          "basic",
-          "fling",
-          "pp-updated"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 10,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 0
-        },
-        "category": "physical",
-        "power": 40,
-        "accuracy": 95,
-        "types": [
-          "untyped"
-        ],
-        "description": "<p>Effect: The Type, Power, Accuracy, and Range of this attack are modified by the Fling stats of the utilized item. When using Fling utilizing a Held creature, Fling's Power and Accuracy are as follows:</p><blockquote><p>Power = 20 + (userLift / 4) + (thrownWC * 3)<br>Accuracy = 75 + (userLift / 5) + userCatMod - (4 * thrownCatMod)<br>Range = 8 + (userLift / 6) + userCatMod - (2* thrownCatMod)</p></blockquote>",
-        "free": true,
-        "img": "systems/ptr2e/img/svg/untyped_icon.svg",
-        "predicate": [],
-        "variant": null,
-        "ephemeralVariant": false,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": "",
-        "offensiveStat": null,
-        "defensiveStat": null
-      }
-    ],
+    "description": "<p>Passive: When using Fling with a [Ball] item, you increase the power of the attack by +15. This perk allows poke balls to deal damage.</p>",
+    "actions": [],
     "slug": "curveball-technique",
-    "traits": [],
+    "traits": [
+      "capture-specialist"
+    ],
     "_migration": {
       "version": null,
       "previous": null
@@ -90,13 +31,10 @@
           "lethal-restraint"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#8080ff",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Capture%20Spec.svg",
-          "tint": null,
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
         "tier": null
       }
@@ -115,13 +53,64 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "_id": "XOggUhl7hxBP9PHa",
   "img": "systems/ptr2e/img/perk-icons/Capture%20Spec.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Curveball Technique",
+      "type": "passive",
+      "_id": "fZWzk0UvtbVhsnNo",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "ball-trait-attack-power",
+            "value": 15,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "createdTime": 1759921694150,
+        "modifiedTime": 1759921714386,
+        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      }
+    }
+  ],
   "folder": "ADL1Oc2oQaQK45IU"
 }


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Perk: Curveball Technique
- Update Consumable: Pester Ball (Burn)
- Update Consumable: Pester Ball (Charmed)
- Update Consumable: Pester Ball (Confused)
- Update Consumable: Pester Ball (Drowsy)
- Update Consumable: Pester Ball (Enraged)
- Update Consumable: Pester Ball (Fear)
- Update Consumable: Pester Ball (Frostbite)
- Update Consumable: Pester Ball (Gagged)
- Update Consumable: Pester Ball (Grounded)
- Update Consumable: Pester Ball (Infested)
- Update Consumable: Pester Ball (Paralysis)
- Update Consumable: Pester Ball (Poison)
- Update Consumable: Pester Ball (Powder)
- Update Consumable: Pester Ball (Slow)
- Update Consumable: Pester Ball (Stunted)
- Update Consumable: Pester Ball (Suppressed)
- Update Consumable: Pester Ball (Taunted)