### PR TITLE
Foundry Data Sync - New afflictions

### DIFF
--- a/packs/core-effects/muzzled.json
+++ b/packs/core-effects/muzzled.json
@@ -1,0 +1,23 @@
+{
+  "name": "Muzzled",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "description": "<p>The afflicted creature is unable to use @Trait[jaw] moves.</p>",
+    "traits": [
+      "minor-affliction"
+    ]
+  },
+  "img": "icons/svg/silenced.svg",
+  "effects": [],
+  "flags": {},
+  "_id": "1KhMzt9P8Wng4iOi"
+}

--- a/packs/core-effects/puppet.json
+++ b/packs/core-effects/puppet.json
@@ -1,0 +1,25 @@
+{
+  "name": "Puppet",
+  "type": "effect",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "description": "<p>The afflicted creature's alliance changes to match that of the affliction's source.<br><br>NPC enemies become temporary Allies of the PCs, whilst afflicted PCs fall under the control of the GM.</p>",
+    "traits": [
+      "major-affliction"
+    ]
+  },
+  "img": "icons/magic/control/control-influence-puppet.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "tks8Fa9ZmwYOSr4Z"
+}


### PR DESCRIPTION
Muzzled and Puppet. Currently no way to apply them, need to be careful with Puppet in particular.
- Update Effect: Muzzled
- Update Effect: Puppet