### PR TITLE
Foundry Data Sync - Vulnerable Effect (19 Type Variants)

### DIFF
--- a/packs/core-effects/vulnerable-bug.json
+++ b/packs/core-effects/vulnerable-bug.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Bug)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[bug] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/bug_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Bug)",
+      "type": "affliction",
+      "_id": "H7p1GKdZdspDZVHn",
+      "img": "systems/ptr2e/img/svg/bug_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "bug-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "faMwJRXfgNsTc6Yk"
+}

--- a/packs/core-effects/vulnerable-dark.json
+++ b/packs/core-effects/vulnerable-dark.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Dark)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[dark] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/dark_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Dark)",
+      "type": "affliction",
+      "_id": "RVit2n5p7pPT1yXj",
+      "img": "systems/ptr2e/img/svg/dark_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "dark-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "26IPhMibQ0lzvAqS"
+}

--- a/packs/core-effects/vulnerable-dragon.json
+++ b/packs/core-effects/vulnerable-dragon.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Dragon)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[dragon] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/dragon_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Dragon)",
+      "type": "affliction",
+      "_id": "u7BoF3zDvxOhd4R7",
+      "img": "systems/ptr2e/img/svg/dragon_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "dragon-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "uUvR309c9UV7myji"
+}

--- a/packs/core-effects/vulnerable-electric.json
+++ b/packs/core-effects/vulnerable-electric.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Electric)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[electric] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/electric_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Electric)",
+      "type": "affliction",
+      "_id": "rxvNWH4Q4J0GADj6",
+      "img": "systems/ptr2e/img/svg/electric_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "electric-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "sq9cnHBPVLDPYnno"
+}

--- a/packs/core-effects/vulnerable-fairy.json
+++ b/packs/core-effects/vulnerable-fairy.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Fairy)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[fairy] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/fairy_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Fairy)",
+      "type": "affliction",
+      "_id": "Q5dSn8lLL5foeumT",
+      "img": "systems/ptr2e/img/svg/fairy_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "fairy-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "ShKXnWCV59pLsMUE"
+}

--- a/packs/core-effects/vulnerable-fighting.json
+++ b/packs/core-effects/vulnerable-fighting.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Fighting)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[fighting] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/fighting_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Fighting)",
+      "type": "affliction",
+      "_id": "WEs5ZQLYrHNs6K34",
+      "img": "systems/ptr2e/img/svg/fighting_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "fighting-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "F6QEYx7CvQHpy2dj"
+}

--- a/packs/core-effects/vulnerable-fire.json
+++ b/packs/core-effects/vulnerable-fire.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Fire)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[fire] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/fire_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Fire)",
+      "type": "affliction",
+      "_id": "yPQbKNJNddD620mq",
+      "img": "systems/ptr2e/img/svg/fire_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "fire-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "I1z28u5ma3IItySu"
+}

--- a/packs/core-effects/vulnerable-flying.json
+++ b/packs/core-effects/vulnerable-flying.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Flying)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[flying] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/flying_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Flying)",
+      "type": "affliction",
+      "_id": "qclGZOTpstuBBFI3",
+      "img": "systems/ptr2e/img/svg/flying_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "flying-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "o814z13dfeo0AqBW"
+}

--- a/packs/core-effects/vulnerable-ghost.json
+++ b/packs/core-effects/vulnerable-ghost.json
@@ -1,0 +1,78 @@
+{
+  "name": "Vulnerable (Ghost)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[ghost] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/ghost_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Ghost)",
+      "type": "affliction",
+      "_id": "FsnUM3Ia6IRPpbTl",
+      "img": "systems/ptr2e/img/svg/ghost_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "ghost-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "Az1Mu3y5PtsWsKV9"
+}

--- a/packs/core-effects/vulnerable-grass.json
+++ b/packs/core-effects/vulnerable-grass.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Grass)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[grass] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/grass_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Grass)",
+      "type": "affliction",
+      "_id": "3zRbqejF4oHvPoLt",
+      "img": "systems/ptr2e/img/svg/grass_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "grass-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "g4RBNTwSnS2LTSnC"
+}

--- a/packs/core-effects/vulnerable-ground.json
+++ b/packs/core-effects/vulnerable-ground.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Ground)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[ground] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/ground_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Ground)",
+      "type": "affliction",
+      "_id": "mAsfEBaCWP6rDbag",
+      "img": "systems/ptr2e/img/svg/ground_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "ground-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "vJicciOdmJ1ww3GN"
+}

--- a/packs/core-effects/vulnerable-ice.json
+++ b/packs/core-effects/vulnerable-ice.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Ice)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[ice] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/ice_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Ice)",
+      "type": "affliction",
+      "_id": "nWAkpOqXcAsNFQMK",
+      "img": "systems/ptr2e/img/svg/ice_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "ice-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "SrEWQMBFscmXdujE"
+}

--- a/packs/core-effects/vulnerable-normal.json
+++ b/packs/core-effects/vulnerable-normal.json
@@ -1,0 +1,81 @@
+{
+  "name": "Vulnerable (Normal)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[normal] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/normal_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Normal)",
+      "type": "affliction",
+      "_id": "0nCdPB4Pg3fnMQZ3",
+      "img": "systems/ptr2e/img/svg/normal_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "normal-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "label": "Vulnerable (Normal)",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "TCF7NhY1D0H76ol2"
+}

--- a/packs/core-effects/vulnerable-nuclear.json
+++ b/packs/core-effects/vulnerable-nuclear.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Nuclear)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[nuclear] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/nuclear_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Nuclear)",
+      "type": "affliction",
+      "_id": "tBp6zHpWsblVkcUF",
+      "img": "systems/ptr2e/img/svg/nuclear_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "nuclear-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "ZdAAHp7YoVjvcjuo"
+}

--- a/packs/core-effects/vulnerable-poison.json
+++ b/packs/core-effects/vulnerable-poison.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Poison)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[poison] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/poison_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Poison)",
+      "type": "affliction",
+      "_id": "wlwQlNDUALrmPWLp",
+      "img": "systems/ptr2e/img/svg/poison_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "poison-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "uaphGf8OFSUg2jZs"
+}

--- a/packs/core-effects/vulnerable-psychic.json
+++ b/packs/core-effects/vulnerable-psychic.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Psychic)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[psychic] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/psychic_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Psychic)",
+      "type": "affliction",
+      "_id": "CFU3zHkupw7y3eJI",
+      "img": "systems/ptr2e/img/svg/psychic_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "psychic-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "QaPWQdhv1nkqwb2R"
+}

--- a/packs/core-effects/vulnerable-rock.json
+++ b/packs/core-effects/vulnerable-rock.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Rock)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[rock] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/rock_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Rock)",
+      "type": "affliction",
+      "_id": "ALnOrSBAx5vXIY8P",
+      "img": "systems/ptr2e/img/svg/rock_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "rock-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "5vn99dUfgeMF5PYO"
+}

--- a/packs/core-effects/vulnerable-steel.json
+++ b/packs/core-effects/vulnerable-steel.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Steel)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>This effect renders @Trait[steel] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/steel_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Steel)",
+      "type": "affliction",
+      "_id": "3lfRrw6tnwOk5q7X",
+      "img": "systems/ptr2e/img/svg/steel_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "steel-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": 3,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "YCXxMBWGGr8aIRme"
+}

--- a/packs/core-effects/vulnerable-water.json
+++ b/packs/core-effects/vulnerable-water.json
@@ -1,0 +1,80 @@
+{
+  "name": "Vulnerable (Water)",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": "<p>This effect renders @Trait[water] attacks one stage more effective against the victim.</p>"
+    },
+    "description": "<p>This effect renders @Trait[water] attacks one stage more effective against the victim.</p>",
+    "traits": []
+  },
+  "img": "systems/ptr2e/img/svg/water_icon.svg",
+  "effects": [
+    {
+      "name": "Vulnerable (Water)",
+      "type": "affliction",
+      "_id": "xx4qSQwlUYSJ2KYl",
+      "img": "systems/ptr2e/img/svg/water_icon.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "key": "water-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage"
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null,
+        "turns": null,
+        "startTurn": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "C2AY320OyjnI6hXq"
+}


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Effect: Vulnerable (Bug)
- Update Effect: Vulnerable (Dark)
- Update Effect: Vulnerable (Dragon)
- Update Effect: Vulnerable (Electric)
- Update Effect: Vulnerable (Fairy)
- Update Effect: Vulnerable (Fighting)
- Update Effect: Vulnerable (Fire)
- Update Effect: Vulnerable (Flying)
- Update Effect: Vulnerable (Ghost)
- Update Effect: Vulnerable (Grass)
- Update Effect: Vulnerable (Ground)
- Update Effect: Vulnerable (Ice)
- Update Effect: Vulnerable (Normal)
- Update Effect: Vulnerable (Nuclear)
- Update Effect: Vulnerable (Poison)
- Update Effect: Vulnerable (Psychic)
- Update Effect: Vulnerable (Rock)
- Update Effect: Vulnerable (Steel)
- Update Effect: Vulnerable (Water)