### PR TITLE
Foundry Data Sync - Equipment Image Tweaks + Folder Reshuffles

### DIFF
--- a/packs/core-gear/black-sludge.json
+++ b/packs/core-gear/black-sludge.json
@@ -39,7 +39,8 @@
         ],
         "range": {
           "target": "creature",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "cost": {
           "activation": "complex"
@@ -73,5 +74,5 @@
   },
   "_id": "3gkmbLFDhHHyJ9yU",
   "effects": [],
-  "folder": "ZJQbcaoYaa7A40WO"
+  "folder": "6VDJBcrqVDh5bYtA"
 }

--- a/packs/core-gear/breastplate.json
+++ b/packs/core-gear/breastplate.json
@@ -57,7 +57,7 @@
       }
     }
   },
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "icons/equipment/chest/breastplate-collared-steel.webp",
   "effects": [
     {
       "name": "Breastplate",
@@ -193,13 +193,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "lastModifiedBy": null
       }
     }
   ],
-  "flags": {},
   "_id": "WF8cwW8lYe7Lg45j"
 }

--- a/packs/core-gear/buckler-shield.json
+++ b/packs/core-gear/buckler-shield.json
@@ -26,7 +26,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "common",
@@ -43,10 +48,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "wEHg9Z8FCj2x5k7e",
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "icons/equipment/shield/buckler-wooden-boss-brown.webp",
   "effects": []
 }

--- a/packs/core-gear/chitin-breastplate.json
+++ b/packs/core-gear/chitin-breastplate.json
@@ -26,7 +26,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "uncommon",
@@ -43,11 +48,12 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "Yx30uqsUHq25S2Wq",
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "icons/equipment/chest/breastplate-sculpted-grey.webp",
   "effects": [
     {
       "name": "Chitin Breastplate",
@@ -88,7 +94,9 @@
         "traits": [],
         "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -110,12 +118,13 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.2.1.6",
         "createdTime": 1724253302338,
         "modifiedTime": 1724253355814,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "exportSource": null
       }
     }
   ]

--- a/packs/core-gear/cotton-down-padded-armour.json
+++ b/packs/core-gear/cotton-down-padded-armour.json
@@ -26,7 +26,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "common",
@@ -43,11 +48,12 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "pxQSNHfKTGUSOmYM",
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "icons/equipment/chest/coat-collared-studded-red.webp",
   "effects": [
     {
       "name": "Cotton Down Padded Armour",
@@ -70,7 +76,9 @@
         "traits": [],
         "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -92,12 +100,13 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.2.1.6",
         "createdTime": 1724252301104,
         "modifiedTime": 1724252796805,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "exportSource": null
       }
     }
   ]

--- a/packs/core-gear/dubious-disc.json
+++ b/packs/core-gear/dubious-disc.json
@@ -1,5 +1,5 @@
 {
-  "folder": "6VDJBcrqVDh5bYtA",
+  "folder": "V4skAU6G3OH5fXae",
   "name": "Dubious Disc",
   "type": "equipment",
   "system": {
@@ -34,7 +34,12 @@
       "type": "normal",
       "power": 70,
       "accuracy": 100,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "rare",
@@ -51,10 +56,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/dubious%20disk.webp",
   "effects": [
     {
       "name": "Type Booster (Normal)",
@@ -90,7 +96,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -112,12 +120,13 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "1.0.3.beta",
         "createdTime": null,
         "modifiedTime": null,
-        "lastModifiedBy": null
+        "lastModifiedBy": null,
+        "exportSource": null
       }
     }
   ],

--- a/packs/core-gear/leather-armour.json
+++ b/packs/core-gear/leather-armour.json
@@ -26,7 +26,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "common",
@@ -43,11 +48,12 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "7BY2h7qLsQITfXNH",
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "icons/equipment/chest/breastplate-layered-leather-brown-silver.webp",
   "effects": [
     {
       "name": "Leather Armour",
@@ -70,7 +76,9 @@
         "traits": [],
         "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -92,12 +100,13 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.2.1.6",
         "createdTime": 1724252893363,
         "modifiedTime": 1724252990858,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "exportSource": null
       }
     }
   ]

--- a/packs/core-gear/lucky-punch.json
+++ b/packs/core-gear/lucky-punch.json
@@ -37,7 +37,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "rare",
@@ -51,7 +56,7 @@
       }
     }
   },
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/lucky%20punch.webp",
   "effects": [
     {
       "name": "Lucky Punch",
@@ -106,7 +111,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758376216132,

--- a/packs/core-gear/oval-stone.json
+++ b/packs/core-gear/oval-stone.json
@@ -1,5 +1,5 @@
 {
-  "folder": "6VDJBcrqVDh5bYtA",
+  "folder": "V4skAU6G3OH5fXae",
   "name": "Oval Stone",
   "type": "equipment",
   "system": {
@@ -34,7 +34,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "rare",
@@ -51,10 +56,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/oval%20stone.webp",
   "effects": [
     {
       "name": "Type Booster (Normal)",
@@ -90,7 +96,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -112,12 +120,13 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "1.0.3.beta",
         "createdTime": null,
         "modifiedTime": null,
-        "lastModifiedBy": null
+        "lastModifiedBy": null,
+        "exportSource": null
       }
     }
   ],

--- a/packs/core-gear/plate-armour.json
+++ b/packs/core-gear/plate-armour.json
@@ -26,7 +26,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "rare",
@@ -43,11 +48,12 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "U40afTGvwz4kzAXJ",
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "icons/equipment/chest/breastplate-layered-gilded-orange.webp",
   "effects": [
     {
       "name": "Plate Armour",
@@ -88,7 +94,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -110,12 +118,13 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.2.1.6",
         "createdTime": 1724253432798,
         "modifiedTime": 1724253478394,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "exportSource": null
       }
     }
   ]

--- a/packs/core-gear/prison-bottle.json
+++ b/packs/core-gear/prison-bottle.json
@@ -77,5 +77,5 @@
   },
   "_id": "BTl38IL09UA64VQR",
   "effects": [],
-  "folder": "ZJQbcaoYaa7A40WO"
+  "folder": "6VDJBcrqVDh5bYtA"
 }

--- a/packs/core-gear/protector.json
+++ b/packs/core-gear/protector.json
@@ -1,5 +1,5 @@
 {
-  "folder": "6VDJBcrqVDh5bYtA",
+  "folder": "V4skAU6G3OH5fXae",
   "name": "Protector",
   "type": "equipment",
   "system": {
@@ -33,7 +33,12 @@
       "type": "rock",
       "power": 70,
       "accuracy": 100,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "rare",
@@ -50,10 +55,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/protector.webp",
   "effects": [
     {
       "name": "Type Booster (Rock)",
@@ -89,7 +95,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -111,12 +119,13 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "1.0.3.beta",
         "createdTime": null,
         "modifiedTime": null,
-        "lastModifiedBy": null
+        "lastModifiedBy": null,
+        "exportSource": null
       }
     }
   ],

--- a/packs/core-gear/reveal-glass.json
+++ b/packs/core-gear/reveal-glass.json
@@ -83,5 +83,5 @@
   },
   "_id": "n21Z7NfgrYrQdg9z",
   "effects": [],
-  "folder": "ZJQbcaoYaa7A40WO"
+  "folder": "V4skAU6G3OH5fXad"
 }

--- a/packs/core-gear/robes-of-thaumaturgy.json
+++ b/packs/core-gear/robes-of-thaumaturgy.json
@@ -33,7 +33,12 @@
       "type": "untyped",
       "power": 50,
       "accuracy": 100,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "rare",
@@ -51,10 +56,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "icons/equipment/chest/robe-layered-red.webp",
   "effects": [
     {
       "name": "Robes of Thaumaturgy",
@@ -83,7 +89,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -105,12 +113,13 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.5.1.5",
         "createdTime": null,
         "modifiedTime": null,
-        "lastModifiedBy": null
+        "lastModifiedBy": null,
+        "exportSource": null
       }
     }
   ],

--- a/packs/core-gear/room-service.json
+++ b/packs/core-gear/room-service.json
@@ -124,7 +124,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "1.4.2.beta",
         "createdTime": 1754781149015,
@@ -133,5 +133,5 @@
       }
     }
   ],
-  "folder": "PGpYU7mfnRpzOZSm"
+  "folder": "6VDJBcrqVDh5bYtA"
 }

--- a/packs/core-gear/scale-mail.json
+++ b/packs/core-gear/scale-mail.json
@@ -26,7 +26,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "uncommon",
@@ -43,11 +48,12 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "WrHoB2iSdeZnYTh9",
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "icons/equipment/chest/breastplate-metal-scaled-grey.webp",
   "effects": [
     {
       "name": "Scale Mail",
@@ -88,7 +94,9 @@
         "traits": [],
         "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -110,12 +118,13 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.2.1.6",
         "createdTime": 1724252978292,
         "modifiedTime": 1724253039402,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "exportSource": null
       }
     }
   ]

--- a/packs/core-gear/soothe-bell.json
+++ b/packs/core-gear/soothe-bell.json
@@ -32,7 +32,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "common",
@@ -46,9 +51,8 @@
       }
     }
   },
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/soothe%20bell.webp",
   "effects": [],
   "folder": "6VDJBcrqVDh5bYtA",
-  "flags": {},
   "_id": "xVS4t6HCW4v8PoCq"
 }

--- a/packs/core-gear/up-grade.json
+++ b/packs/core-gear/up-grade.json
@@ -1,5 +1,5 @@
 {
-  "folder": "6VDJBcrqVDh5bYtA",
+  "folder": "V4skAU6G3OH5fXae",
   "name": "Up-Grade",
   "type": "equipment",
   "system": {
@@ -34,7 +34,12 @@
       "type": "normal",
       "power": 55,
       "accuracy": 100,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "rare",
@@ -51,10 +56,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/up-grade.webp",
   "effects": [
     {
       "name": "Type Booster (Normal)",
@@ -90,7 +96,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -112,12 +120,13 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "1.0.3.beta",
         "createdTime": null,
         "modifiedTime": null,
-        "lastModifiedBy": null
+        "lastModifiedBy": null,
+        "exportSource": null
       }
     }
   ],

--- a/packs/core-gear/whipped-dream.json
+++ b/packs/core-gear/whipped-dream.json
@@ -1,5 +1,5 @@
 {
-  "folder": "6VDJBcrqVDh5bYtA",
+  "folder": "V4skAU6G3OH5fXae",
   "name": "Whipped Dream",
   "type": "equipment",
   "system": {
@@ -26,7 +26,12 @@
       "type": "fairy",
       "power": 70,
       "accuracy": 100,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "rare",
@@ -43,10 +48,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/whipped%20dream.webp",
   "effects": [
     {
       "name": "Type Booster (Fairy)",
@@ -82,7 +88,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -104,12 +112,13 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.JhU4x5wZQlVuqvfz.ActiveEffect.pMVRnjGSvrhLNVtr",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "1.0.3.beta",
         "createdTime": null,
         "modifiedTime": null,
-        "lastModifiedBy": null
+        "lastModifiedBy": null,
+        "exportSource": null
       }
     }
   ],

--- a/packs/core-gear/wise-glasses.json
+++ b/packs/core-gear/wise-glasses.json
@@ -2,7 +2,7 @@
   "name": "Wise Glasses",
   "_id": "JhU4x5wZQlVuqvfd",
   "folder": "6VDJBcrqVDh5bYtA",
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/sunglasses.webp",
   "type": "equipment",
   "system": {
     "crafting": {
@@ -20,7 +20,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "traits": [
@@ -38,7 +43,8 @@
         ],
         "range": {
           "target": "creature",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "cost": {
           "activation": "complex"
@@ -69,7 +75,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "effects": [
@@ -96,7 +103,9 @@
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -118,21 +127,14 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.329",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.2.0.3",
         "createdTime": null,
         "modifiedTime": null,
-        "lastModifiedBy": null
+        "lastModifiedBy": null,
+        "exportSource": null
       }
     }
-  ],
-  "flags": {
-    "exportSource": {
-      "world": "pokemon-mystery-dungeon-shrouded-kingdoms",
-      "system": "ptr2e",
-      "coreVersion": "12.330",
-      "systemVersion": "0.10.0-alpha.2.0.3"
-    }
-  }
+  ]
 }

--- a/packs/core-gear/wooloo-gambeson.json
+++ b/packs/core-gear/wooloo-gambeson.json
@@ -8,7 +8,11 @@
       "previous": null
     },
     "slug": "wooloo-gambeson",
-    "traits": [],
+    "traits": [
+      "armour",
+      "fantasy",
+      "worn"
+    ],
     "actions": [],
     "crafting": {
       "skill": "",
@@ -25,7 +29,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": null
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "common",
@@ -43,11 +52,12 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "2hB9vPRT02DQf8OE",
-  "img": "systems/ptr2e/img/icons/equipment_icon.webp",
+  "img": "icons/equipment/chest/breastplate-quilted-brown.webp",
   "effects": [
     {
       "name": "Wooloo Gambeson",
@@ -79,7 +89,9 @@
         "traits": [],
         "removeAfterCombat": false,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -101,12 +113,13 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "13.350",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.2.1.6",
         "createdTime": 1724252719981,
         "modifiedTime": 1724252835697,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
+        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "exportSource": null
       }
     }
   ]


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Equipment: Wooloo Gambeson
- Update Equipment: Black Sludge
- Update Equipment: Reveal Glass
- Update Equipment: Prison Bottle
- Update Equipment: Buckler Shield
- Update Equipment: Dubious Disc
- Update Equipment: Lucky Punch
- Update Equipment: Oval Stone
- Update Equipment: Protector
- Update Equipment: Soothe Bell
- Update Equipment: Up-Grade
- Update Equipment: Whipped Dream
- Update Equipment: Wise Glasses
- Update Equipment: Room Service
- Update Equipment: Chitin Breastplate
- Update Equipment: Cotton Down Padded Armour
- Update Equipment: Leather Armour
- Update Equipment: Plate Armour
- Update Equipment: Robes of Thaumaturgy
- Update Equipment: Scale Mail
- Update Equipment: Breastplate