### PR TITLE
Foundry Data Sync - Misc. Gear text and trait fixes

### DIFF
--- a/packs/core-gear/all-mach-orb.json
+++ b/packs/core-gear/all-mach-orb.json
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
@@ -28,7 +33,8 @@
       "consumable",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "The user and all allies freely use Rush.",
     "quantity": 1,
@@ -42,8 +48,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "ammoType": []
   },
   "_id": "gV8a4mHVxD9Bq2TX",
   "effects": [],

--- a/packs/core-gear/bank-orb.json
+++ b/packs/core-gear/bank-orb.json
@@ -29,7 +29,8 @@
     "consumableType": "other",
     "traits": [
       "treasure",
-      "wonder-orb"
+      "wonder-orb",
+      "mystery-dungeon"
     ],
     "description": "<p>The user recovers 5 IP. This item cannot be purchased in stores.</p>",
     "quantity": 1,
@@ -46,7 +47,8 @@
       ],
       "notes": ""
     },
-    "actions": []
+    "actions": [],
+    "ammoType": []
   },
   "_id": "SZpkaj0gWKopbTit",
   "effects": [],

--- a/packs/core-gear/coagulant.json
+++ b/packs/core-gear/coagulant.json
@@ -22,7 +22,12 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "restorative",
@@ -33,7 +38,7 @@
       "consumable",
       "healing"
     ],
-    "description": "The target is healed of the @Affliction[Splinter] Affliction.",
+    "description": "<p>The target is healed of the @Affliction[splinter] Affliction.</p>",
     "quantity": 1,
     "slug": "coagulant",
     "stack": 3,
@@ -45,8 +50,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "ammoType": []
   },
   "_id": "KHnOfbcAg06oUUOZ",
   "effects": [],

--- a/packs/core-gear/decoy-orb.json
+++ b/packs/core-gear/decoy-orb.json
@@ -31,7 +31,8 @@
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb"
+      "wonder-orb",
+      "mystery-dungeon"
     ],
     "description": "<p>The user applies @Affliction[marked 5] to a creature within the Room.</p>",
     "quantity": 1,
@@ -69,7 +70,8 @@
           "unit": "m"
         }
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "2fgivZ3zTOc2koQW",
   "effects": [
@@ -122,7 +124,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758646697365,

--- a/packs/core-gear/escape-orb.json
+++ b/packs/core-gear/escape-orb.json
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
@@ -27,7 +32,8 @@
       "consumable",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "Transports the user and all allies to the nearest settlement, checkpoint, or dungeon exit.",
     "quantity": 1,
@@ -41,8 +47,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "ammoType": []
   },
   "_id": "jZ8FJ4ntjCFUJ15s",
   "effects": [],

--- a/packs/core-gear/evasion-orb.json
+++ b/packs/core-gear/evasion-orb.json
@@ -31,7 +31,8 @@
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb"
+      "wonder-orb",
+      "mystery-dungeon"
     ],
     "description": "<p>The user gains +1 EVA for 5 activations.</p>",
     "quantity": 1,
@@ -69,7 +70,8 @@
           "unit": "m"
         }
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "0Oau8hUKhEIA4lNZ",
   "effects": [
@@ -122,7 +124,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758647400232,

--- a/packs/core-gear/foe-fear-orb.json
+++ b/packs/core-gear/foe-fear-orb.json
@@ -31,7 +31,8 @@
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb"
+      "wonder-orb",
+      "mystery-dungeon"
     ],
     "description": "<p>All foes in the Room gain @Affliction[fear 3].</p>",
     "quantity": 1,
@@ -67,10 +68,12 @@
         },
         "range": {
           "target": "field",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         }
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "k9gR62byZczNuTYj",
   "effects": [
@@ -129,7 +132,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758756513648,

--- a/packs/core-gear/foe-hold-orb.json
+++ b/packs/core-gear/foe-hold-orb.json
@@ -31,7 +31,9 @@
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb"
+      "wonder-orb",
+      "mystery-dungeon",
+      "mystery-dungeon"
     ],
     "description": "<p>All foes in the Room gain @Affliction[bound 3].</p>",
     "quantity": 1,
@@ -65,10 +67,12 @@
         },
         "range": {
           "target": "field",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         }
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "hZn5dGH90gSnvcCG",
   "effects": [
@@ -127,7 +131,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758756637951,

--- a/packs/core-gear/foe-hold-orb.json
+++ b/packs/core-gear/foe-hold-orb.json
@@ -32,7 +32,6 @@
       "combat",
       "consumable",
       "wonder-orb",
-      "mystery-dungeon",
       "mystery-dungeon"
     ],
     "description": "<p>All foes in the Room gain @Affliction[bound 3].</p>",

--- a/packs/core-gear/health-orb.json
+++ b/packs/core-gear/health-orb.json
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
@@ -29,7 +34,8 @@
       "restorative",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "The user and all allies in the Room are healed of all Status Afflictions.",
     "quantity": 1,
@@ -43,8 +49,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "ammoType": []
   },
   "_id": "JNNBvVqx2oV7uhFF",
   "effects": [],

--- a/packs/core-gear/hopo-berry.json
+++ b/packs/core-gear/hopo-berry.json
@@ -1,6 +1,6 @@
 {
   "name": "Hopo Berry",
-  "img": "systems/ptr2e/img/icons/consumable_icon.webp",
+  "img": "systems/ptr2e/img/item-icons/hopo%20berry.webp",
   "type": "consumable",
   "system": {
     "cost": 2,
@@ -75,7 +75,8 @@
           "unit": "m"
         }
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "PyfMOQBXiL0NexN5",
   "effects": [
@@ -139,7 +140,7 @@
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.UGTXYL1GX6QLUfM5.ActiveEffect.RyVoE01nh7JpzY4y",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758641381545,

--- a/packs/core-gear/identify-orb.json
+++ b/packs/core-gear/identify-orb.json
@@ -31,7 +31,8 @@
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb"
+      "wonder-orb",
+      "mystery-dungeon"
     ],
     "description": "<p>The user gains @Affliction[true-sight 5].</p>",
     "quantity": 1,
@@ -65,10 +66,12 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         }
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "7gyAnJ4CTxtpw0Ta",
   "effects": [
@@ -121,7 +124,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758757090473,

--- a/packs/core-gear/invisify-orb.json
+++ b/packs/core-gear/invisify-orb.json
@@ -31,7 +31,8 @@
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb"
+      "wonder-orb",
+      "mystery-dungeon"
     ],
     "description": "<p>The user gains @Affliction[invisible 5].</p>",
     "quantity": 1,
@@ -69,7 +70,8 @@
     "_migration": {
       "version": null,
       "previous": null
-    }
+    },
+    "ammoType": []
   },
   "_id": "E3ChEh9YkAe7P3d5",
   "effects": [
@@ -122,7 +124,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758757217666,

--- a/packs/core-gear/lasso-orb.json
+++ b/packs/core-gear/lasso-orb.json
@@ -33,7 +33,8 @@
       "consumable",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "<p>All allies of the target on the Floor are teleported to the target. The target and its allies gain @Affliction[bound] 5. This can be broken out of with a -30 Lift Check or  -10 Thaumaturgy check.</p>",
     "quantity": 1,
@@ -50,7 +51,8 @@
       ],
       "notes": ""
     },
-    "actions": []
+    "actions": [],
+    "ammoType": []
   },
   "_id": "j4ovHYdNWAAAHvHM",
   "effects": [],

--- a/packs/core-gear/lob-orb.json
+++ b/packs/core-gear/lob-orb.json
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
@@ -28,7 +33,8 @@
       "consumable",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "The user uses the attack \"Lob Orb.\" (Typeless, Range 16, 100 Pow, 100 Accuracy, [Missile])",
     "quantity": 1,
@@ -42,8 +48,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "ammoType": []
   },
   "_id": "3YTHwd8H8fLpbORd",
   "effects": [],

--- a/packs/core-gear/longtoss-orb.json
+++ b/packs/core-gear/longtoss-orb.json
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
@@ -28,7 +33,8 @@
       "consumable",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "For 5 activations, the user's Fling Range is doubled.",
     "quantity": 1,
@@ -42,8 +48,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "ammoType": []
   },
   "_id": "Kn64pG91RUSoW1BG",
   "effects": [],

--- a/packs/core-gear/mug-orb.json
+++ b/packs/core-gear/mug-orb.json
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
@@ -28,7 +33,8 @@
       "consumable",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "The user freely uses Thief, with Range set as \"10m\".",
     "quantity": 1,
@@ -42,8 +48,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "ammoType": []
   },
   "_id": "5iYAGyLctHqJMPuA",
   "effects": [],

--- a/packs/core-gear/shocker-orb.json
+++ b/packs/core-gear/shocker-orb.json
@@ -31,7 +31,8 @@
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb"
+      "wonder-orb",
+      "mystery-dungeon"
     ],
     "description": "<p>The target is inflicted with @Affliction[paralysis 5].</p>",
     "quantity": 1,
@@ -75,7 +76,8 @@
         "free": true,
         "predicate": []
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "j2o4rX391XWjpwrk",
   "effects": [
@@ -128,7 +130,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758758140048,

--- a/packs/core-gear/silence-orb.json
+++ b/packs/core-gear/silence-orb.json
@@ -31,7 +31,8 @@
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb"
+      "wonder-orb",
+      "mystery-dungeon"
     ],
     "description": "<p>The target creature becomes @UUID[Compendium.ptr2e.core-effects.V8CNzN148X1bYsSS]{Gagged} for 5 activations.</p>",
     "quantity": 1,
@@ -69,7 +70,8 @@
           "unit": "m"
         }
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "pdPVNihRTrYX6Dey",
   "effects": [
@@ -122,7 +124,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1759320117683,

--- a/packs/core-gear/sizebust-orb.json
+++ b/packs/core-gear/sizebust-orb.json
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
@@ -28,7 +33,8 @@
       "consumable",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "This item deals damage to a target in range, Power being dependent on the target's Weight Class: \n20 vs WC 1, 40 vs WC 2 & 3, 60 vs WC 4, 80 vs WC 5, 6, 7, 100 vs WC 8, 9, 10, and 120 vs WC 11+.",
     "quantity": 1,
@@ -42,8 +48,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "ammoType": []
   },
   "_id": "DaJL739GwrL3JsYx",
   "effects": [],

--- a/packs/core-gear/slow-orb.json
+++ b/packs/core-gear/slow-orb.json
@@ -31,7 +31,8 @@
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb"
+      "wonder-orb",
+      "mystery-dungeon"
     ],
     "description": "<p>All foes in the Room gain @Affliction[slowed 5].</p>",
     "quantity": 1,
@@ -65,10 +66,12 @@
         },
         "range": {
           "target": "field",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         }
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "jQaGwJVcHkNc8Jyj",
   "effects": [
@@ -121,7 +124,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758758264084,

--- a/packs/core-gear/snatch-orb.json
+++ b/packs/core-gear/snatch-orb.json
@@ -31,7 +31,8 @@
     "traits": [
       "combat",
       "consumable",
-      "wonder-orb"
+      "wonder-orb",
+      "mystery-dungeon"
     ],
     "description": "<p>The user may consume this to use the move @UUID[Compendium.ptr2e.core-moves.8U5CdSY2okR90rh4]{Snatch} as if it were on their active moves list.</p>",
     "quantity": 1,
@@ -48,7 +49,8 @@
       ],
       "notes": ""
     },
-    "actions": []
+    "actions": [],
+    "ammoType": []
   },
   "_id": "lFTEuvkjRDUkD0qP",
   "effects": [],

--- a/packs/core-gear/stayaway-orb.json
+++ b/packs/core-gear/stayaway-orb.json
@@ -32,7 +32,8 @@
       "combat",
       "consumable",
       "wonder-orb",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "<p>The target is teleported to the nearest Stairs (unless the nearest Stairs would be in the same room) and is removed from the combat encounter.</p>",
     "quantity": 1,
@@ -77,7 +78,8 @@
         "free": true,
         "predicate": []
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "zgtncClL81ICmusK",
   "effects": [],

--- a/packs/core-gear/switcher-orb.json
+++ b/packs/core-gear/switcher-orb.json
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
@@ -28,7 +33,8 @@
       "consumable",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "The user and a creature in the Room switch locations instantly.",
     "quantity": 1,
@@ -42,8 +48,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "ammoType": []
   },
   "_id": "qtOrFW5l3EWBt6VZ",
   "effects": [],

--- a/packs/core-gear/tiny-reviver-seed.json
+++ b/packs/core-gear/tiny-reviver-seed.json
@@ -33,7 +33,8 @@
       "consumable",
       "natural",
       "healing",
-      "seed"
+      "seed",
+      "mystery-dungeon"
     ],
     "description": "<p>When you would gain @Affliction[fainted] you may use @UUID[Compendium.ptr2e.core-moves.Item.NlcDvnyup6PzQIoK]{Use} as an Interrupt action to consume this item from the Belt.<br><br>Effect: You recover @Tick[16].</p>",
     "quantity": 1,
@@ -73,10 +74,12 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         }
       }
-    ]
+    ],
+    "ammoType": []
   },
   "effects": [
     {
@@ -134,7 +137,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1759240558002,

--- a/packs/core-gear/totter-orb.json
+++ b/packs/core-gear/totter-orb.json
@@ -33,7 +33,8 @@
       "consumable",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "<p>All foes in the Room are @Affliction[confused 5].</p>",
     "quantity": 1,
@@ -69,10 +70,12 @@
         },
         "range": {
           "target": "field",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         }
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "92YFtg6fkugEfQdd",
   "effects": [
@@ -125,7 +128,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758633821182,

--- a/packs/core-gear/trapper-orb.json
+++ b/packs/core-gear/trapper-orb.json
@@ -33,7 +33,8 @@
       "consumable",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "<p>Creates a random 2x2 trap tile within the room.</p>",
     "quantity": 1,
@@ -50,7 +51,8 @@
       ],
       "notes": ""
     },
-    "actions": []
+    "actions": [],
+    "ammoType": []
   },
   "_id": "D8mMAuGKVbooHU2G",
   "effects": [],

--- a/packs/core-gear/warp-orb.json
+++ b/packs/core-gear/warp-orb.json
@@ -19,7 +19,12 @@
       "type": "untyped",
       "power": 40,
       "accuracy": 100,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "common",
     "consumableType": "other",
@@ -28,7 +33,8 @@
       "consumable",
       "wonder-orb",
       "held",
-      "fling"
+      "fling",
+      "mystery-dungeon"
     ],
     "description": "A target in the Room is freely teleported to a random place on the Floor.",
     "quantity": 1,
@@ -42,8 +48,11 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "ammoType": []
   },
   "_id": "yEueXWlxZqbSVriw",
   "effects": [],


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Consumable: Tiny Reviver Seed
- Update Consumable: Coagulant
- Update Consumable: All-Mach Orb
- Update Consumable: Bank Orb
- Update Consumable: Decoy Orb
- Update Consumable: Escape Orb
- Update Consumable: Evasion Orb
- Update Consumable: Foe-Fear Orb
- Update Consumable: Foe-Hold Orb
- Update Consumable: Health Orb
- Update Consumable: Identify Orb
- Update Consumable: Invisify Orb
- Update Consumable: Lasso Orb
- Update Consumable: Lob Orb
- Update Consumable: Longtoss Orb
- Update Consumable: Mug Orb
- Update Consumable: Shocker Orb
- Update Consumable: Silence Orb
- Update Consumable: Sizebust Orb
- Update Consumable: Slow Orb
- Update Consumable: Snatch Orb
- Update Consumable: Stayaway Orb
- Update Consumable: Switcher Orb
- Update Consumable: Totter Orb
- Update Consumable: Trapper Orb
- Update Consumable: Warp Orb
- Update Consumable: Hopo Berry