### PR TITLE
Foundry Data Sync - Missed moves migration to Digimon Module

### DIFF
--- a/packs/core-moves/pendragons-glory.json
+++ b/packs/core-moves/pendragons-glory.json
@@ -8,8 +8,10 @@
       "previous": null
     },
     "publication": {
-      "source": "",
-      "authors": [],
+      "source": "Digidex",
+      "authors": [
+        "Fox"
+      ],
       "notes": ""
     },
     "traits": [],
@@ -43,10 +45,10 @@
         "accuracy": 100
       }
     ],
-    "grade": "E"
+    "grade": "S",
+    "slug": "pendragons-glory"
   },
   "img": "systems/ptr2e/img/svg/electric_icon.svg",
   "effects": [],
-  "flags": {},
   "_id": "DUDenFA5nc572rvN"
 }

--- a/packs/core-moves/raddle-star.json
+++ b/packs/core-moves/raddle-star.json
@@ -1,0 +1,54 @@
+{
+  "folder": "BImk1fcMbR5akA4z",
+  "name": "Raddle Star",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "Digidex",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Raddle Star",
+        "slug": "raddle-star",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/steel_icon.svg",
+        "traits": [
+          "digimon",
+          "8-strike",
+          "danger-close",
+          "crit-2"
+        ],
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 9
+        },
+        "types": [
+          "steel"
+        ],
+        "category": "physical",
+        "predicate": [],
+        "range": {
+          "target": "creature",
+          "distance": 9,
+          "unit": "m"
+        },
+        "power": 15,
+        "accuracy": 100
+      }
+    ],
+    "grade": "S",
+    "slug": "raddle-star"
+  },
+  "img": "systems/ptr2e/img/svg/steel_icon.svg",
+  "effects": [],
+  "_id": "YTdNpVU98HPHGdR7"
+}

--- a/packs/core-moves/strike-fishing.json
+++ b/packs/core-moves/strike-fishing.json
@@ -1,0 +1,122 @@
+{
+  "folder": "BImk1fcMbR5akA4z",
+  "name": "Strike Fishing",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.111,
+      "previous": null
+    },
+    "publication": {
+      "source": "Digidex",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Strike Fishing",
+        "slug": "strike-fishing",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/steel_icon.svg",
+        "traits": [
+          "digimon",
+          "missile",
+          "pierce",
+          "danger-close"
+        ],
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 6
+        },
+        "types": [
+          "steel"
+        ],
+        "category": "physical",
+        "predicate": [],
+        "description": "<p>Effect: This attack inflicts @UUID[Compendium.ptr2e.core-effects.hIE6W3Y5E9CyHiTy]{-1 Evasion Stage} for 3 activations and gains +1 Effectiveness Stage vs @Trait[water] creatures.</p>",
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "power": 95,
+        "accuracy": 100
+      }
+    ],
+    "grade": "B",
+    "slug": "strike-fishing"
+  },
+  "img": "systems/ptr2e/img/svg/steel_icon.svg",
+  "effects": [
+    {
+      "name": "Strike Fishing",
+      "type": "passive",
+      "_id": "08ef9dRuk4GV5Mf9",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "strike-fishing-attack-effectiveness-stage",
+            "value": 1,
+            "predicate": [
+              "target:trait:water"
+            ],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "strike-fishing-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.hIE6W3Y5E9CyHiTy",
+            "predicate": [],
+            "alterations": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.4.6.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "_id": "cUaPfdMsKV8Xuttr"
+}


### PR DESCRIPTION
Source data was previously omitted from these moves.
- Update Move: Pendragon's Glory
- Update Move: Raddle Star
- Update Move: Strike Fishing