### PR TITLE
Foundry Data Sync - Ninja Weapons #1

### DIFF
--- a/packs/core-gear/bo-staff.json
+++ b/packs/core-gear/bo-staff.json
@@ -1,0 +1,483 @@
+{
+  "folder": "V4skAU6G3OH5fXaf",
+  "name": "Bo Staff",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "bo-staff",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "weapon",
+      "fling",
+      "polearm",
+      "blunt",
+      "1-handed",
+      "switch-grip",
+      "ninja",
+      "martial",
+      "conventional",
+      "modern",
+      "early-modern",
+      "medieval",
+      "ancient",
+      "fantasy"
+    ],
+    "actions": [
+      {
+        "name": "Bo Staff Strike",
+        "slug": "bo-staff-strike",
+        "description": "<p>Effect: On hit, the target has a 20% chance of gaining @Affliction[delay 10].</p>",
+        "traits": [
+          "weapon",
+          "priority-30",
+          "contact"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 30,
+        "accuracy": 75
+      },
+      {
+        "name": "Bo Staff Thrust",
+        "slug": "bo-staff-thrust",
+        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[delay 20] and a 20% chance of losing -1 DEF Stage for 5 Activations.</p>",
+        "traits": [
+          "weapon",
+          "push-2",
+          "contact"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 2
+        },
+        "range": {
+          "target": "creature",
+          "distance": 2,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 65,
+        "accuracy": 70
+      },
+      {
+        "name": "Bo Staff Flurry",
+        "slug": "bo-staff-flurry",
+        "description": "<p>Effect: On hit, the target gains @Affliction[delay 20] and has a 30% chance of gaining a further @Affliction[delay 20] and @Affliction[suppressed 5].</p>",
+        "traits": [
+          "weapon",
+          "7-strike",
+          "flinch-30",
+          "contact"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 18,
+        "accuracy": 65
+      },
+      {
+        "name": "Bo Staff Spin",
+        "slug": "bo-staff-action-4",
+        "description": "<p>Effect: On hit, all valid targets have a 10% chance of gaining @Affliction[delay 40] and @Affliction[confused 5].</p>",
+        "traits": [
+          "weapon",
+          "flinch-40",
+          "push-1",
+          "contact"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "range": {
+          "target": "emanation",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 90,
+        "accuracy": 60
+      },
+      {
+        "name": "Bo Staff Sweep",
+        "slug": "bo-staff-action-5",
+        "description": "<p>Effect: On hit, the target gains @Affliction[delay 30] and has a 25% chance of losing -1 SPD and EVA Stage for 5 Activations.</p>",
+        "traits": [
+          "weapon",
+          "priority-10",
+          "contact"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 2
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 20,
+        "accuracy": 55
+      }
+    ],
+    "description": "<p>A bo is a staff weapon that is utilized in a number of martial arts, usually made with unfinished hardwood or a flexible wood. Thrusting, swinging, and striking techniques often resemble empty-hand movements, following the philosophy that the bo staff is merely an \"extension of one’s limbs\", which makes it a common inclusion in many traditionally-weaponless martial arts. The bo’s design and intended use makes it a less useful implement in the hands of someone not trained in martial arts. </p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "held",
+      "handsHeld": 1
+    },
+    "grade": "D",
+    "fling": {
+      "type": "untyped",
+      "power": 50,
+      "accuracy": 85,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 3,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "uncommon",
+    "ammoType": [],
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "Bo Staff",
+      "type": "passive",
+      "_id": "1E5i0CYlIGF9oAHj",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "{item|id}-attack-damage-flat",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "bo-staff-thrust-attack-damage-flat",
+            "value": 4,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "bo-staff-flurry-attack-damage-flat",
+            "value": 2,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "bo-staff-spin-attack-damage-flat",
+            "value": 3,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "fling-bo-staff-attack-damage-flat",
+            "value": 5,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bo-staff-strike-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bo-staff-thrust-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -20
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bo-staff-thrust-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.bdYCJcqjMNqTpJJQ",
+            "predicate": [],
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bo-staff-flurry-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -20
+              }
+            ],
+            "dontMerge": true,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bo-staff-flurry-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -20
+              }
+            ],
+            "dontMerge": true,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bo-staff-flurry-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.suppressedcoitem",
+            "predicate": [],
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bo-staff-spin-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -40
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bo-staff-spin-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bo-staff-sweep-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -30
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bo-staff-sweep-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.HLAV9dhz632Rfp1K",
+            "predicate": [],
+            "chance": 25,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "bo-staff-sweep-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.hIE6W3Y5E9CyHiTy",
+            "predicate": [],
+            "chance": 25,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "sxVB9DR6aewbRe3Z"
+}

--- a/packs/core-gear/kusarigama.json
+++ b/packs/core-gear/kusarigama.json
@@ -1,0 +1,287 @@
+{
+  "folder": "V4skAU6G3OH5fXaf",
+  "name": "Kusarigama",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "kusarigama",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "weapon",
+      "fling",
+      "blade",
+      "blunt",
+      "2-handed",
+      "ninja",
+      "conventional",
+      "modern",
+      "early-modern",
+      "medieval",
+      "fantasy"
+    ],
+    "actions": [
+      {
+        "name": "Kusarigama Slash",
+        "slug": "kusarigama-slash",
+        "description": "<p>Effect: This Attack gains +35 base Power, +20 Accuracy, +4 flat damage, and +1 CRIT against targets Afflicted with @Affliction[bound].</p>",
+        "traits": [
+          "weapon",
+          "sharp",
+          "priority-20",
+          "contact",
+          "adaptable"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 25,
+        "accuracy": 50
+      },
+      {
+        "name": "Kusarigama Strike",
+        "slug": "kusarigama-strike",
+        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[delay 10].</p>",
+        "traits": [
+          "weapon",
+          "hammer",
+          "missile",
+          "adaptable"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 45,
+        "accuracy": 60
+      },
+      {
+        "name": "Kusarigama Bind",
+        "slug": "kusarigama-bind",
+        "description": "<p>While @Affliction[bound], the target is also @Affliction[grapple], and cannot utilize Attacks using their Held Items. This @Affliction[bound] effect can be removed with a Taxing Acrobatics, Lift, or Sleight of Hand Skill Check taken as a Simple Action. The user must remain within 3 RI of the target to keep them @Affliction[bound].</p>",
+        "traits": [
+          "weapon",
+          "flinch-20"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 1
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": [],
+        "accuracy": 55
+      }
+    ],
+    "description": "<p>The kusarigama or “chain-sickle” is an older-fashioned weapon that was developed from a number of conventional tools into a half-improvised, half-purpose-made weapon that finds use in some more obscure martial arts. It consists of a kama (a type of sickle or billhook) on a kusari-fundo – a type of metal chain (kusari) with a heavy iron weight (fundo) at the end. Generally, the weapon was focused on utilizing the weight and chain to confound, disable, disarm, or grapple foes to allow the user to get in close with the sickle.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "held",
+      "handsHeld": null
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 85,
+      "accuracy": 70,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 2,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "uncommon",
+    "ammoType": [],
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "Kusarigama",
+      "type": "passive",
+      "_id": "Y0ZxWQ5oJ4XIKZom",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "{item|id}-attack-damage-flat",
+            "value": 4,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "fling-kusarigama-attack-damage-flat",
+            "value": 6,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "kusarigama-slash-attack-power",
+            "value": 35,
+            "predicate": [
+              "target:effect:affliction:bound"
+            ],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "kusarigama-slash-attack-accuracy",
+            "value": 20,
+            "predicate": [
+              "target:effect:affliction:bound"
+            ],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "stage-modifier",
+            "key": "kusarigama-slash-attack-crit",
+            "value": 1,
+            "predicate": [
+              "target:effect:affliction:bound"
+            ],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "basic",
+            "key": "kusarigama-slash-attack-damage",
+            "value": 4,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "kusarigama-strike-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 50,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "kusarigama-bind-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.boundconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "MTR3g3O8kGCdkP1t"
+}

--- a/packs/core-gear/naginata.json
+++ b/packs/core-gear/naginata.json
@@ -1,0 +1,266 @@
+{
+  "folder": "V4skAU6G3OH5fXaf",
+  "name": "Naginata",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "naginata",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "weapon",
+      "fling",
+      "polearm",
+      "blade",
+      "2-handed",
+      "ninja",
+      "conventional",
+      "modern",
+      "early-modern",
+      "medieval",
+      "fantasy"
+    ],
+    "actions": [
+      {
+        "name": "Naginata Swing",
+        "slug": "naginata-swing",
+        "traits": [
+          "weapon",
+          "contact",
+          "sharp",
+          "adaptable",
+          "pass-1",
+          "flinch-10"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 1
+        },
+        "range": {
+          "target": "creature",
+          "distance": 2,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "predicate": [],
+        "power": 70,
+        "accuracy": 65
+      },
+      {
+        "name": "Naginata Thrust",
+        "slug": "naginata-thrust",
+        "description": "<p>Effect: On hit, the target has a 20% chance of losing -1 SPDEF Stage for 5 Activations.</p>",
+        "traits": [
+          "weapon",
+          "contact",
+          "sharp",
+          "crit-1",
+          "adaptable",
+          "flinch-20"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 1
+        },
+        "range": {
+          "target": "creature",
+          "distance": 2,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "predicate": [],
+        "power": 85,
+        "accuracy": 60
+      },
+      {
+        "name": "Naginata Spin",
+        "slug": "naginata-spin",
+        "description": "<p>Effect: On hit, all valid targets have a 30% chance of gaining @Affliction[delay 20].</p>",
+        "traits": [
+          "weapon",
+          "sharp",
+          "contact",
+          "push-1",
+          "flinch-50"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "range": {
+          "target": "emanation",
+          "distance": 2,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "predicate": [],
+        "power": 100,
+        "accuracy": 55
+      }
+    ],
+    "description": "<p>The naginata is a type of polearm more often resembling a polesword, though sometimes they may sometimes sport broader blades instead resembling the guandao or glaive. Generally, these are curved, single-edged blades on the end of a staff, designed to batter, stab, and hook opponents, though they are quite deadly with longer-ranged slashes and spins compared to other polearms like the halberd.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "held",
+      "handsHeld": 2
+    },
+    "grade": "B",
+    "fling": {
+      "type": "untyped",
+      "power": 110,
+      "accuracy": 80,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 3,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "uncommon",
+    "ammoType": [],
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "Naginata",
+      "type": "passive",
+      "_id": "bme6VyrjjZKqk5rn",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "{item|id}-attack-damage-flat",
+            "value": 14,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "naginata-thrust-attack-damage-flat",
+            "value": 4,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "fling-naginata-attack-damage-flat",
+            "value": 11,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "naginata-thrust-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.qe5aLBJuwb9eYqvv",
+            "predicate": [],
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "naginata-spin-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -20
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "HsqoWWc741QmV8dD"
+}

--- a/packs/core-gear/ninjato.json
+++ b/packs/core-gear/ninjato.json
@@ -1,0 +1,204 @@
+{
+  "folder": "V4skAU6G3OH5fXaf",
+  "name": "Ninjato",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "ninjato",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "weapon",
+      "fling",
+      "blade",
+      "1-handed",
+      "switch-grip",
+      "ninja",
+      "conventional",
+      "modern",
+      "early-modern",
+      "medieval",
+      "fantasy"
+    ],
+    "actions": [
+      {
+        "name": "Ninjato Swing",
+        "slug": "ninjato-swing",
+        "traits": [
+          "weapon",
+          "sharp",
+          "contact",
+          "adaptable",
+          "pass-1",
+          "priority-15"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 40,
+        "accuracy": 75
+      },
+      {
+        "name": "Ninjato Thrust",
+        "slug": "ninjato-thrust",
+        "traits": [
+          "weapon",
+          "contact",
+          "adaptable",
+          "grapple",
+          "flinch-10",
+          "crit-2"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 1
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "predicate": [],
+        "power": 90,
+        "accuracy": 70,
+        "free": true
+      }
+    ],
+    "description": "<p>The ninjato is a shorter, single-edged guardless short sword that is lauded as the primary weapon of a ninja, though many experts dispute the weapon’s prominence or existence in the times ninja were more prominent. Nevertheless, it being a shorter, straight-edged katana-like sword means it retains a number of the slashing benefits that a katana bestows, but is quicker on the draw and better suited for thrusts. Its slimmed-down, utilitarian configuration that allow for it to be used stealthily mean it’s unwieldy in the hands of the inexperienced.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "held",
+      "handsHeld": 1
+    },
+    "grade": "C",
+    "fling": {
+      "type": "untyped",
+      "power": 80,
+      "accuracy": 90,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 3,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "ammoType": [],
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "Ninjato",
+      "type": "passive",
+      "_id": "tFmMoIRHdSCansSm",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "{item|id}-attack-damage-flat",
+            "value": 8,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "ninjato-thrust-attack-damage-flat",
+            "value": 11,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "fling-ninjato-attack-damage-flat",
+            "value": 8,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "uHzqFPlbGoL48MYp"
+}

--- a/packs/core-gear/sheathed-knife.json
+++ b/packs/core-gear/sheathed-knife.json
@@ -13,24 +13,23 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "C",
+    "grade": "D",
     "fling": {
-      "type": "fighting",
+      "type": "untyped",
       "power": 80,
       "accuracy": 85,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 4,
         "unit": "m"
       }
     },
-    "rarity": "uncommon",
+    "rarity": "common",
     "traits": [
       "weapon",
       "fling",
       "blade",
-      "fighting",
       "1-handed",
       "switch-grip",
       "conventional",
@@ -68,7 +67,8 @@
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "predicate": [],
         "power": 40,
-        "accuracy": 90
+        "accuracy": 90,
+        "free": true
       },
       {
         "name": "Sheathed Knife Thrust",
@@ -77,12 +77,14 @@
           "weapon",
           "contact",
           "crit-1",
-          "grapple"
+          "grapple",
+          "adaptable"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "cost": {
-          "activation": "complex"
+          "activation": "complex",
+          "powerPoints": 1
         },
         "range": {
           "target": "creature",
@@ -94,13 +96,12 @@
         ],
         "category": "physical",
         "predicate": [],
-        "power": 70,
-        "accuracy": 85
+        "power": 75,
+        "accuracy": 85,
+        "free": true
       }
     ],
     "description": "<p>A sheath knife is a fixed-bladed knife that fits into a sheath, generally due to the size of the knife's blade. These tools are as versatile as smaller knives, though the broader blade opens the door for different uses of these knives, most significantly for offense and defense.</p>",
-    "weaponType": "untyped",
-    "weaponRange": "Creature",
     "slug": "sheathed-knife",
     "quantity": 1,
     "identification": {
@@ -122,7 +123,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "LrhYW6Hg6szAqBas",
   "effects": [
@@ -152,12 +154,13 @@
             "hideIfDisabled": false
           },
           {
-            "type": "basic",
+            "type": "flat-modifier",
             "key": "fling-sheathed-knife-attack-damage-flat",
             "value": 12,
             "predicate": [],
             "mode": 2,
-            "ignored": false
+            "ignored": false,
+            "hideIfDisabled": false
           }
         ],
         "slug": null,
@@ -188,12 +191,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
+        "systemVersion": "1.5.0.beta",
         "createdTime": 1757553244816,
-        "modifiedTime": 1757553352207,
-        "lastModifiedBy": "UTlFSVhgfIUeTsoW"
+        "modifiedTime": 1770678695273,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
       }
     }
   ],

--- a/packs/core-gear/sword.json
+++ b/packs/core-gear/sword.json
@@ -12,7 +12,6 @@
       "weapon",
       "blade",
       "fling",
-      "steel",
       "1-handed",
       "switch-grip",
       "modern",
@@ -79,7 +78,8 @@
         "category": "physical",
         "predicate": [],
         "power": 80,
-        "accuracy": 95
+        "accuracy": 95,
+        "free": true
       }
     ],
     "description": "<p>A sword is an edged, bladed weapon intended for manual cutting and thrusting. These are often straight, double-edged weapons with a one-and-a-half-handed hilt, crossguard, and a blade length between 0.7-1.1m.</p>",
@@ -95,10 +95,10 @@
     },
     "grade": "D",
     "fling": {
-      "type": "steel",
+      "type": "untyped",
       "power": 85,
       "accuracy": 90,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 3,
@@ -116,15 +116,14 @@
         "description": "<p>Unidentified Item</p>"
       }
     },
-    "weaponType": "Melee",
-    "weaponRange": "1",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "2MoMKszqC3PlxHxN",
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -195,7 +194,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1757548541362,

--- a/packs/core-gear/tanto.json
+++ b/packs/core-gear/tanto.json
@@ -1,0 +1,203 @@
+{
+  "folder": "V4skAU6G3OH5fXaf",
+  "name": "Tanto",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "tanto",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "weapon",
+      "fling",
+      "blade",
+      "1-handed",
+      "switch-grip",
+      "ninja",
+      "conventional",
+      "modern",
+      "early-modern",
+      "medieval",
+      "fantasy"
+    ],
+    "actions": [
+      {
+        "name": "Tanto Swing",
+        "slug": "tanto-swing",
+        "type": "attack",
+        "traits": [
+          "weapon",
+          "contact",
+          "sharp",
+          "adaptable",
+          "grapple",
+          "priority-20"
+        ],
+        "range": {
+          "target": "creature",
+          "unit": "m",
+          "distance": 1
+        },
+        "cost": {
+          "activation": "complex"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "predicate": [],
+        "power": 30,
+        "accuracy": 65,
+        "free": true
+      },
+      {
+        "name": "Tanto Thrust",
+        "slug": "tanto-thrust",
+        "traits": [
+          "weapon",
+          "contact",
+          "grapple",
+          "adaptable",
+          "crit-2",
+          "flinch-10"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 1
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "predicate": [],
+        "power": 80,
+        "accuracy": 60
+      }
+    ],
+    "description": "<p>The tanto is a traditional, guardless dagger that is the more common edged weapon utilized by ninja for their missions or for self-defense. These blades can have a wide variety of blade shapes and configurations, but the common configurations resembled the ninjato more than a katana - straighter with an increased emphasis on thrusts.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "held",
+      "handsHeld": 1
+    },
+    "grade": "D",
+    "fling": {
+      "type": "untyped",
+      "power": 70,
+      "accuracy": 85,
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 4,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "rare",
+    "ammoType": [],
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "Tanto",
+      "type": "passive",
+      "_id": "OseMp3FbqNlcXfXx",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "{item|id}-attack-damage-flat",
+            "value": 5,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "tanto-thrust-attack-damage-flat",
+            "value": 11,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "fling-tanto-attack-damage-flat",
+            "value": 10,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "licn4f2AwAU2hKLY"
+}

--- a/packs/core-gear/yari.json
+++ b/packs/core-gear/yari.json
@@ -1,0 +1,197 @@
+{
+  "folder": "V4skAU6G3OH5fXaf",
+  "name": "Yari",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "yari",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "weapon",
+      "fling",
+      "polearm",
+      "2-handed",
+      "ninja",
+      "conventional",
+      "modern",
+      "early-modern",
+      "medieval",
+      "ancient",
+      "fantasy"
+    ],
+    "actions": [
+      {
+        "name": "Yari Thrust",
+        "slug": "yari-thrust",
+        "traits": [
+          "weapon",
+          "adaptable",
+          "contact",
+          "crit-2",
+          "flinch-15"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 2,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 75,
+        "accuracy": 60
+      },
+      {
+        "name": "Yari Thrust (Readied)",
+        "slug": "yari-thrust-readied",
+        "description": "<p>Trigger: A creature within range of this attack attempts to leave the range of this Attack, or that creature attempts to move adjacent to the user, while the user is @Affliction[braced].</p>",
+        "traits": [
+          "weapon",
+          "interrupt-2",
+          "adaptable",
+          "contact",
+          "priority-15",
+          "crit-2"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 2,
+          "trigger": "A creature within range of this attack attempts to leave the range of this Attack, or that creature attempts to move adjacent to the user while the user is @Affliction[braced]."
+        },
+        "range": {
+          "target": "creature",
+          "distance": 2,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "predicate": [],
+        "power": 75,
+        "accuracy": 70,
+        "free": true
+      }
+    ],
+    "description": "<p>The yari is a traditionally-styled spear, often used in martial arts. These spears’ heads tend to be narrower, if not more-swordlike, than other examples throughout history, meaning that they are often lighter and have less overall force behind their strikes, but are more than capable of hurting opponents like any other spear. Though, of course, this makes them a bit more unusual to the common layperson, so they do require a bit more training to use than one might expect.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "held",
+      "handsHeld": 2
+    },
+    "grade": "D",
+    "fling": {
+      "type": "untyped",
+      "power": 90,
+      "accuracy": 80,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 2,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "uncommon",
+    "ammoType": [],
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "Yari",
+      "type": "passive",
+      "_id": "Cutxe8glfht1BMJn",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "{item|id}-attack-damage-flat",
+            "value": 10,
+            "predicate": [],
+            "label": "Yari",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "fling-yari-attack-damage-flat",
+            "value": 6,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "PAbzrx2uxfJW6kyz"
+}


### PR DESCRIPTION
Plus minor tweaks to the Sword and Sheathed Knife.
- Update Weapon: Sword
- Update Weapon: Sheathed Knife
- Update Weapon: Bo Staff
- Update Weapon: Kusarigama
- Update Weapon: Naginata
- Update Weapon: Ninjato
- Update Weapon: Tanto
- Update Weapon: Yari