### PR TITLE
Foundry Data Sync - EHR and Increment Clock Effects, Muse and Overbooster touck ups and automations.

### DIFF
--- a/packs/core-effects/10-ehr.json
+++ b/packs/core-effects/10-ehr.json
@@ -1,0 +1,76 @@
+{
+  "name": "+10% EHR",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "10-ehr",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": []
+  },
+  "_id": "cTqkSSjz3mvoSjwW",
+  "img": "systems/ptr2e/img/icons/effect_icon.webp",
+  "effects": [
+    {
+      "name": "+10% EHR",
+      "type": "passive",
+      "_id": "4FLjKp9nBo2bfPia",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.modifiers.effectHitRate",
+            "value": 10,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "createdTime": 1764115221116,
+        "modifiedTime": 1764115262818,
+        "lastModifiedBy": "UTlFSVhgfIUeTsoW"
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-effects/10-res
+++ b/packs/core-effects/10-res
@@ -1,0 +1,76 @@
+{
+  "name": "+10% RES",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "10-res",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": []
+  },
+  "_id": "0rhNpbnUvCWGggUK",
+  "img": "systems/ptr2e/img/icons/effect_icon.webp",
+  "effects": [
+    {
+      "name": "+10% RES",
+      "type": "passive",
+      "_id": "o2bfPia4FLjKp9nB",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.modifiers.effectResistance",
+            "value": 10,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "createdTime": 1764115221116,
+        "modifiedTime": 1764115262818,
+        "lastModifiedBy": "UTlFSVhgfIUeTsoW"
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-effects/increment-clock.json
+++ b/packs/core-effects/increment-clock.json
@@ -1,0 +1,76 @@
+{
+  "name": "Increment Clock",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "slug": "increment-clock",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": []
+  },
+  "_id": "w6LCoIGG3DiKRJB0",
+  "img": "systems/ptr2e/img/icons/effect_icon.webp",
+  "effects": [
+    {
+      "name": "Tick Clock",
+      "type": "passive",
+      "_id": "8PRXCcmOIoVSWi6t",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "increment-clock",
+            "key": "aaaaaaaaaaaaaaaa",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "createdTime": 1764116597092,
+        "modifiedTime": 1764116784478,
+        "lastModifiedBy": "UTlFSVhgfIUeTsoW"
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/muse.json
+++ b/packs/core-perks/muse.json
@@ -10,21 +10,17 @@
       {
         "name": "Muse",
         "slug": "muse",
-        "description": "<p>Effect: As a Simple Action, the user designates an ally as their Muse, setting a Muse Clock on the user's sheet with 6 Spans. When the designated ally ends an Activation, tick one Span on the Muse Clock. For every Span that is filled, the user's Attacks have their Power increased by 20%, up to a max increase of 100%. When the Muse Clock expires, the user is healed of all Afflictions with the @Trait[major-affliction] or @Trait[minor-affliction] traits.</p><p>The Muse Clock disappears if either the user or their Muse is switched out or @Affliction[fainted], or if combat ends. The user may only possess one Muse Clock at any given time.</p>",
+        "description": "<p>Effect: As a Simple Action, the user designates an ally as their Muse, setting a Muse Clock on the user's sheet with 6 Spans. When the designated ally ends an Activation, tick one Span on the Muse Clock. For every Span that is filled, the user's Attacks have their Power and EHR increased by +20% and +10%, up to a max of +100% and +50% respectively. When the Muse Clock expires, the user is healed of all Afflictions with the @Trait[major-affliction] or @Trait[minor-affliction] traits.</p><p>The Muse Clock disappears if either the user or their Muse is switched out or @Affliction[fainted], or if combat ends. The user may only possess one Muse Clock at any given time.</p>",
         "traits": [],
         "type": "generic",
         "img": "systems/ptr2e/img/conditions/cheered.svg",
         "range": {
           "target": "ally",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
-          "activation": "simple",
-          "powerPoints": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false
+          "activation": "simple"
+        }
       }
     ],
     "description": "<p>Effect: As a Simple Action, the user designates an ally as their Muse, setting a Muse Clock on the user's sheet with 6 Spans. When the designated ally ends an Activation, tick one Span on the Muse Clock. For every Span that is filled, the user's Attacks have their Power increased by 20%, up to a max increase of 100%. When the Muse Clock expires, the user is healed of all Afflictions with the @Trait[major-affliction] or @Trait[minor-affliction] traits.</p><p>The Muse Clock disappears if either the user or their Muse is switched out or @Affliction[fainted], or if combat ends. The user may only possess one Muse Clock at any given time.</p>",
@@ -77,13 +73,97 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    }
   },
   "img": "systems/ptr2e/img/conditions/cheered.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Muse",
+      "type": "passive",
+      "_id": "cRL4JX53XpfmrFQu",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "create-clock",
+            "key": "QMg4CYIKEc9QM2lz",
+            "value": 0,
+            "predicate": [],
+            "label": "Muse",
+            "max": 6,
+            "color": "#c2f55f",
+            "private": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "damaging-attack-power",
+            "value": "max(100,20*@actor.clocks.QMg4CYIKEc9QM2lz)",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "key": "attack",
+            "value": "Compendium.ptr2e.core-effects.Item.cTqkSSjz3mvoSjwW",
+            "predicate": [],
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.label",
+                "value": "Muse EHR"
+              },
+              {
+                "mode": 5,
+                "property": "system.changes.0.value",
+                "value": "max(50,10*@actor.clocks.QMg4CYIKEc9QM2lz)"
+              }
+            ],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#c2f55f",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "createdTime": 1764117451717,
+        "modifiedTime": 1764117735036,
+        "lastModifiedBy": "UTlFSVhgfIUeTsoW"
+      }
+    }
+  ],
   "_id": "OXVqgQQ78QUgRinK",
   "folder": "UZGN1glVNXLieg48"
 }

--- a/packs/core-perks/overbooster.json
+++ b/packs/core-perks/overbooster.json
@@ -7,24 +7,25 @@
   "system": {
     "actions": [
       {
-        "name": "Overbooster",
-        "slug": "overbooster",
-        "description": "<p>The user loses a Tick of HP. The user's next Physical- or Special-Category Attack deals +20% more damage. This can be done twice on each of the user's Activations.</p>",
-        "traits": [],
+        "name": "Overbooster (Tick)",
+        "slug": "overbooster-tick",
+        "description": "<p>The user loses @Tick[-1]. The user Ticks their Overbooster Clock by 1 Span.<br><br>This may only be done up two times during each of the user's Activations.</p>",
+        "traits": [
+          "priority-10"
+        ],
         "type": "generic",
         "range": {
           "target": "self",
           "unit": "m"
         },
         "cost": {
-          "activation": "free",
-          "powerPoints": 1
+          "activation": "free"
         },
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/perk-icons/Combat.svg"
       }
     ],
     "slug": "overbooster",
-    "description": "<p>The user spends a Tick of HP and 1 PP. The user's next Physical- or Special-Category Attack deals +20% more damage. This can be done twice on each of the user's Activations.</p>",
+    "description": "<p>The user maintains an Overbooster Clock, maximum 20 Spans. Up to twice per Activation as a Free Action at @Trait[priority-10], the user can Tick the Overbooster Clock by 1 Span and lose @Tick[-1].</p><p>The user can choose to empty the Overbooster Clock as a Free Action when they declare a Physical- or Special-Category Attack, increasing the EHR and Damage of the Attack by +2% and +20% respectively per Span consumed. The Overbooster Clock is emptied when the user enters or exits combat.</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 3,
@@ -70,5 +71,124 @@
       "notes": ""
     }
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Overbooster",
+      "type": "passive",
+      "_id": "BZCTFJh2KJosyZvX",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "create-clock",
+            "key": "tsKvTmarivU7SRqz",
+            "value": 0,
+            "predicate": [],
+            "max": 20,
+            "color": "#e02e6f",
+            "private": false,
+            "label": "Overbooster",
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "damaging-attack-damage",
+            "value": "20*@actor.clocks.tsKvTmarivU7SRqz",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "key": "damaging-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.cTqkSSjz3mvoSjwW",
+            "predicate": [],
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.label",
+                "value": "Overbooster EHR"
+              },
+              {
+                "mode": 5,
+                "property": "system.changes.0.value",
+                "value": "2*@actor.clocks.tsKvTmarivU7SRqz"
+              }
+            ],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "overbooster-tick-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.4DlXFTVooz07YcDm",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "overbooster-tick-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.w6LCoIGG3DiKRJB0",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.key",
+                "value": "tsKvTmarivU7SRqz"
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#e02e6f",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": "never"
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.350",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "createdTime": 1764113923903,
+        "modifiedTime": 1764117302727,
+        "lastModifiedBy": "UTlFSVhgfIUeTsoW"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/overbooster.json
+++ b/packs/core-perks/overbooster.json
@@ -128,7 +128,7 @@
             "predicate": [],
             "chance": 100,
             "isFixedChance": true,
-            "affects": "target",
+            "affects": "self",
             "alterations": [],
             "dontMerge": false,
             "mode": 2,
@@ -141,7 +141,7 @@
             "predicate": [],
             "chance": 100,
             "isFixedChance": true,
-            "affects": "target",
+            "affects": "self",
             "alterations": [
               {
                 "mode": 5,


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Effect: +10% EHR
- Update Perk: Muse
- Update Perk: Overbooster
- Update Effect: Increment Clock