### PR TITLE
Foundry Data Sync - Fix Truant Automation

### DIFF
--- a/packs/core-abilities/truant.json
+++ b/packs/core-abilities/truant.json
@@ -14,7 +14,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user's Attacks have +30% Power and the user takes 10% less damage from Attacks, but each time the user resolves an attack, they gain @Affliction[delay 25].</p>",
         "img": "systems/ptr2e/img/conditions/sleep.svg"
@@ -72,7 +73,7 @@
             "predicate": [],
             "chance": 100,
             "isFixedChance": false,
-            "affects": "target",
+            "affects": "self",
             "alterations": [
               {
                 "mode": 5,
@@ -118,12 +119,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
+        "systemVersion": "1.5.0.beta",
         "createdTime": 1737563805624,
-        "modifiedTime": 1760668698757,
-        "lastModifiedBy": "r8rxDx9bzq5ASx3l",
+        "modifiedTime": 1769233748786,
+        "lastModifiedBy": "xh6Pq7RQCtnsVX8n",
         "exportSource": null
       }
     }


### PR DESCRIPTION
Originally, truant put the dealy on the target, not on self.
- Update Ability: Truant