### PR TITLE
Foundry Data Sync - Laser and Beam Weapons

### DIFF
--- a/packs/core-gear/altru-tera-dp4-laser-pistol.json
+++ b/packs/core-gear/altru-tera-dp4-laser-pistol.json
@@ -13,19 +13,20 @@
       "notes": ""
     },
     "traits": [
-      "reload",
-      "reload-1",
-      "charge-pool-16",
-      "ray",
-      "sci-fi"
+      "weapon",
+      "fling",
+      "laser",
+      "reload-3",
+      "steel",
+      "charge-pool-20",
+      "sci-fi",
+      "1-handed"
     ],
     "actions": [
       {
         "name": "Las-Shot",
         "slug": "las-shot",
         "traits": [
-          "reload",
-          "charge-pool-16",
           "ray"
         ],
         "type": "attack",
@@ -51,11 +52,9 @@
       {
         "name": "Magnum Laser",
         "slug": "magnum-laser",
-        "description": "<p>On hit, the target has a 30% chance of being Flinched.</p>",
         "traits": [
-          "reload",
-          "charge-pool-16",
-          "ray"
+          "ray",
+          "flinch-15"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -73,9 +72,9 @@
         ],
         "category": "special",
         "power": 140,
-        "accuracy": 95,
-        "free": true,
-        "predicate": []
+        "accuracy": 90,
+        "predicate": [],
+        "variant": "las-shot"
       }
     ],
     "description": "<p>The DP4 is a specialty-manufactured directed energy weapon, designed to fit the role of a sidearm for security or military personnel. The DP4 is loaded with current generation capacitor bank magazines as their standard configuration, giving them a fair few number of shots at quite a significant punch and a “Beam Magnum” selector, to allow for higher output and stopping power.</p>",
@@ -92,9 +91,14 @@
     "grade": "B",
     "fling": {
       "type": "untyped",
-      "power": null,
-      "accuracy": 100,
-      "hide": false
+      "power": 80,
+      "accuracy": 80,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 3,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "common",
@@ -106,7 +110,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "slug": "altru-tera-dp4-laser-pistol",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -119,48 +125,23 @@
         "changes": [
           {
             "type": "flat-modifier",
-            "key": "las-shot-attack-damage-flat",
+            "key": "las-shot-attack-damage",
             "value": 20,
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false,
             "hideIfDisabled": false
           },
           {
             "type": "flat-modifier",
-            "key": "magnum-laser-attack-damage-flat",
+            "key": "magnum-laser-attack-damage",
             "value": 50,
             "predicate": [],
-            "mode": 2,
             "priority": null,
+            "mode": 2,
             "ignored": false,
             "hideIfDisabled": false
-          },
-          {
-            "type": "roll-effect",
-            "key": "magnum-laser-attack",
-            "value": "Compendium.ptr2e.core-effects.Item.advanceffectitem",
-            "predicate": [],
-            "chance": 30,
-            "affects": "target",
-            "dontMerge": false,
-            "alterations": [
-              {
-                "mode": 5,
-                "property": "system.amount",
-                "value": -30
-              },
-              {
-                "mode": 5,
-                "property": "name",
-                "value": "Flinch 20%"
-              }
-            ],
-            "mode": 2,
-            "priority": null,
-            "ignored": false,
-            "isFixedChance": false
           }
         ],
         "slug": null,
@@ -187,18 +168,22 @@
       "transfer": true,
       "statuses": [],
       "sort": 0,
-      "flags": {},
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.4.beta",
-        "lastModifiedBy": null
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": "5ImYyhOS2D6D7ypO",
+        "modifiedTime": 1767455878957
       }
     }
   ],
-  "flags": {},
   "_id": "diU7kRmRRVoAsCX8"
 }

--- a/packs/core-gear/altru-tera-dp7-laser-rifle.json
+++ b/packs/core-gear/altru-tera-dp7-laser-rifle.json
@@ -1,0 +1,182 @@
+{
+  "folder": "V4skAU6G3OH5fXaf",
+  "name": "Altru-Tera DP7 Laser Rifle",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "altru-tera-dp7-laser-rifle",
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "traits": [
+      "weapon",
+      "fling",
+      "laser",
+      "reload-4",
+      "steel",
+      "charge-pool-28",
+      "sci-fi",
+      "2-handed"
+    ],
+    "actions": [
+      {
+        "name": "Las-Beam",
+        "slug": "las-beam",
+        "traits": [
+          "ray"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "range": {
+          "target": "creature",
+          "distance": 32,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 1
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 75,
+        "accuracy": 100,
+        "free": true,
+        "predicate": []
+      },
+      {
+        "name": "Magnum Beam",
+        "slug": "magnum-beam",
+        "traits": [
+          "ray",
+          "flinch-20"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "range": {
+          "target": "creature",
+          "distance": 21,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "power": 170,
+        "accuracy": 90,
+        "free": true,
+        "predicate": [],
+        "variant": "las-beam"
+      }
+    ],
+    "description": "<p>The DR7 is a specialty-manufactured directed energy weapon, designed to fit the role of a battle rifle for security or military personnel. The DR7 is loaded with current generation capacitor bank magazines as their standard configuration, giving them a fair few number of shots at quite a significant punch and a “Beam Magnum” selector, to allow for higher output and stopping power.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "held",
+      "handsHeld": null
+    },
+    "fling": {
+      "type": "untyped",
+      "power": 110,
+      "accuracy": 65,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 2,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "common",
+    "ammoType": [],
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "DP7 Laser Rifle",
+      "type": "passive",
+      "_id": "NdBTmaCJIlnwvue2",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "las-beam-attack-damage",
+            "value": 35,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "magnum-beam-attack-damage",
+            "value": 88,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "bl6lDzDCN1L8rPTD"
+}

--- a/packs/core-gear/halcyon-al-comm-nl2-hi-freq-laser-repeater.json
+++ b/packs/core-gear/halcyon-al-comm-nl2-hi-freq-laser-repeater.json
@@ -1,0 +1,261 @@
+{
+  "folder": "V4skAU6G3OH5fXaf",
+  "name": "Halcyon-AlComm NL2 HiFreq Laser Repeater",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "halcyon-alcomm-laser-repeater",
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "traits": [
+      "weapon",
+      "fling",
+      "laser",
+      "reload-6",
+      "steel",
+      "charge-pool-20",
+      "sci-fi",
+      "2-handed"
+    ],
+    "actions": [
+      {
+        "name": "Laser Repeater Burst",
+        "slug": "laser-repeater-burst",
+        "traits": [
+          "weapon",
+          "ray",
+          "double-strike",
+          "flinch-15"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 1
+        },
+        "range": {
+          "target": "creature",
+          "distance": 40,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "predicate": [],
+        "power": 60,
+        "accuracy": 95
+      },
+      {
+        "name": "Laser Repeater Volley",
+        "slug": "laser-repeater-volley",
+        "traits": [
+          "weapon",
+          "ray",
+          "8-strike",
+          "flinch-30"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "variant": "laser-repeater-burst",
+        "range": {
+          "target": "creature",
+          "distance": 30,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "predicate": [],
+        "power": 30,
+        "accuracy": 85
+      },
+      {
+        "name": "Laser Repeater Salvo",
+        "slug": "laser-repeater-salvo",
+        "traits": [
+          "weapon",
+          "ray",
+          "4-strike",
+          "flinch-50"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 6
+        },
+        "variant": "laser-repeater-burst",
+        "range": {
+          "target": "wide-line",
+          "distance": 50,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "predicate": [],
+        "power": 40,
+        "accuracy": 75
+      },
+      {
+        "name": "Laser Repeater Blast",
+        "slug": "laser-repeater-blast",
+        "traits": [
+          "weapon",
+          "ray",
+          "flinch-35"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "variant": "laser-repeater-burst",
+        "range": {
+          "target": "creature",
+          "distance": 45,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "predicate": [],
+        "power": 140,
+        "accuracy": 85
+      }
+    ],
+    "description": "<p>The NL2 is a specialized directed energy weapon, filling the roles of both a squad suppression weapon and anti-materiel weapon. The NL2 utilizes high end power cells to fuel its discharges, giving it significant power, albeit at a potential risk of a catastrophic explosion if the power cell itself is stuck with significant force or heat.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "held",
+      "handsHeld": null
+    },
+    "grade": "A",
+    "fling": {
+      "type": "steel",
+      "power": 150,
+      "accuracy": 50,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 1,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "uncommon",
+    "ammoType": [],
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "Halcyon-AlComm NL2 HiFreq Laser Repeater",
+      "type": "passive",
+      "_id": "MUvPKBaQxkmiD7Bg",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "laser-repeater-burst-attack-damage",
+            "value": 40,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "laser-repeater-volley-attack-damage",
+            "value": 20,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "laser-repeater-salvo-attack-damage",
+            "value": 30,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "laser-repeater-blast-attack-damage",
+            "value": 105,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "Luwq47Vy5Zv8wKLa"
+}

--- a/packs/core-gear/lucasine-bx-03-beam-sword.json
+++ b/packs/core-gear/lucasine-bx-03-beam-sword.json
@@ -1,0 +1,238 @@
+{
+  "folder": "V4skAU6G3OH5fXaf",
+  "name": "Lucasine BX-03 Beam Sword",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "lucasine-beam-sword",
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "traits": [
+      "weapon",
+      "fling",
+      "1-handed",
+      "switch-grip",
+      "blade",
+      "sci-fi"
+    ],
+    "actions": [
+      {
+        "name": "Beam Strike",
+        "slug": "beam-strike",
+        "traits": [
+          "weapon",
+          "contact",
+          "sharp",
+          "ray",
+          "pulse"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 1
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "defensiveStat": "spd",
+        "predicate": [],
+        "power": 65,
+        "accuracy": 100
+      },
+      {
+        "name": "Beam Thrust",
+        "slug": "beam-thrust",
+        "traits": [
+          "weapon",
+          "contact",
+          "sharp",
+          "ray",
+          "pulse",
+          "pierce",
+          "flinch-10"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 2
+        },
+        "variant": "beam-strike",
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "defensiveStat": "spd",
+        "predicate": [],
+        "power": 95,
+        "accuracy": 90
+      },
+      {
+        "name": "Beam Flurry",
+        "slug": "beam-flurry",
+        "traits": [
+          "weapon",
+          "contact",
+          "sharp",
+          "ray",
+          "pulse",
+          "5-strike",
+          "flinch-30"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "variant": "beam-strike",
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "defensiveStat": "spd",
+        "predicate": [],
+        "power": 35,
+        "accuracy": 85
+      }
+    ],
+    "description": "<p>Lucasine’s BX-03 Beam Sword is the modern innovation of a “beam sword”, a technology doggedly pursued by corporate executives with major nostalgia complexes. The BX line is the first iteration of “true” beam swords - ones that do not require an emission skeleton to bind the plasma in place to form the blade. Instead, the BX line has innovated and miniaturized the emission and binding mechanisms solely into the hilt. However, still short of the nostalgic dream, the BX line requires a substantial power supply, which is carried on the hip or on the back and wired into the hilt.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "held",
+      "handsHeld": 1
+    },
+    "grade": "B",
+    "fling": {
+      "type": "steel",
+      "power": 80,
+      "accuracy": 90,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 4,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "ammoType": [],
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "eNUnXzFjxW2lgmKy",
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "Lucasine BX-03 Beam Sword",
+      "type": "passive",
+      "_id": "XqBJbeRIb9HkfiSa",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "beam-strike-damage",
+            "value": 35,
+            "predicate": [],
+            "label": "Beam Strike",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "beam-thrust-damage",
+            "value": 50,
+            "predicate": [],
+            "label": "Beam Thrust",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "beam-flurry-damage",
+            "value": 25,
+            "predicate": [],
+            "label": "Beam Flurry",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1767457889286,
+        "modifiedTime": 1767458691871,
+        "lastModifiedBy": "5ImYyhOS2D6D7ypO"
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-gear/mx-4-arch-archimedes-laser-cannon.json
+++ b/packs/core-gear/mx-4-arch-archimedes-laser-cannon.json
@@ -1,0 +1,154 @@
+{
+  "folder": "V4skAU6G3OH5fXaf",
+  "name": "MX-4-ARCH “Archimedes” Laser Cannon",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.112,
+      "previous": {
+        "schema": 0.111,
+        "foundry": "13.351",
+        "system": "1.4.7.beta"
+      }
+    },
+    "slug": "mx-4-arch-laser-cannon",
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "traits": [
+      "weapon",
+      "fling",
+      "laser",
+      "reload-6",
+      "steel",
+      "charge-pool-2",
+      "sci-fi",
+      "2-handed"
+    ],
+    "actions": [
+      {
+        "name": "Archimedes Shot",
+        "slug": "archimedes-shot",
+        "traits": [
+          "ray",
+          "pierce",
+          "flinch-60",
+          "crit-3",
+          "weapon"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 1
+        },
+        "range": {
+          "target": "creature",
+          "distance": 60,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "special",
+        "predicate": [],
+        "power": 250,
+        "accuracy": 85
+      }
+    ],
+    "description": "<p>The “Archimedes” is a bleeding edge over-shoulder anti-materiel directed energy weapon, designed with enough power to blast through not only armored vehicles, but even fortifications and starships. The immense power of the Archimedes platform is only really balanced by its unwieldiness and poor accuracy against smaller entities, and its charge time.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "held",
+      "handsHeld": 2
+    },
+    "grade": "S",
+    "fling": {
+      "type": "untyped",
+      "power": 190,
+      "accuracy": 60,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 1,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    },
+    "ammoType": []
+  },
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "Archimedes",
+      "type": "passive",
+      "_id": "ToRd4MzZ2wwzVbnC",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "archimedes-shot-attack-damage",
+            "value": 250,
+            "predicate": [],
+            "label": "Archimedes",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "Kg5BCt49OHyNFxb1"
+}

--- a/packs/core-gear/silphco-defender-sidearm.json
+++ b/packs/core-gear/silphco-defender-sidearm.json
@@ -8,14 +8,13 @@
     },
     "traits": [
       "laser",
-      "adaptable-ammunition",
       "firearm",
-      "autoload",
       "weapon",
       "energy-weapon",
       "sci-fi",
       "reload-2",
-      "charge-pool-12"
+      "charge-pool-12",
+      "1-handed"
     ],
     "actions": [
       {
@@ -41,7 +40,7 @@
           "untyped"
         ],
         "category": "special",
-        "power": 65,
+        "power": 60,
         "accuracy": 100,
         "free": true,
         "predicate": []
@@ -93,7 +92,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -106,7 +106,7 @@
         "changes": [
           {
             "type": "flat-modifier",
-            "key": "{item|id}-attack-damage-flat",
+            "key": "defender-shot-attack-damage",
             "value": 5,
             "predicate": [],
             "mode": 2,
@@ -142,12 +142,12 @@
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.fhfuptGmpadYy37I.ActiveEffect.QO0MYb3X5EGQF0Iv",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
+        "systemVersion": "1.5.0.beta",
         "createdTime": 1758158102085,
-        "modifiedTime": 1758158110337,
-        "lastModifiedBy": "UTlFSVhgfIUeTsoW"
+        "modifiedTime": 1767461586862,
+        "lastModifiedBy": "5ImYyhOS2D6D7ypO"
       }
     }
   ],

--- a/packs/core-gear/silphco-laslock-rifle.json
+++ b/packs/core-gear/silphco-laslock-rifle.json
@@ -9,12 +9,11 @@
     "traits": [
       "weapon",
       "laser",
-      "adaptable-ammunition",
-      "firearm",
-      "autoload",
       "energy-weapon",
       "sci-fi",
-      "charge-pool-18"
+      "charge-pool-18",
+      "reload-3",
+      "2-handed"
     ],
     "actions": [
       {
@@ -23,7 +22,8 @@
         "description": "<p>The SilphCo Laslock is a single-shot rifle that trades out on the convenience of the Defender for a higher power output and thus longer effective range.</p>",
         "traits": [
           "weapon",
-          "ray"
+          "ray",
+          "flinch-25"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -41,7 +41,7 @@
         ],
         "category": "special",
         "power": 80,
-        "accuracy": 100,
+        "accuracy": 95,
         "free": true,
         "predicate": []
       }
@@ -92,7 +92,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -105,8 +106,8 @@
         "changes": [
           {
             "type": "flat-modifier",
-            "key": "{item|id}-attack-damage-flat",
-            "value": 5,
+            "key": "laslock-beam-attack-damage",
+            "value": 30,
             "predicate": [],
             "mode": 2,
             "ignored": false,
@@ -141,12 +142,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
+        "systemVersion": "1.5.0.beta",
         "createdTime": 1758158061278,
-        "modifiedTime": 1758158094534,
-        "lastModifiedBy": "UTlFSVhgfIUeTsoW"
+        "modifiedTime": 1767461598425,
+        "lastModifiedBy": "5ImYyhOS2D6D7ypO"
       }
     }
   ],

--- a/static/traits.json
+++ b/static/traits.json
@@ -4517,6 +4517,24 @@
     "description": "Weapons with this trait use a mechanism to automatically feed their ammunition, rather than loading each shot by hand, like with a sling, bow, or muzzleloading firearm."
   },
   {
+    "slug": "caseless",
+    "label": "Caseless",
+    "related": [],
+    "description": "A @Trait[firearm] @Trait[weapon] with this trait uses advanced solid block ammunition – no longer needing a case or primer, only the bullet wrapped in the solid propellant ignited by an electric impulse, with no case or eject or clear. This ammunition is also significantly more space-efficient – these weapons have a @Trait[charge-pool-x] usually 1.5× to 4× times larger than contemporary cased firearms of similar design."
+  },
+  {
+    "slug": "coilgun",
+    "label": "Coilgun",
+    "related": [],
+    "description": "A @Trait[weapon] with this trait resembles a @Trait[firearm], but instead utilizes an array of electromagnets curled around a barrel as a sort of linear motor to fire a conductive projectile."
+  },
+  {
+    "slug": "arc",
+    "label": "Arc",
+    "related": [],
+    "description": "A @Trait[weapon] with this trait utilizes technology to harness prolonged, high-yield electric discharges that, when jumping through most mediums, produces a plasma arc and heat akin to lightning."
+  },
+  {
     "slug": "ranger",
     "label": "Ranger",
     "related": [],

--- a/static/traits.json
+++ b/static/traits.json
@@ -4747,6 +4747,12 @@
     "description": "This Trait denotes the creature to be or be in a Unidentified Flying Object (UFO). Meaning they must use Pilot (Aerospace) for its Rush skill."
   },
   {
+    "slug": "impel",
+    "label": "Impel",
+    "related": [],
+    "description": "Denotes if an Action or effect is violently provocative. Generally, this is a forceful measure to exert control of or coerce action from its target."
+  },
+  {
     "slug": "agitator",
     "label": "Agitator",
     "related": [],

--- a/static/traits.json
+++ b/static/traits.json
@@ -2141,7 +2141,7 @@
     "slug": "firearm",
     "label": "Firearm",
     "related": [],
-    "description": "This trait refers to guns and other such @Trait[projectile] devices that utilize an explosive charge to propel one or more projectiles down a barrel to inflict damage on a target. Firearms tend to be synonymous with more cold and calculated modern-style warfare, away from the romanticized sword and spear combat of the Middle Ages and Antiquity, and are ubiquitious in many settings that resemble contemporary society to any degree."
+    "description": "This trait refers to guns and other such @Trait[projectile] devices that utilize an explosive charge to propel one or more projectiles down a barrel to inflict damage on a target. Firearms tend to be synonymous with more cold and calculated modern-style warfare, away from the romanticized sword and spear combat of the Middle Ages and Antiquity, and are ubiquitious in many settings that resemble contemporary society to any degree. Attacks made by Firearm @Trait[weapon]s are Physical-Category, but utilize the attacker’s SPATK for damage calculation."
   },
   {
     "slug": "weathervane",
@@ -4005,20 +4005,6 @@
     "type": "automated"
   },
   {
-    "slug": "aberrant",
-    "label": "Aberrant",
-    "related": [],
-    "description": "This represents the Aberrant Type. When on creatures, it grants access to the Type's Tutor List. When on Items, it confers the Type to the Item's Fling characteristics and to the @Trait[adaptable] Actions provided by the Item (including the user's own Struggle).",
-    "type": "automated"
-  },
-  {
-    "slug": "radiant",
-    "label": "Radiant",
-    "related": [],
-    "description": "This represents the Radiant Type. When on creatures, it grants access to the Type's Tutor List. When on Items, it confers the Type to the Item's Fling characteristics and to the @Trait[adaptable] Actions provided by the Item (including the user's own Struggle).",
-    "type": "automated"
-  },
-  {
     "slug": "type-shift",
     "label": "Type Shift",
     "related": [],
@@ -4526,13 +4512,25 @@
     "slug": "coilgun",
     "label": "Coilgun",
     "related": [],
-    "description": "A @Trait[weapon] with this trait resembles a @Trait[firearm], but instead utilizes an array of electromagnets curled around a barrel as a sort of linear motor to fire a conductive projectile."
+    "description": "A @Trait[weapon] with this trait resembles a @Trait[firearm], but instead utilizes an array of electromagnets curled around a barrel as a sort of linear motor to fire a conductive projectile. These weapons feature physical ammunition like @Trait[firearm]s and expendable batteries like @Trait[laser] weapons, which causes their reloads to cost +1 IP. Attacks made by Coilgun @Trait[weapon]s are Physical-Category, but utilize the attacker’s SPATK for damage calculation."
   },
   {
     "slug": "arc",
     "label": "Arc",
     "related": [],
     "description": "A @Trait[weapon] with this trait utilizes technology to harness prolonged, high-yield electric discharges that, when jumping through most mediums, produces a plasma arc and heat akin to lightning."
+  },
+  {
+    "slug": "plasma",
+    "label": "Plasma",
+    "related": [],
+    "description": "A @Trait[weapon] with this trait fires superheated blasts of plasma energy as a @Trait[firearm] would a bullet."
+  },
+  {
+    "slug": "powered",
+    "label": "Powered",
+    "related": [],
+    "description": "Equipment or Gear with this trait utilizes motors or some other method (technological or magical) to augment the user’s body - adding to and slightly enhancing their natural strength."
   },
   {
     "slug": "ranger",


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Weapon: Altru-Tera DP4 Laser Pistol
- Update Weapon: Altru-Tera DP7 Laser Rifle
- Update Weapon: Lucasine BX-03 Beam Sword
- Update Weapon: Halcyon-AlComm NL2 HiFreq Laser Repeater
- Update Weapon: MX-4-ARCH “Archimedes” Laser Cannon
- Update Weapon: SilphCo Defender Sidearm
- Update Weapon: SilphCo Laslock Rifle