### PR TITLE
Foundry Data Sync - Frisk Automation Correction

### DIFF
--- a/packs/core-abilities/frisk.json
+++ b/packs/core-abilities/frisk.json
@@ -119,7 +119,7 @@
         "compendiumSource": "Actor.A02xdMnnGFUEgVLP.Item.m3G3abHjeyxhULLM.ActiveEffect.EhMbi4LWYpA3IVUh",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1758155858770,
@@ -153,11 +153,11 @@
               "grantee": "detach",
               "granter": "cascade"
             },
+            "reevaluateOnUpdate": true,
+            "allowDuplicate": false,
             "mode": 2,
             "ignored": false,
-            "reevaluateOnUpdate": false,
             "inMemoryOnly": false,
-            "allowDuplicate": true,
             "track": false,
             "replaceSelf": false
           }
@@ -195,12 +195,12 @@
         "compendiumSource": "Actor.A02xdMnnGFUEgVLP.Item.m3G3abHjeyxhULLM.ActiveEffect.Frisk4LWYpA3IVUh",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "13.351",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
+        "systemVersion": "1.5.0.beta",
         "createdTime": 1758155863495,
-        "modifiedTime": 1758155863495,
-        "lastModifiedBy": "UTlFSVhgfIUeTsoW"
+        "modifiedTime": 1773534906591,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
       }
     }
   ]


### PR DESCRIPTION
Was set to allow duplicate instead of re-evaluate on update. Since corrected.
- Update Ability: Frisk