### PR TITLE
Foundry Data Sync - Ninja Archetype Expansion

### DIFF
--- a/packs/core-perks/arms-of-the-resistance.json
+++ b/packs/core-perks/arms-of-the-resistance.json
@@ -1,0 +1,134 @@
+{
+  "name": "Arms of the Resistance",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "arms-of-the-resistance",
+    "description": "<p>The user spends 2 fewer IP on @Trait[ninja] items and can purchase @Trait[ninja] items one Rarity higher using IP.</p><p>The user provides a (non-stacking) +10 bonus to their Party’s Thrifting Rolls, doubled for @Trait[ninja] items, and the user’s Attacks and Actions with @Trait[ball] items gain @Trait[ninja].</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "trait:ace",
+      "trait:ninja",
+      {
+        "gte": [
+          "{actor|skills.handiwork.mod}",
+          50
+        ]
+      },
+      {
+        "gte": [
+          "{actor|skills.locksmith.mod}",
+          50
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 191,
+        "y": 47,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "secret-ninja-tools"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/magic/control/control-influence-rally-purple.webp",
+  "effects": [
+    {
+      "name": "Arms of Resistance",
+      "type": "passive",
+      "_id": "a4gSGV65LZB9UvcU",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "key": "ball-trait-attack",
+            "value": "ninja",
+            "predicate": [],
+            "property": "traits",
+            "definition": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "key": "ball-trait-generic",
+            "value": "ninja",
+            "predicate": [],
+            "property": "traits",
+            "definition": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "1ZmPr9WTnzLdK40k"
+}

--- a/packs/core-perks/army-of-phantoms.json
+++ b/packs/core-perks/army-of-phantoms.json
@@ -17,7 +17,7 @@
       {
         "name": "Army of Phantoms",
         "slug": "army-of-phantoms",
-        "description": "<p>Effect: As a Complex Action, the user can make themselves and all allies within range become @Affliction[invisible 3].</p>",
+        "description": "<p>Effect: The user can make themselves and all allies within range gain @Affliction[invisible 3].</p>",
         "traits": [
           "ninja"
         ],
@@ -28,13 +28,13 @@
           "powerPoints": 5
         },
         "range": {
-          "target": "creature",
-          "distance": 10,
+          "target": "emanation",
+          "distance": 3,
           "unit": "m"
         }
       }
     ],
-    "description": "<p>Effect: As a Complex Action, the user can make themselves and all allies within range become @Affliction[invisible 3].</p>",
+    "description": "<p>Effect: By spending 5 PP as a Complex Action, the user and all allies within a 3m Emanation gain @Affliction[invisible 3].</p>",
     "traits": [
       "ninja"
     ],
@@ -42,7 +42,7 @@
       "item:perk:smokestep"
     ],
     "autoUnlock": [],
-    "cost": 4,
+    "cost": 3,
     "design": {
       "arena": "physical",
       "approach": "finesse",
@@ -52,17 +52,27 @@
     "webs": [],
     "nodes": [
       {
-        "x": 188,
-        "y": 39,
-        "connected": [
-          "smokestep",
-          "aura-empathy"
-        ],
+        "x": 182,
+        "y": 35,
         "hidden": false,
         "type": "normal",
+        "connected": [
+          "one-with-the-shadows",
+          "aura-empathy",
+          "smokestep",
+          "monomi-no-ikki"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
-    ]
+    ],
+    "slug": "army-of-phantoms",
+    "traitWebs": []
   },
   "img": "icons/svg/invisible.svg",
   "effects": [
@@ -128,6 +138,5 @@
       }
     }
   ],
-  "flags": {},
   "_id": "klID8J4yUuKFvW43"
 }

--- a/packs/core-perks/aura-empathy.json
+++ b/packs/core-perks/aura-empathy.json
@@ -18,22 +18,15 @@
         "slug": "aura-empathy",
         "description": "<p>You have a knack for reading the auras of others, allowing you to understand their moods and potentially pick up some surface thoughts. (Skill check may be required)</p>",
         "cost": {
-          "activation": "free",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "free"
         },
         "type": "passive",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "hidden": false,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "aura-empathy",
@@ -46,7 +39,8 @@
       {
         "connected": [
           "aura-user",
-          "aura-bonding"
+          "aura-bonding",
+          "army-of-phantoms"
         ],
         "config": {
           "alpha": null,
@@ -65,9 +59,6 @@
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -81,7 +72,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "_id": "0oopLlKDWl1rf2Sm",
   "img": "systems/ptr2e/img/perk-icons/Aura.svg",

--- a/packs/core-perks/aura-user.json
+++ b/packs/core-perks/aura-user.json
@@ -25,7 +25,8 @@
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         }
       }
     ],
@@ -43,11 +44,10 @@
         "type": "entry",
         "connected": [
           "root-2",
-          "aura-projection",
           "aura-empathy",
           "aura-haze",
           "sight-beyond-sight",
-          "out-of-options"
+          "aura-projection"
         ],
         "config": {
           "texture": "systems/ptr2e/img/perk-icons/Aura.svg",
@@ -74,7 +74,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "_id": "ft8sIBRLOGVjp70g",
   "img": "systems/ptr2e/img/perk-icons/Aura.svg",
@@ -124,7 +125,7 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.1.beta",
         "createdTime": 1732233165457,

--- a/packs/core-perks/behind-every-blade-of-grass.json
+++ b/packs/core-perks/behind-every-blade-of-grass.json
@@ -1,0 +1,104 @@
+{
+  "name": "Behind Every Blade of Grass",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Behind Every Blade of Grass",
+        "slug": "behind-every-blade-of-grass-generic",
+        "description": "<p>Effect: The user gains a @Trait[consumable] Item following standard out-of-Combat IP procurement rules, spending IP as necessary.</p>",
+        "traits": [
+          "ninja",
+          "flinch-20",
+          "manipulate"
+        ],
+        "type": "generic",
+        "img": "icons/consumables/plants/grass-bundle-green.webp",
+        "cost": {
+          "activation": "simple",
+          "powerPoints": 3
+        },
+        "range": {
+          "target": "self",
+          "unit": "m"
+        }
+      },
+      {
+        "name": "Behind Every Blade of Grass",
+        "slug": "behind-every-blade-of-grass-exploration",
+        "description": "<p>Trigger: The current Combat ends.</p><p>Effect: The user may make a Luck Roll, recovering 1/3 IP per DoS.</p>",
+        "traits": [
+          "ninja"
+        ],
+        "type": "exploration",
+        "img": "icons/consumables/plants/grass-bundle-green.webp",
+        "cost": {
+          "activation": "free"
+        },
+        "range": {
+          "target": "self",
+          "unit": "m"
+        }
+      }
+    ],
+    "slug": "behind-every-blade-of-grass",
+    "description": "<p>The user spends 1 fewer IP on @Trait[ninja] items and can purchase @Trait[ninja] items one Rarity higher using IP.</p><p>The user can spend 3 PP as a @Trait[manipulate] @Trait[flinch-20] Simple Generic Action to spend IP and obtain a @Trait[consumable] using the standard out-of-Combat IP procurement rules, even during Combat.</p><p>At the end of Combat, the user may make a Luck Roll, recovering 1/3 IP per DoS.</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "trait:ace",
+      "trait:ninja",
+      {
+        "gte": [
+          "{actor|skills.navigate.mod}",
+          50
+        ]
+      },
+      {
+        "gte": [
+          "{actor|skills.survival.mod}",
+          50
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 178,
+        "y": 41,
+        "connected": [
+          "nothing-is-true",
+          "minor-buff-66"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/consumables/plants/grass-bundle-green.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "nvbP95mP7UxbnaUf"
+}

--- a/packs/core-perks/belt-expansion-1.json
+++ b/packs/core-perks/belt-expansion-1.json
@@ -88,7 +88,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "_id": "zAKTLdBrA5eeGCsX",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
@@ -138,7 +139,7 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.1.beta",
         "createdTime": 1737934804061,

--- a/packs/core-perks/cheerleader.json
+++ b/packs/core-perks/cheerleader.json
@@ -17,27 +17,23 @@
       }
     ],
     "cost": 2,
-    "description": "<p>You are practiced in psyching up your allies. You may use Moves which are normally Self-Targeting instead as having Range 10m and able to target yourself or allied creatures.</p>",
+    "description": "<p>Effect: The user can choose to gain @Affliction[delay 15] as a Free Action, and can use an Attack with target \"Self\" and instead target an Ally within 10m with that Attack.</p><p>The user may spend @PP[-2] to increase the Range of this Perk to 20m, and @PP[-5] to increase it to 30m.</p>",
     "actions": [
       {
         "name": "Cheerleader",
         "slug": "cheerleader",
-        "description": "<p>You are practiced in psyching up your allies. You may use Moves which are normally Self-Targeting instead as having Range 10m and able to target yourself or allied creatures.</p>",
-        "type": "passive",
+        "description": "<p>Effect: The user may use an Attack that is normally target \"Self\" on the target.</p>",
+        "type": "generic",
         "traits": [],
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/perk-icons/Orders_Training.svg",
         "range": {
-          "target": "enemy",
+          "target": "ally",
           "unit": "m",
-          "distance": 0
+          "distance": 10
         },
-        "variant": null,
-        "hidden": false,
         "cost": {
-          "activation": "simple",
-          "powerPoints": 0
-        },
-        "ephemeralVariant": false
+          "activation": "free"
+        }
       }
     ],
     "slug": "cheerleader",
@@ -48,6 +44,10 @@
     },
     "nodes": [
       {
+        "x": 38,
+        "y": 56,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "mobilize",
           "tactician",
@@ -55,25 +55,15 @@
           "the-meaning-of-haste"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#ff80ff",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Orders_Training.svg",
-          "tint": "#141414",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 38,
-        "y": 56,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -87,10 +77,75 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "_id": "mVWaaMJ4l5KVO4IP",
   "img": "systems/ptr2e/img/perk-icons/Orders_Training.svg",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Cheerleader",
+      "type": "passive",
+      "_id": "LfffO81a97AsuPwO",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "cheerleader-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -15
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1772122041989,
+        "modifiedTime": 1772122245839,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "folder": "PAZ8zWUPw7Azm5V6"
 }

--- a/packs/core-perks/conservation-of-ninjutsu.json
+++ b/packs/core-perks/conservation-of-ninjutsu.json
@@ -1,0 +1,184 @@
+{
+  "name": "Conservation of Ninjutsu",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "conservation-of-ninjutsu",
+    "description": "<p>The user maintains a Conservation Clock, 10 Spans in size, which empties when a Combat starts or ends. For each @Affliction[fainted] @Trait[ninja] ally in the user’s Party, manually increment the Clock 1 Span. For each Span filled on the Conservation Clock, the user gains the following effects:</p><p>    +6% damage dealt while @Affliction[invisible]<br>    +2% EHR<br>    +1% EHR while @Affliction[invisible]<br>    +2% RES<br>    -2 flat Accuracy to Attacks targeting the user<br>    +5% SPD</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|level}",
+          25
+        ]
+      },
+      {
+        "gte": [
+          "{actor|skills.stealth.mod}",
+          80
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 5,
+    "design": {
+      "arena": "social",
+      "approach": "resilience",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 186,
+        "y": 35,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "one-with-the-shadows",
+          "misdirect"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/weapons/thrown/dagger-ringed-steel.webp",
+  "effects": [
+    {
+      "name": "Conservation of Ninjutsu",
+      "type": "passive",
+      "_id": "2XGipYSlTb7G1xoq",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "create-clock",
+            "key": "conserNinjaClock",
+            "value": 0,
+            "predicate": [
+              "trait:ninja"
+            ],
+            "max": 10,
+            "color": "#78736f",
+            "private": false,
+            "label": "Conservation",
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "attack-damage",
+            "value": "6*@actor.clocks.conserNinjaClock",
+            "predicate": [
+              "effect:affliction:invisible"
+            ],
+            "label": "Conservation of Ninjutsu",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "basic",
+            "key": "system.modifiers.effectHitRate",
+            "value": "2*@actor.clocks.conserNinjaClock",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.modifiers.effectHitRate",
+            "value": "@actor.clocks.conserNinjaClock",
+            "predicate": [
+              "effect:affliction:invisible"
+            ],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.modifiers.effectResistance",
+            "value": "2*@actor.clocks.conserNinjaClock",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "attack-accuracy-flat",
+            "value": "-2*@target.clocks.conserNinjaClock",
+            "predicate": [],
+            "label": "Conservation of Ninjutsu",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "basic",
+            "key": "system.modifiers.speMultiplier",
+            "value": "0.05*@target.clocks.conserNinjaClock",
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL",
+        "modifiedTime": 1772120336954
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "ji85RxkoJYlJXhlN"
+}

--- a/packs/core-perks/dress-to-impress.json
+++ b/packs/core-perks/dress-to-impress.json
@@ -47,7 +47,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "img": "systems/ptr2e/img/icons/equipment_icon.webp",
   "effects": [
@@ -96,7 +97,7 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.1.beta",
         "createdTime": 1737934863150,

--- a/packs/core-perks/dual-wielder.json
+++ b/packs/core-perks/dual-wielder.json
@@ -21,7 +21,8 @@
           "belt-expansion-1",
           "dress-to-impress",
           "yeomanry",
-          "nock-shot"
+          "nock-shot",
+          "flexible-iron"
         ],
         "config": {
           "alpha": null,
@@ -53,7 +54,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "_id": "QioUEl6UBFclZvzG",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
@@ -103,7 +105,7 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.1.beta",
         "createdTime": 1737566059443,

--- a/packs/core-perks/edgerunner.json
+++ b/packs/core-perks/edgerunner.json
@@ -17,8 +17,8 @@
     },
     "nodes": [
       {
-        "x": 182,
-        "y": 40,
+        "x": 175,
+        "y": 50,
         "hidden": false,
         "type": "normal",
         "connected": [
@@ -47,7 +47,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "effects": [
     {
@@ -98,7 +99,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.1.beta",
         "createdTime": 1754300144759,

--- a/packs/core-perks/flexible-iron.json
+++ b/packs/core-perks/flexible-iron.json
@@ -1,0 +1,134 @@
+{
+  "name": "Flexible Iron",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "flexible-iron",
+    "description": "<p>The user’s @Trait[weapon] Attacks have +10 Base Power, deal +5 flat damage, and the user’s @Trait[basic] Attacks gain @Trait[ninja].</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "trait:wielder",
+      "trait:ninja"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 194,
+        "y": 52,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "dual-wielder",
+          "secret-ninja-tools",
+          "pyrotechnical",
+          "pervasive-shadow"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/weapons/swords/sword-katana.webp",
+  "effects": [
+    {
+      "name": "Flexible Iron",
+      "type": "passive",
+      "_id": "1CyQ5BrYPKLs3Spk",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "key": "weapon-trait-attack",
+            "value": 10,
+            "predicate": [],
+            "property": "power",
+            "definition": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "weapon-trait-attack-damage-flat",
+            "value": 5,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "alter-attack",
+            "key": "basic-trait-attack",
+            "value": "ninja",
+            "predicate": [],
+            "property": "traits",
+            "definition": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "kJ2ykq4Nut3Wmec2"
+}

--- a/packs/core-perks/harass.json
+++ b/packs/core-perks/harass.json
@@ -1,0 +1,61 @@
+{
+  "name": "Harass",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "harass",
+    "description": "<p>If the user applies @UUID[Compendium.ptr2e.core-perks.1iAaHzCp7bW9108k]{Thug} to a creature after resolving an Attack affected by Shurikenjutsu, the targeted creature gains @Affliction[delay 20].</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "item:perk:shurikenjutsu",
+      "item:perk:thug"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 186,
+        "y": 44,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "whispering-wound",
+          "shurikenjutsu",
+          "minor-buff-68"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/weapons/thrown/daggers-kunai-purple.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "X8EqLOs66KcK0lZU"
+}

--- a/packs/core-perks/im-with-you.json
+++ b/packs/core-perks/im-with-you.json
@@ -7,7 +7,7 @@
   "system": {
     "actions": [],
     "slug": "im-with-you",
-    "description": "<p>Connection: Helping Hand<br><br>Effect: The user's @UUID[Compendium.ptr2e.core-moves.losiXPVUcTy72boW]{Helping Hand} move gains @Trait[interrupt-1].</p>",
+    "description": "<p>Connection - @UUID[Compendium.ptr2e.core-moves.losiXPVUcTy72boW]{Helping Hand}</p><p>Effect: The user is able to use Helping Hand as an @Trait[interrupt].</p>",
     "traits": [],
     "prerequisites": [
       {
@@ -61,7 +61,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "effects": [
     {
@@ -96,6 +97,16 @@
             "inMemoryOnly": false,
             "track": false,
             "replaceSelf": false
+          },
+          {
+            "type": "alter-attack",
+            "key": "helping-hand-attack",
+            "value": "interrupt",
+            "predicate": [],
+            "property": "traits",
+            "definition": [],
+            "mode": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -122,12 +133,20 @@
       "transfer": true,
       "statuses": [],
       "sort": 0,
-      "flags": {},
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-perks.Item.Z9RvqAZwW3zjuOrn.ActiveEffect.8rp8aXRLwsRFusz4",
         "duplicateSource": null,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
-        "exportSource": null
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL",
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "modifiedTime": 1772120905801
       }
     }
   ]

--- a/packs/core-perks/keep-fighting.json
+++ b/packs/core-perks/keep-fighting.json
@@ -17,16 +17,16 @@
       }
     ],
     "cost": 4,
-    "description": "<p>Trigger: An ally gains @Affliction[fainted].</p><p>Effect: The user can spend 8 PP as a Complex Action at @Trait[interrupt-4] when a creature at a range of 10m of the user gains @Affliction[fainted] to revive the target to @HP[5 tick] and heal have it lose 1 Stack of @Affliction[weary], and the user is Flinched 40%.</p>",
+    "description": "<p>Effect: The user can spend @PP[-7] as an @Trait[interrupt] @Trait[flinch-40] Complex Action when an Ally within 10m gains @Affliction[fainted],. The Ally is healed @HP[5 tick] and cured of 1 Stack of @Affliction[weary].</p>",
     "actions": [
       {
         "name": "Keep Fighting!",
         "slug": "keep-fighting",
-        "description": "<p>Trigger: An ally gains @Affliction[fainted].</p><p>Effect: The user can spend 8 PP as a Complex Action at @Trait[interrupt-4] when a creature at a range of 10m of the user gains @Affliction[fainted] to revive the target to @HP[5 tick] and heal have it lose 1 Stack of @Affliction[weary], and the user is Flinched 40%.</p>",
+        "description": "<p>Trigger: An ally gains @Affliction[fainted].</p><p>Effect: The target is healed @HP[5 tick] and loses 1 Stack of @Affliction[weary].</p>",
         "type": "generic",
         "cost": {
           "activation": "complex",
-          "powerPoints": 8,
+          "powerPoints": 7,
           "trigger": "An ally gains @Affliction[fainted]."
         },
         "range": {
@@ -35,9 +35,8 @@
           "unit": "m"
         },
         "traits": [
-          "interrupt-4",
           "healing",
-          "flinch-40"
+          "interrupt"
         ],
         "img": "systems/ptr2e/img/perk-icons/Tactician.svg"
       }
@@ -82,7 +81,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "_id": "3RMFsZTuMdDhCyZg",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
@@ -98,7 +98,9 @@
             "type": "roll-effect",
             "key": "keep-fighting-generic",
             "value": "Compendium.ptr2e.core-effects.Item.4DlXFTVooz07YcDm",
-            "predicate": [],
+            "predicate": [
+              "origin:ally"
+            ],
             "chance": 100,
             "isFixedChance": true,
             "affects": "target",
@@ -107,6 +109,25 @@
                 "mode": 5,
                 "property": "system.changes.0.value",
                 "value": 5
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "the-meaning-of-haste-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -40
               }
             ],
             "dontMerge": false,
@@ -144,10 +165,10 @@
         "exportSource": null,
         "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
+        "systemVersion": "1.5.0.beta",
         "createdTime": 1765234874919,
-        "modifiedTime": 1765234997941,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
+        "modifiedTime": 1772123680193,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
       }
     }
   ],

--- a/packs/core-perks/kinjutsu-1.json
+++ b/packs/core-perks/kinjutsu-1.json
@@ -1,0 +1,161 @@
+{
+  "name": "Kinjutsu 1",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "kinjutsu-1",
+    "description": "<p>The user learns 2 Moves from the @Trait[ninja] Tutor List and gains an extra Active Move Slot.</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "trait:ninja",
+      {
+        "gte": [
+          "{actor|level}",
+          10
+        ]
+      },
+      {
+        "gte": [
+          "{actor|skills.research.mod}",
+          50
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "ninja"
+    },
+    "variant": "tiered",
+    "mode": "coexist",
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 183,
+        "y": 42,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "shurikenjutsu",
+          "silence-is-golden"
+        ],
+        "tier": {
+          "rank": 1,
+          "uuid": null
+        },
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        }
+      },
+      {
+        "x": null,
+        "y": null,
+        "hidden": false,
+        "type": "normal",
+        "connected": [],
+        "tier": {
+          "rank": 2,
+          "uuid": "Item.8CztyY2bAb4zHSsg"
+        },
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        }
+      },
+      {
+        "x": null,
+        "y": null,
+        "hidden": false,
+        "type": "normal",
+        "connected": [],
+        "tier": {
+          "rank": 3,
+          "uuid": "Item.1nKJujeFmZjyfE53"
+        },
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        }
+      }
+    ]
+  },
+  "img": "icons/magic/unholy/hands-praying-fire-green.webp",
+  "effects": [
+    {
+      "name": "Kinjutsu 1",
+      "type": "passive",
+      "_id": "QGxn3P0KgD1dgWuS",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.modifiers.slots",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "zUVFDmegvWwiOReI"
+}

--- a/packs/core-perks/kinjutsu-2.json
+++ b/packs/core-perks/kinjutsu-2.json
@@ -1,0 +1,104 @@
+{
+  "name": "Kinjutsu 2",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "kinjutsu-2",
+    "description": "<p>The user learns 3 Moves from the @Trait[ninja] Tutor List and gains an extra Active Move Slot.</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "trait:ninja",
+      {
+        "gte": [
+          "{actor|level}",
+          20
+        ]
+      },
+      {
+        "gte": [
+          "{actor|skills.research.mod}",
+          65
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": []
+  },
+  "img": "icons/magic/unholy/hands-praying-fire-green.webp",
+  "effects": [
+    {
+      "name": "Kinjutsu 2",
+      "type": "passive",
+      "_id": "7DRG466k7XLWx22Q",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.modifiers.slots",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "QIoENOFG6zcvSzUM"
+}

--- a/packs/core-perks/kinjutsu-3.json
+++ b/packs/core-perks/kinjutsu-3.json
@@ -1,0 +1,104 @@
+{
+  "name": "Kinjutsu 3",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "kinjutsu-3",
+    "description": "<p>The user learns 4 Moves from the @Trait[ninja] Tutor List and gains an extra Accessory Slot.</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "trait:ninja",
+      {
+        "gte": [
+          "{actor|level}",
+          30
+        ]
+      },
+      {
+        "gte": [
+          "{actor|skills.research.mod}",
+          80
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 5,
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": []
+  },
+  "img": "icons/magic/unholy/hands-praying-fire-green.webp",
+  "effects": [
+    {
+      "name": "Kinjutsu 3",
+      "type": "passive",
+      "_id": "c9V7JyTEsGwOqYw4",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.inventory.accessory.max",
+            "value": 1,
+            "predicate": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "IArv81Uv7M8tx70C"
+}

--- a/packs/core-perks/minor-buff.json
+++ b/packs/core-perks/minor-buff.json
@@ -972,7 +972,9 @@
         "connected": [
           "snare",
           "stat-iv-booster-1",
-          "thermal-dynamics"
+          "thermal-dynamics",
+          "quantum-displacement",
+          "saprophyte"
         ],
         "config": {
           "texture": null,
@@ -993,7 +995,9 @@
           "minor-buff-8",
           "biting-cold",
           "ready-for-anything",
-          "dowsing-instinct"
+          "dowsing-instinct",
+          "refrigerate",
+          "quantum-displacement"
         ],
         "config": {
           "texture": null,
@@ -1472,8 +1476,46 @@
           "tint": null
         },
         "tier": null
+      },
+      {
+        "x": 180,
+        "y": 43,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "nothing-is-true",
+          "shurikenjutsu",
+          "whispering-wound",
+          "behind-every-blade-of-grass"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      },
+      {
+        "x": 185,
+        "y": 48,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "harass",
+          "pervasive-shadow",
+          "secret-ninja-tools"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
       }
-    ]
+    ],
+    "traitWebs": []
   },
   "_id": "minorbuffperk000",
   "img": "icons/svg/chest.svg",
@@ -1621,7 +1663,7 @@
       "disabled": false,
       "description": "<p>Offers a Choice Set to pick a @Trait[minor-buff] Perk.</p>",
       "_stats": {
-        "coreVersion": "13.346",
+        "coreVersion": "13.351",
         "systemId": null,
         "systemVersion": null,
         "createdTime": null,

--- a/packs/core-perks/misdirect.json
+++ b/packs/core-perks/misdirect.json
@@ -1,0 +1,61 @@
+{
+  "name": "Misdirect",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "misdirect",
+    "description": "<p>When the user inflicts a @Trait[major-affliction] or @Trait[minor-affliction] on one or more targeted creatures with an Attack affected by Shurikenjutsu, the user can then freely Move 3m using a Movement Type of their choice.</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "item:perk:shurikenjutsu"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 185,
+        "y": 37,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "shurikenjutsu",
+          "conservation-of-ninjutsu",
+          "smokestep",
+          "one-with-the-shadows"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/skills/targeting/target-glowing-yellow.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "GMdOyvZIWeXJa8Xs"
+}

--- a/packs/core-perks/mobilize.json
+++ b/packs/core-perks/mobilize.json
@@ -11,7 +11,7 @@
       }
     ],
     "cost": 1,
-    "description": "<p>Effect: The user spends 4 PP as a Simple Action and sets a Mobilize Summon at 100. While the Summon is active, allies cannot have [interrupt-x] Actions or Abilities triggered by their Movement.</p>",
+    "description": "<p>Effect: The user may spend @PP[-4] as a Simple Action to set a Mobilize Summon at 100. While the Summon is active, the user and their allies cannot have @Trait[interrupt] Actions or Abilities triggered by their Movement.</p>",
     "actions": [
       {
         "name": "Mobilize",
@@ -31,9 +31,7 @@
           "command",
           "social"
         ],
-        "img": "icons/svg/explosion.svg",
-        "variant": null,
-        "ephemeralVariant": false
+        "img": "icons/svg/explosion.svg"
       }
     ],
     "slug": "mobilize",
@@ -86,9 +84,7 @@
       ],
       "notes": ""
     },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "traitWebs": []
   },
   "_id": "EhfPkS23yRI8VENp",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",

--- a/packs/core-perks/monomi-no-ikki.json
+++ b/packs/core-perks/monomi-no-ikki.json
@@ -1,0 +1,66 @@
+{
+  "name": "Monomi-no-Ikki",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "monomi-no-ikki",
+    "description": "<p>The user spends 1 fewer IP on @Trait[ninja] items and can purchase @Trait[ninja] items one Rarity higher using IP.</p><p>The user provides a (non-stacking) +20 bonus on Special Order Rolls, which is doubled for @Trait[ninja] items, and the duration of the user’s @Trait[command] effects applied to other @Trait[ninja] creatures is increased by +1.</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "trait:ace",
+      "trait:ninja",
+      {
+        "gte": [
+          "{actor|skills.leadership.mod}",
+          50
+        ]
+      },
+      {
+        "gte": [
+          "{actor|skills.negotiate.mod}",
+          50
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 181,
+        "y": 37,
+        "connected": [
+          "smokestep",
+          "army-of-phantoms"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/sundries/documents/document-symbol-eye.webp",
+  "effects": [],
+  "flags": {},
+  "_id": "Q7i6DGm8c3eiZMdV"
+}

--- a/packs/core-perks/nothing-is-true.json
+++ b/packs/core-perks/nothing-is-true.json
@@ -14,7 +14,7 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Effect: The user gains the @Trait[ninja] trait.</p>",
+    "description": "<p>Connection - @UUID[Compendium.ptr2e.core-moves.PjOZd4TXRrr4PyHx]{Feint}. The user gains the @Trait[ninja] trait and learns 3 Grade D or lower Moves from the @Trait[ninja] Tutor List.</p>",
     "traits": [
       "ninja"
     ],
@@ -27,7 +27,7 @@
       }
     ],
     "autoUnlock": [],
-    "cost": 1,
+    "cost": 2,
     "design": {
       "arena": "physical",
       "approach": "finesse",
@@ -37,20 +37,29 @@
     "webs": [],
     "nodes": [
       {
-        "x": 177,
-        "y": 48,
-        "connected": [
-          "out-of-options",
-          "belt-expansion-1",
-          "pervasive-shadow",
-          "smokestep",
-          "root-2"
-        ],
+        "x": 174,
+        "y": 41,
         "hidden": false,
         "type": "normal",
+        "connected": [
+          "silence-is-golden",
+          "pervasive-shadow",
+          "smokestep",
+          "root-2",
+          "behind-every-blade-of-grass",
+          "minor-buff-66"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
-    ]
+    ],
+    "slug": "nothing-is-true",
+    "traitWebs": []
   },
   "img": "icons/skills/melee/strike-dagger-poison-green.webp",
   "effects": [
@@ -68,6 +77,32 @@
             "predicate": [],
             "mode": 2,
             "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "key": "",
+            "value": "Compendium.ptr2e.core-moves.Item.PjOZd4TXRrr4PyHx",
+            "predicate": [
+              "trait:ninja"
+            ],
+            "reevaluateOnUpdate": true,
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "mode": 2,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
           }
         ],
         "slug": null,
@@ -100,11 +135,11 @@
         "exportSource": null,
         "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
-        "lastModifiedBy": null
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL",
+        "modifiedTime": 1770738514573
       }
     }
   ],
-  "flags": {},
   "_id": "eJxc0lYNgPi8fooF"
 }

--- a/packs/core-perks/one-with-the-shadows.json
+++ b/packs/core-perks/one-with-the-shadows.json
@@ -1,0 +1,175 @@
+{
+  "name": "One With The Shadows",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "one-with-the-shadows",
+    "description": "<p>The user’s @Trait[ninja] Attacks have +20 Accuracy and have +10% EHR. Attacks targeting the user have -5 Accuracy and deal +15% more damage, doubled for @Trait[weapon] Attacks.</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "trait:ninja"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 189,
+        "y": 33,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "army-of-phantoms",
+          "conservation-of-ninjutsu",
+          "misdirect"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/magic/perception/silhouette-stealth-shadow.webp",
+  "effects": [
+    {
+      "name": "One With The Shadows",
+      "type": "passive",
+      "_id": "wuveSay7zTcIqvXZ",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-effect",
+            "key": "ninja-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.auJlcV40ua09ITga",
+            "predicate": [],
+            "affects": "self",
+            "alterations": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "key": "ninja-trait-attack",
+            "value": 20,
+            "predicate": [],
+            "property": "accuracy",
+            "definition": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "attack-accuracy-flat",
+            "value": -5,
+            "predicate": [
+              {
+                "not": "self:action:trait:weapon"
+              }
+            ],
+            "label": "One With The Shadows (Acc)",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "attack-accuracy-flat",
+            "value": -10,
+            "predicate": [
+              "self:action:trait:weapon"
+            ],
+            "label": "One With The Shadows (Wpn Acc)",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "attack-damage-percentile",
+            "value": 15,
+            "predicate": [
+              {
+                "not": "self:action:trait:weapon"
+              }
+            ],
+            "label": "One With The Shadows (Dmg)",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "key": "attack-damage-percentile",
+            "value": 30,
+            "predicate": [
+              "self:action:trait:weapon"
+            ],
+            "label": "One With The Shadows (Wpn Dmg)",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "YhYbM161HYod7ArC"
+}

--- a/packs/core-perks/out-of-options.json
+++ b/packs/core-perks/out-of-options.json
@@ -17,14 +17,13 @@
     },
     "nodes": [
       {
-        "x": 180,
-        "y": 44,
+        "x": 175,
+        "y": 46,
         "hidden": false,
         "type": "entry",
         "connected": [
           "edgerunner",
           "running-on-fumes",
-          "aura-user",
           "root-2",
           "belt-expansion-1"
         ],
@@ -51,7 +50,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "effects": [
     {
@@ -102,7 +102,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.1.beta",
         "createdTime": 1754299744190,

--- a/packs/core-perks/pervasive-shadow.json
+++ b/packs/core-perks/pervasive-shadow.json
@@ -14,7 +14,7 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Passive: The user gains +20% EHR while @Affliction[invisible].</p>",
+    "description": "<p>If the user is Undetected by at least one creature at the start of a Combat, the user may freely Move up to the Movement Score of their choice.</p><p>Passive: The user gains +20% EHR while @Affliction[invisible].</p>",
     "traits": [
       "ninja"
     ],
@@ -22,7 +22,7 @@
       "trait:ninja"
     ],
     "autoUnlock": [],
-    "cost": 3,
+    "cost": 2,
     "design": {
       "arena": "mental",
       "approach": "finesse",
@@ -32,20 +32,28 @@
     "webs": [],
     "nodes": [
       {
-        "x": 187,
+        "x": 182,
         "y": 50,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "nothing-is-true",
           "whispering-wound",
-          "silence-is-golden",
-          "smokestep",
-          "dual-wielder"
+          "minor-buff-68",
+          "minor-buff-67",
+          "flexible-iron"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
-    ]
+    ],
+    "slug": "pervasive-shadow",
+    "traitWebs": []
   },
   "img": "systems/ptr2e/img/perk-icons/Ninja.svg",
   "effects": [
@@ -97,11 +105,11 @@
         "exportSource": null,
         "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
-        "lastModifiedBy": null
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL",
+        "modifiedTime": 1770738235283
       }
     }
   ],
-  "flags": {},
   "_id": "WTDVHLvuuuI794TT"
 }

--- a/packs/core-perks/pyrotechnical.json
+++ b/packs/core-perks/pyrotechnical.json
@@ -1,0 +1,164 @@
+{
+  "name": "Pyrotechnical",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "pyrotechnical",
+    "description": "<p>Effect: The user's @Trait[explode], @Trait[firearm], and @Trait[fire] Attacks deal +20% more damage and have +10% EHR, while the user has +25% RES against Attacks with these Traits.</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "trait:ninja"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "mental",
+      "approach": "power",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 192,
+        "y": 46,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "shurikenjutsu",
+          "flexible-iron"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/weapons/thrown/rocket.webp",
+  "effects": [
+    {
+      "name": "Pyrotechnical",
+      "type": "passive",
+      "_id": "KmGkSUbAebK0M3n4",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "attack-damage",
+            "value": 20,
+            "predicate": [
+              {
+                "or": [
+                  "self:action:trait:firearm",
+                  "self:action:trait:explode",
+                  "self:action:trait:firearm"
+                ]
+              }
+            ],
+            "label": "Pyrotechnical",
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "key": "attack",
+            "value": "Compendium.ptr2e.core-effects.Item.auJlcV40ua09ITga",
+            "predicate": [
+              {
+                "or": [
+                  "self:action:trait:firearm",
+                  "self:action:trait:explode",
+                  "self:action:trait:firearm"
+                ]
+              }
+            ],
+            "label": "Pyrotechnical EHR",
+            "affects": "self",
+            "alterations": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "key": "attack",
+            "value": "Compendium.ptr2e.core-effects.Item.CekJx2L2a3x60g1b",
+            "predicate": [
+              {
+                "or": [
+                  "self:action:trait:firearm",
+                  "self:action:trait:explode",
+                  "self:action:trait:firearm"
+                ]
+              }
+            ],
+            "label": "Pyrotechnical RES",
+            "affects": "defensive",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.value",
+                "value": 25
+              }
+            ],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "NvYIhqsEzZDtRXnb"
+}

--- a/packs/core-perks/rapid-fire-commands.json
+++ b/packs/core-perks/rapid-fire-commands.json
@@ -23,6 +23,19 @@
             "dontMerge": false,
             "mode": 2,
             "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "command-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -55,10 +68,10 @@
         "exportSource": null,
         "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
+        "systemVersion": "1.5.0.beta",
         "createdTime": 1764896643568,
-        "modifiedTime": 1764896677521,
-        "lastModifiedBy": "bDEGyOQfZwkb2ml2"
+        "modifiedTime": 1772123976134,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
       }
     }
   ],
@@ -119,7 +132,8 @@
         },
         "tier": null
       }
-    ]
+    ],
+    "traitWebs": []
   },
   "folder": "PAZ8zWUPw7Azm5V6"
 }

--- a/packs/core-perks/root-2.json
+++ b/packs/core-perks/root-2.json
@@ -3,7 +3,7 @@
   "type": "perk",
   "folder": "zrVtKATNxzLNxTUc",
   "system": {
-    "description": "<p>This is an entry perk to the Web, it has no effect on its own.</p><p>Some of the clusters near Root 2 include:</p><ul><li>Mobility</li><li>Aura</li><li>Gear & Weapons</li><li>Damage over Time</li><li>Flying-Type</li></ul>",
+    "description": "<p>This is an entry perk to the Web, it has no effect on its own.</p><p>Some of the clusters near Root 2 include:</p><ul><li>Mobility</li><li>Aura</li><li>Gear & Weapons</li><li>Ninja</li><li>Damage over Time (DoT)</li><li>Flying-Type</li></ul>",
     "actions": [],
     "traits": [],
     "prerequisites": [],
@@ -36,24 +36,19 @@
           "lithic",
           "megafaunic",
           "echo-of-the-lost-world",
-          "recovered-instincts"
+          "recovered-instincts",
+          "nothing-is-true"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#5eaf3c",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "icons/svg/door-exit.svg",
-          "tint": "#ffffff",
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -67,7 +62,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "img": "icons/svg/door-exit.svg",
   "effects": [],

--- a/packs/core-perks/secret-ninja-tools.json
+++ b/packs/core-perks/secret-ninja-tools.json
@@ -4,76 +4,64 @@
   "folder": "CpqiTFuJPCaphgZU",
   "system": {
     "prerequisites": [
-      {
-        "gte": [
-          "{actor|skills.ninja.mod}",
-          30
-        ]
-      }
+      "trait:ninja"
     ],
-    "cost": 1,
-    "description": "<p>You have been trained to make the secret tools of the Ninja, and may now learn [Ninja] Crafting Recipes.</p>",
+    "cost": 3,
+    "description": "<p>While @Affliction[invisible], the user deals +10% damage with @Trait[ninja] Attacks, +10% damage with @Trait[weapon] Attacks, gains @Affliction[advance 10] when they use Draw, Store, or Use, and @Affliction[advance 20] when they use Bestow.</p><p>Bonus: The user's Draw, Store, Use, and Bestow Actions lose @Trait[manipulate] if the affected Item has @Trait[ninja].</p>",
     "actions": [
       {
         "name": "Secret Ninja Tools",
         "slug": "secret-ninja-tools",
         "description": "<p>You have been trained to make the secret tools of the Ninja, and may now learn [Ninja] Crafting Recipes.</p>",
         "cost": {
-          "activation": "complex",
-          "powerPoints": 0,
-          "delay": null,
-          "priority": null
+          "activation": "complex"
         },
         "type": "camping",
         "traits": [],
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m",
-          "distance": 0
-        },
-        "variant": null,
-        "ephemeralVariant": false
+          "unit": "m"
+        }
       }
     ],
     "slug": "secret-ninja-tools",
-    "traits": [],
+    "traits": [
+      "ninja"
+    ],
     "_migration": {
       "version": null,
       "previous": null
     },
     "nodes": [
       {
-        "connected": [
-          "blacksmith",
-          "trained-wielder"
-        ],
-        "config": {
-          "alpha": null,
-          "backgroundColor": "#804000",
-          "borderColor": null,
-          "borderWidth": null,
-          "texture": "systems/ptr2e/img/perk-icons/Ninja.svg",
-          "tint": "#ffffff",
-          "scale": null
-        },
+        "x": 190,
+        "y": 48,
         "hidden": false,
         "type": "normal",
-        "x": null,
-        "y": null,
+        "connected": [
+          "minor-buff-68",
+          "arms-of-resistance",
+          "shurikenjutsu",
+          "flexible-iron",
+          "minor-buff-67"
+        ],
+        "config": {
+          "texture": "systems/ptr2e/img/perk-icons/Ninja.svg",
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
-      "arena": "mental",
+      "arena": "physical",
       "approach": "finesse",
-      "archetype": "crafting"
+      "archetype": "ninja"
     },
     "publication": {
       "source": "PTR 2e Core",
@@ -81,9 +69,77 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "_id": "lgXZKwY1meY9SiO0",
   "img": "systems/ptr2e/img/perk-icons/Ninja.svg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Secret Ninja Tools",
+      "type": "passive",
+      "_id": "ZyJLdOfFHaVx7bSO",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "key": "ninja-trait-attack-damage",
+            "value": 10,
+            "predicate": [
+              "effect:affliction:invisible"
+            ],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "weapon-trait-attack-damage",
+            "value": 10,
+            "predicate": [
+              "effect:affliction:invisible"
+            ],
+            "mode": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1770928266811,
+        "modifiedTime": 1771963903171,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ]
 }

--- a/packs/core-perks/shurikenjutsu.json
+++ b/packs/core-perks/shurikenjutsu.json
@@ -1,0 +1,387 @@
+{
+  "name": "Shurikenjutsu",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "shurikenjutsu",
+    "description": "<p>The user’s @Trait[fling] or @Trait[missile] Attacks have +10% EHR and have a 10% chance of granting the user @Affliction[advance 20], with these amounts increasing by +5% if the attack has @Trait[weapon] and by +5% if it has @Trait[ninja].</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "trait:ninja"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 188,
+        "y": 42,
+        "connected": [
+          "silence-is-golden",
+          "secret-ninja-tools",
+          "minor-buff-66",
+          "harass",
+          "kinjutsu-1",
+          "misdirect",
+          "pyrotechnical"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/weapons/thrown/shuriken-blue.webp",
+  "effects": [
+    {
+      "name": "Shurikenjutsu",
+      "type": "passive",
+      "_id": "9obG5K9NFVQXZm8g",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-effect",
+            "key": "missile-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.auJlcV40ua09ITga",
+            "predicate": [
+              {
+                "not": "attack:original:fling"
+              }
+            ],
+            "label": "Shurikenjutsu",
+            "affects": "self",
+            "alterations": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "key": "missile-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.auJlcV40ua09ITga",
+            "predicate": [
+              {
+                "and": [
+                  {
+                    "not": "attack:original:fling"
+                  },
+                  "self:action:trait:weapon"
+                ]
+              }
+            ],
+            "label": "Shurikenjutsu",
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.value",
+                "value": 5
+              }
+            ],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "key": "missile-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.auJlcV40ua09ITga",
+            "predicate": [
+              {
+                "and": [
+                  {
+                    "not": "attack:original:fling"
+                  },
+                  "self:action:trait:ninja"
+                ]
+              }
+            ],
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.value",
+                "value": 5
+              }
+            ],
+            "label": "Shurikenjutsu",
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "key": "fling-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.auJlcV40ua09ITga",
+            "predicate": [
+              "attack:original:fling"
+            ],
+            "label": "Shurikenjutsu",
+            "affects": "self",
+            "alterations": [],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "key": "fling-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.auJlcV40ua09ITga",
+            "predicate": [
+              {
+                "and": [
+                  "attack:original:fling",
+                  "self:action:trait:weapon"
+                ]
+              }
+            ],
+            "label": "Shurikenjutsu",
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.value",
+                "value": 5
+              }
+            ],
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "key": "fling-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.auJlcV40ua09ITga",
+            "predicate": [
+              {
+                "and": [
+                  "attack:original:fling",
+                  "self:action:trait:ninja"
+                ]
+              }
+            ],
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.value",
+                "value": 5
+              }
+            ],
+            "label": "Shurikenjutsu",
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "missile-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
+            "predicate": [
+              {
+                "not": "attack:original:fling"
+              }
+            ],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": 20
+              }
+            ],
+            "dontMerge": false,
+            "label": "Shurikenjutsu (Adv)",
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "missile-trait-attack-effect-chance",
+            "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
+            "predicate": [
+              {
+                "and": [
+                  {
+                    "not": "attack:original:fling"
+                  },
+                  "self:action:trait:weapon"
+                ]
+              }
+            ],
+            "chance": 5,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": 20
+              }
+            ],
+            "dontMerge": false,
+            "label": "Shurikenjutsu (Adv)",
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "missile-trait-attack-effect-chance",
+            "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
+            "predicate": [
+              {
+                "and": [
+                  {
+                    "not": "attack:original:fling"
+                  },
+                  "self:action:trait:ninja"
+                ]
+              }
+            ],
+            "chance": 5,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": 20
+              }
+            ],
+            "dontMerge": false,
+            "label": "Shurikenjutsu (Adv)",
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "fling-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
+            "predicate": [
+              "attack:original:fling"
+            ],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": 20
+              }
+            ],
+            "dontMerge": false,
+            "label": "Shurikenjutsu (Adv)",
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "fling-trait-attack-effect-chance",
+            "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
+            "predicate": [
+              {
+                "and": [
+                  "attack:original:fling",
+                  "self:action:trait:weapon"
+                ]
+              }
+            ],
+            "chance": 5,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": 20
+              }
+            ],
+            "dontMerge": false,
+            "label": "Shurikenjutsu (Adv)",
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "fling-trait-attack-effect-chance",
+            "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
+            "predicate": [
+              {
+                "and": [
+                  "attack:original:fling",
+                  "self:action:trait:ninja"
+                ]
+              }
+            ],
+            "chance": 5,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": 20
+              }
+            ],
+            "dontMerge": false,
+            "label": "Shurikenjutsu (Adv)",
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "khKBbLQNt3gZsdjC"
+}

--- a/packs/core-perks/silence-is-golden.json
+++ b/packs/core-perks/silence-is-golden.json
@@ -32,18 +32,26 @@
     "webs": [],
     "nodes": [
       {
-        "x": 195,
-        "y": 41,
-        "connected": [
-          "pervasive-shadow",
-          "whispering-wound",
-          "smokestep"
-        ],
+        "x": 181,
+        "y": 40,
         "hidden": false,
         "type": "normal",
+        "connected": [
+          "shurikenjutsu",
+          "nothing-is-true",
+          "kinjutsu-1"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
-    ]
+    ],
+    "slug": "silence-is-golden",
+    "traitWebs": []
   },
   "img": "systems/ptr2e/img/perk-icons/Ninja.svg",
   "effects": [
@@ -103,6 +111,5 @@
       }
     }
   ],
-  "flags": {},
   "_id": "9gudOsfeHiyXZnqF"
 }

--- a/packs/core-perks/smokestep.json
+++ b/packs/core-perks/smokestep.json
@@ -17,7 +17,7 @@
       {
         "name": "Smokestep",
         "slug": "smokestep",
-        "description": "<p>Effect: As a Simple Action, the user can become @Affliction[invisible 3].<br><br>Passive: Whilst @Affliction[invisible], the user is considered to be Hidden or In Stealth even if enemies are aware of their presence.</p>",
+        "description": "<p>Effect: The user gains @Affliction[invisible 3].</p>",
         "traits": [
           "ninja"
         ],
@@ -33,7 +33,7 @@
         }
       }
     ],
-    "description": "<p>Effect: As a Simple Action, the user can become @Affliction[invisible 3].<br><br>Passive:  Whilst @Affliction[invisible], the user is considered to be Hidden or In Stealth even if enemies are aware of their presence.</p>",
+    "description": "<p>Effect: By spending 3 PP as a Simple Action at @Trait[flinch-20], the user can become @Affliction[invisible 3].<br><br>Passive: While @Affliction[invisible], the user is considered to be Undetected, in addition to Hidden, even if non-allied creatures are aware of their presence.</p>",
     "traits": [
       "ninja"
     ],
@@ -41,7 +41,7 @@
       "trait:ninja"
     ],
     "autoUnlock": [],
-    "cost": 3,
+    "cost": 2,
     "design": {
       "arena": "physical",
       "approach": "finesse",
@@ -51,20 +51,27 @@
     "webs": [],
     "nodes": [
       {
-        "x": 186,
-        "y": 44,
-        "connected": [
-          "nothing-is-true",
-          "edgerunner",
-          "army-of-phantoms",
-          "silence-is-golden",
-          "pervasive-shadow"
-        ],
+        "x": 178,
+        "y": 39,
         "hidden": false,
         "type": "normal",
+        "connected": [
+          "nothing-is-true",
+          "monomi-no-ikki",
+          "army-of-phantoms",
+          "misdirect"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
-    ]
+    ],
+    "slug": "smokestep",
+    "traitWebs": []
   },
   "img": "icons/svg/invisible.svg",
   "effects": [
@@ -88,6 +95,25 @@
                 "mode": 5,
                 "property": "duration.turns",
                 "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "smokestep-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": -20
               }
             ],
             "dontMerge": false,
@@ -125,11 +151,11 @@
         "exportSource": null,
         "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
-        "lastModifiedBy": null
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL",
+        "modifiedTime": 1770687228125
       }
     }
   ],
-  "flags": {},
   "_id": "xnEnVeWUELOEknw5"
 }

--- a/packs/core-perks/soothing-aura.json
+++ b/packs/core-perks/soothing-aura.json
@@ -29,7 +29,8 @@
         "img": "systems/ptr2e/img/perk-icons/Aura.svg",
         "range": {
           "target": "enemy",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         }
       }
     ],
@@ -71,7 +72,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "_id": "6m9rPR0KNKTQ2B40",
   "img": "systems/ptr2e/img/perk-icons/Aura.svg",

--- a/packs/core-perks/tactician.json
+++ b/packs/core-perks/tactician.json
@@ -25,7 +25,8 @@
         "img": "icons/svg/explosion.svg",
         "range": {
           "target": "enemy",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         }
       }
     ],
@@ -77,7 +78,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "_id": "13JRGGWEpyfuZZuG",
   "img": "systems/ptr2e/img/perk-icons/Tactician.svg",
@@ -93,7 +95,24 @@
             "type": "roll-effect",
             "key": "command-trait-generic",
             "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
-            "predicate": [],
+            "predicate": [
+              "origin:ally"
+            ],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "command-trait-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
+            "predicate": [
+              "origin:ally"
+            ],
             "chance": 100,
             "isFixedChance": true,
             "affects": "target",
@@ -133,10 +152,10 @@
         "exportSource": null,
         "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
+        "systemVersion": "1.5.0.beta",
         "createdTime": 1764897157595,
-        "modifiedTime": 1764897181010,
-        "lastModifiedBy": "bDEGyOQfZwkb2ml2"
+        "modifiedTime": 1772123940611,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
       }
     }
   ],

--- a/packs/core-perks/tag-and-bag.json
+++ b/packs/core-perks/tag-and-bag.json
@@ -1,0 +1,111 @@
+{
+  "name": "Tag and Bag",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "tag-and-bag",
+    "description": "<p>Effect: When using a @Trait[ninja] @Trait[contact] Attack on a creature, the user may freely use @UUID[Compendium.ptr2e.core-moves.nZIEKK2aQE5Y53Q4]{Grab} on the target creature with a +20 bonus. When using @UUID[Compendium.ptr2e.core-perks.Hya0QN5ldLWP9NVm]{Whispering Wound}, this bonus increases to +40, and the user may also freely use  @UUID[Compendium.ptr2e.core-perks.1iAaHzCp7bW9108k]{Thug} , if they have it.</p><p>Passive: The user's @Trait[ninja] Attacks gain @Trait[grapple].</p>",
+    "traits": [
+      "ninja"
+    ],
+    "prerequisites": [
+      "item:perk:whispering-wound"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "ninja"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 184,
+        "y": 47,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "whispering-wound"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/containers/bags/coinpouch-leather-orange.webp",
+  "effects": [
+    {
+      "name": "Tag and Bag",
+      "type": "passive",
+      "_id": "DroG5cCvyxlOcmD8",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "key": "ninja-trait-attack",
+            "value": "grapple",
+            "predicate": [],
+            "property": "traits",
+            "definition": [],
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "lastModifiedBy": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "alsv6gH4jnacH0BX"
+}

--- a/packs/core-perks/the-meaning-of-haste.json
+++ b/packs/core-perks/the-meaning-of-haste.json
@@ -9,39 +9,22 @@
       {
         "name": "The Meaning of Haste",
         "slug": "the-meaning-of-haste",
-        "description": "<p>All allied creatures gain +2 SPD stages for 5 Activations.</p>",
+        "description": "<p>Effect: The user and all allies in range are @Affliction[advance 30] and gain +2 SPD Stages for 3 Activations.</p>",
         "traits": [],
-        "type": "attack",
+        "type": "generic",
         "range": {
           "target": "field",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6
+          "powerPoints": 8
         },
-        "img": "systems/ptr2e/img/perk-icons/Orders_Training.svg",
-        "types": [
-          "untyped"
-        ],
-        "category": "status",
-        "predicate": [],
-        "free": true,
-        "variant": null,
-        "ephemeralVariant": false,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": "",
-        "offensiveStat": null,
-        "defensiveStat": null
+        "img": "systems/ptr2e/img/perk-icons/Orders_Training.svg"
       }
     ],
     "slug": "the-meaning-of-haste",
-    "description": "<p>Spend 6PP and grant a field-wide +2 SPD stages to yourself and all allies for 5 activations as a Complex Action.</p>",
+    "description": "<p>Effect: By spending @PP[-8] as a Complex Action, the user and all allies on the field are @Affliction[advance 30] and gain +2 SPD Stages for 3 Activations.</p>",
     "traits": [],
     "prerequisites": [
       {
@@ -58,24 +41,21 @@
     },
     "nodes": [
       {
+        "x": 39,
+        "y": 58,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "cheerleader",
           "im-with-you",
           "rapid-fire-commands"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#0000ff",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Orders_Training.svg",
-          "tint": null,
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 39,
-        "y": 58,
         "tier": null
       }
     ],
@@ -94,9 +74,7 @@
       ],
       "notes": ""
     },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "traitWebs": []
   },
   "effects": [
     {
@@ -108,23 +86,65 @@
         "changes": [
           {
             "type": "roll-effect",
-            "key": "the-meaning-of-haste-attack",
+            "key": "the-meaning-of-haste-generic",
             "value": "Compendium.ptr2e.core-effects.Item.XeiSuS3APUcN0MLZ",
-            "predicate": [],
+            "predicate": [
+              {
+                "or": [
+                  "targets:self",
+                  "origin:ally"
+                ]
+              }
+            ],
             "chance": 100,
             "affects": "target",
-            "mode": 2,
             "priority": null,
-            "ignored": false,
-            "alterations": [],
-            "dontMerge": false
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "isFixedChance": true,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "the-meaning-of-haste-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
+            "predicate": [
+              {
+                "or": [
+                  "targets:self",
+                  "origin:ally"
+                ]
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.amount",
+                "value": 30
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
@@ -142,16 +162,20 @@
       "transfer": true,
       "statuses": [],
       "sort": 0,
-      "flags": {},
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.2",
+        "systemVersion": "1.5.0.beta",
         "createdTime": 1736877838885,
-        "modifiedTime": 1736877883752,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "modifiedTime": 1772122900501,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL",
         "exportSource": null
       }
     }

--- a/packs/core-perks/victory-march.json
+++ b/packs/core-perks/victory-march.json
@@ -24,7 +24,7 @@
         "img": "icons/sundries/flags/banner-flag-red-white.webp",
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 5
         },
         "summon": "Compendium.ptr2e.core-summons.fFAxckcMfiygtqxM",
         "range": {
@@ -39,7 +39,7 @@
         "predicate": []
       }
     ],
-    "description": "<p>Effect: By spending @PP[-4] as a Complex Action, the user may may activate the Victory March summon, which grants allies on the field +20% Damage and +20% Damage Reduction for 3 rounds.</p>",
+    "description": "<p>Effect: By spending @PP[-5] as a Complex Action, the user may may activate the @UUID[Compendium.ptr2e.core-summons.fFAxckcMfiygtqxM]{Victory March Summon}, which grants allies on the field +20% Damage and +20% Damage Reduction for 3 rounds.</p>",
     "traits": [],
     "prerequisites": [],
     "autoUnlock": [],
@@ -71,7 +71,8 @@
         "tier": null
       }
     ],
-    "slug": "victory-march"
+    "slug": "victory-march",
+    "traitWebs": []
   },
   "img": "icons/sundries/flags/banner-flag-red-white.webp",
   "effects": [],

--- a/packs/core-perks/whispering-wound.json
+++ b/packs/core-perks/whispering-wound.json
@@ -17,10 +17,11 @@
       {
         "name": "Whispering Wound",
         "slug": "whispering-wound",
-        "description": "<p>Condition: The user must be @Affliction[invisible] or Undetected to use this action.<br><br>Effect: The user inflicts @UUID[Compendium.ptr2e.core-effects.V8CNzN148X1bYsSS]{Gagged 5} on the target.</p>",
+        "description": "<p>Effect: On hit, the user inflicts @UUID[Compendium.ptr2e.core-effects.V8CNzN148X1bYsSS]{Gagged 5}.</p><p>Restriction: The user must be @Affliction[invisible] or Undetected to use this Attack.</p>",
         "traits": [
           "ninja",
-          "contact"
+          "contact",
+          "priority-30"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/perk-icons/Ninja.svg",
@@ -42,16 +43,15 @@
         "accuracy": 100
       }
     ],
-    "description": "<p>Condition: The user must be @Affliction[invisible] or Undetected to use this action.<br><br>Effect: The user inflicts @UUID[Compendium.ptr2e.core-effects.V8CNzN148X1bYsSS]{Gagged 5} on the target.</p>",
+    "description": "<p>While the user is @Affliction[invisible] or Undetected by a creature, they may spend 2 PP as a Complex Action to target that creature with @UUID[Compendium.ptr2e.core-perks.Item.Hya0QN5ldLWP9NVm.Actions.whispering-wound]{Whispering Wound}.</p>",
     "traits": [
-      "ninja",
-      "contact"
+      "ninja"
     ],
     "prerequisites": [
       "trait:ninja"
     ],
     "autoUnlock": [],
-    "cost": 2,
+    "cost": 1,
     "design": {
       "arena": "physical",
       "approach": "finesse",
@@ -61,17 +61,27 @@
     "webs": [],
     "nodes": [
       {
-        "x": 198,
-        "y": 45,
-        "connected": [
-          "pervasive-shadow",
-          "silence-is-golden"
-        ],
+        "x": 183,
+        "y": 46,
         "hidden": false,
         "type": "normal",
+        "connected": [
+          "tag-and-bag",
+          "harass",
+          "pervasive-shadow",
+          "minor-buff-66"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
-    ]
+    ],
+    "slug": "whispering-wound",
+    "traitWebs": []
   },
   "img": "systems/ptr2e/img/perk-icons/Ninja.svg",
   "effects": [
@@ -131,6 +141,5 @@
       }
     }
   ],
-  "flags": {},
   "_id": "Hya0QN5ldLWP9NVm"
 }

--- a/packs/core-perks/your-targets-right-here.json
+++ b/packs/core-perks/your-targets-right-here.json
@@ -3,7 +3,147 @@
   "_id": "3JzUu6EOj3XHAwlt",
   "type": "perk",
   "img": "icons/creatures/birds/chicken-hen-white.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Your Target's Right Here!",
+      "type": "passive",
+      "_id": "s5iztFqKXXT3xkQ1",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "your-targets-right-here-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.k1FukpHKnZGqjSNc",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "system.changes.0.value",
+                "value": 1
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "your-targets-right-here-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.resolvedconditem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 2
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "your-targets-right-here-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.sMystTj3FBJ00AZp",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 2
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "your-targets-right-here-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.jEX7s3GbbAtzgyS3",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 2
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "your-targets-right-here-generic",
+            "value": "Compendium.ptr2e.core-effects.Item.markedcondititem",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "mode": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "mode": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "ptr2e": {
+          "displayOnToken": ""
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "ptr2e",
+        "systemVersion": "1.5.0.beta",
+        "createdTime": 1772124176935,
+        "modifiedTime": 1772124395990,
+        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -16,9 +156,27 @@
       ],
       "notes": ""
     },
-    "actions": [],
+    "actions": [
+      {
+        "name": "Your Target's Right Here!",
+        "slug": "your-targets-right-here",
+        "description": "<p>Effect: The target gains @Tick[1 shield], @Affliction[resolved 2], +1 DEF and SPDEF Stage for 2 Activations, and @Affliction[marked 3].</p>",
+        "traits": [],
+        "type": "generic",
+        "img": "icons/creatures/birds/chicken-hen-white.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 5
+        },
+        "range": {
+          "target": "ally",
+          "distance": 5,
+          "unit": "m"
+        }
+      }
+    ],
     "slug": "your-targets-right-here",
-    "description": "<p>Effect: The user spends 5 PP as a Complex Action. The target gains @Tick[1 shield], @Affliction[resolved 2], @UUID[Compendium.ptr2e.core-effects.sMystTj3FBJ00AZp]{+1 Defense Stage for 2 activations} and @UUID[Compendium.ptr2e.core-effects.jEX7s3GbbAtzgyS3]{+1 Special Defense Stage for 2 activations}, and @Affliction[marked 3].</p>",
+    "description": "<p>Effect: The user spends @PP[-5] as a Complex Action. An Ally within 5m gains @Tick[1 shield], @Affliction[resolved 2], +1 DEF and SPDEF Stage for 2 Activations, and @Affliction[marked 3].</p>",
     "traits": [],
     "prerequisites": [],
     "autoUnlock": [],
@@ -34,16 +192,23 @@
       {
         "x": 31,
         "y": 61,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "hold-the-line",
           "minor-buff-35",
           "tactician"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
-    ]
+    ],
+    "traitWebs": []
   },
   "folder": "PAZ8zWUPw7Azm5V6"
 }


### PR DESCRIPTION
Also a bunch of wording touchups for the Tactician Perks.

Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Perk: Root 2
- Update Perk: Out Of Options
- Update Perk: Edgerunner
- Update Perk: Belt Expansion 1
- Update Perk: Dress To Impress
- Update Perk: Dual Wielder
- Update Perk: Flexible Iron
- Update Perk: Pyrotechnical
- Update Perk: Arms of the Resistance
- Update Perk: Secret Ninja Tools
- Update Perk: Pervasive Shadow
- Update Perk: Tag and Bag
- Update Perk: Whispering Wound
- Update Perk: Harass
- Update Perk: Minor Buff
- Update Perk: Shurikenjutsu
- Update Perk: Kinjutsu 1
- Update Perk: Silence Is Golden
- Update Perk: Kinjutsu 2
- Update Perk: Kinjutsu 3
- Update Perk: Behind Every Blade of Grass
- Update Perk: Nothing Is True
- Update Perk: Monomi-no-Ikki
- Update Perk: Smokestep
- Update Perk: Conservation of Ninjutsu
- Update Perk: Misdirect
- Update Perk: One With The Shadows
- Update Perk: Army of Phantoms
- Update Perk: Soothing Aura
- Update Perk: Aura Empathy
- Update Perk: Aura User
- Update Perk: Victory March
- Update Perk: I'm With You!
- Update Perk: Cheerleader
- Update Perk: The Meaning of Haste
- Update Perk: Keep Fighting!
- Update Perk: Mobilize
- Update Perk: Tactician
- Update Perk: Rapid-Fire Commands
- Update Perk: Your Target's Right Here!