### PR TITLE
Updating Affliction Traits and Descriptions, Revising Call and Hyper Mode

### DIFF
--- a/packs/core-effects/puppet.json
+++ b/packs/core-effects/puppet.json
@@ -15,7 +15,8 @@
     },
     "description": "<p>The afflicted creature's alliance changes to match that of the affliction's source.<br><br>NPC enemies become temporary Allies of the PCs, whilst afflicted PCs fall under the control of the GM.</p>",
     "traits": [
-      "major-affliction"
+      "minor-affliction",
+      "control"
     ],
     "slug": "puppet"
   },
@@ -30,7 +31,8 @@
         "changes": [],
         "slug": null,
         "traits": [
-          "major-affliction"
+          "minor-affliction",
+          "control"
         ],
         "removeAfterCombat": true,
         "removeOnRecall": false,

--- a/packs/core-moves/call.json
+++ b/packs/core-moves/call.json
@@ -11,7 +11,8 @@
         "type": "generic",
         "traits": [
           "command",
-          "basic"
+          "basic",
+          "flinch-20"
         ],
         "range": {
           "target": "ally",
@@ -20,9 +21,29 @@
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 1
+          "powerPoints": 0
         },
-        "description": "<p>Effect: The @Affliction[drowsy], @Affliction[confused], @Affliction[disabled], @Affliction[suppressed], @Affliction[enraged], @Affliction[charmed], @Affliction[fear], and @Affliction[taunted] Afflictions the user is Afflicted with have their Stack counts reduced by 2. A target afflicted with @Affliction[hyper-mode] is cured of @Affliction[hyper-mode].</p>",
+        "description": "<p>Effect: The target is cured of @Trait[attention] Afflictions and is @Affliction[delay 20]. The user may clear any @Trait[style] or @Trait[stance] effects from the target, if they wish.</p>",
+        "img": "icons/svg/explosion.svg"
+      },
+      {
+        "slug": "call-interrupt",
+        "name": "Call! (Interrupt)",
+        "type": "generic",
+        "traits": [
+          "flinch-20",
+          "interrupt"
+        ],
+        "range": {
+          "target": "self",
+          "distance": 0,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "free",
+          "powerPoints": 2
+        },
+        "description": "<p>The user may use @UUID[Compendium.ptr2e.core-moves.Item.eir0T0FTafp3GG9i.Actions.call]{Call!}, selecting a valid target.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],

--- a/packs/core-moves/call.json
+++ b/packs/core-moves/call.json
@@ -21,7 +21,7 @@
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 0
+          "powerPoints": 1
         },
         "description": "<p>Effect: The target is cured of @Trait[attention] Afflictions and is @Affliction[delay 20]. The user may clear any @Trait[style] or @Trait[stance] effects from the target, if they wish.</p>",
         "img": "icons/svg/explosion.svg"
@@ -41,7 +41,7 @@
         },
         "cost": {
           "activation": "free",
-          "powerPoints": 2
+          "powerPoints": 1
         },
         "description": "<p>The user may use @UUID[Compendium.ptr2e.core-moves.Item.eir0T0FTafp3GG9i.Actions.call]{Call!}, selecting a valid target.</p>",
         "img": "icons/svg/explosion.svg"

--- a/src/scripts/config/effects.json
+++ b/src/scripts/config/effects.json
@@ -191,6 +191,7 @@
       "traits": [
         "sleep",
         "major-affliction",
+        "attention",
         "control"
       ]
     },
@@ -554,7 +555,8 @@
       "removeOnRecall": false,
       "removeAfterCombat": true,
       "traits": [
-        "minor-affliction"
+        "minor-affliction",
+        "attention"
       ]
     },
     "description": "PTR2E.Effect.Statuses.Descriptions.confused"
@@ -616,12 +618,38 @@
         },
         {
           "type": "percentile-modifier",
-          "key": "all-damage",
+          "key": "attack-damage",
           "value": 15
-        }
+        },
+        {
+          "type": "stage-modifier",
+          "key": "shadow-trait-attack-crit",
+          "value": 2,
+          "predicate": [],
+          "mode": 2,
+          "ignored": false,
+          "hideIfDisabled": false
+        },
+        {
+          "type": "ephemeral-effect",
+          "key": "shadow-trait-attack",
+          "value": "Compendium.ptr2e.core-effects.Item.auJlcV40ua09ITga.ActiveEffect.4FLjKp9nBo2bfPia",
+          "predicate": [],
+          "affects": "self",
+          "alterations": [
+            {
+              "mode": 5,
+              "property": "system.changes.0.value",
+              "value": 30
+            }
+          ],
+  "mode": 2,
+  "ignored": false
+}
       ],
       "traits": [
-        "minor-affliction"
+        "minor-affliction",
+        "attention"
       ]
     },
     "description": "PTR2E.Effect.Statuses.Descriptions.hyper-mode"
@@ -918,6 +946,7 @@
       "traits": [
         "shadow",
         "major-affliction",
+        "attention",
         "dot"
       ]
     },
@@ -952,6 +981,7 @@
       "removeAfterCombat": true,
       "traits": [
         "minor-affliction",
+        "attention",
         "control"
       ]
     },
@@ -1012,6 +1042,7 @@
       "removeAfterCombat": true,
       "traits": [
         "minor-affliction",
+        "attention",
         "control"
       ]
     },
@@ -1589,6 +1620,7 @@
       "removeAfterCombat": true,
       "traits": [
         "minor-affliction",
+        "attention",
         "control"
       ]
     },
@@ -1695,6 +1727,7 @@
       "removeAfterCombat": true,
       "traits": [
         "minor-affliction",
+        "attention",
         "control"
       ]
     },
@@ -1716,6 +1749,7 @@
       "removeAfterCombat": true,
       "traits": [
         "minor-affliction",
+        "attention",
         "control"
       ]
     },
@@ -1748,6 +1782,7 @@
       "removeAfterCombat": true,
       "traits": [
         "minor-affliction",
+        "attention",
         "control"
       ]
     },

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -957,6 +957,7 @@
           "nightmares": "Nightmares",
           "frozen": "Frozen",
           "frostbite": "Frostbite",
+          "desync": "Desync",
           "splinter": "Splinter",
           "slowed": "Slowed",
           "hindered": "Hindered",
@@ -1007,8 +1008,7 @@
           "argute": "Argute",
           "loafing": "Loafing",
           "advance": "Advance",
-          "delay": "Delay",
-          "desync": "Desync"
+          "delay": "Delay"
         },
         "Descriptions": {
           "fainted": "<p>When a creature's HP reaches and remains at 0, it is afflicted with Fainted.</p><p>A Fainted creature cannot use Actions, does not benefit from Abilities, and is cured of all @Trait[major-affliction], @Trait[minor-affliction], @Trait[pseudo-affliction], and @Trait[stage-change] effects they possess.</p><p>Fainted is cured when the afflicted creature's HP is greater than 0.</p><p>The creature's @Affliction[weary] count increases by 1 whenever they are cured of Fainted.</p>",
@@ -1020,12 +1020,13 @@
           "nightmares": "This Affliction can only be applied to Drowsy creatures. The Power of all of the afflicted creature's attacks is reduced by 50%, and the creature cannot utilize the [Priority X] or [Interrupt X] capabilities of their actions. The creature loses a Tick of HP at the end of each of its Activations and has their default SPDEF and ACC Stages reduced by 1 while Nightmares is active. When a creature receives Nightmares, it loses the Drowsy Affliction, and gains 33% of its remaining Drowsy Stacks onto Nightmares, and further Nightmares Stacks cannot be applied.",
           "frozen": "The afflicted creature is unable to use actions (either during its Activations or as interrupts/reactions), but takes 33% less damage from all sources. The afflicted creature's default EVA Stages are reduced by 1. Additional Frozen Stacks cannot be added while Frozen is on a creature. When Frozen ticks down to zero Stacks (not cured), the afflicted creature gains Frostbite 5 and their next Activation is Advanced by 50%.",
           "frostbite": "The afflicted creature loses a Tick of HP at the end of each of their Activations. The creature has -1 default DEF Stages while Frostbite is active.",
+          "desync": "<p>When a creature is afflicted with @Affliction[desync], it cannot perform any Actions with the @Trait[interrupt-x] trait. When the afflicted creature is hit, it gains +1 stack of @Affliction[desync]. <br><br>At the end of the afflicted creature's next activation, all stacks of @Affliction[desync] are removed.</p><p>On removal of @Affliction[desync], the afflicted creature suffers a number of ticks of @Trait[dot] damage equal to the number of stacks removed. This is inclusive of the use of curative effects.</p>",
           "splinter": "The afflicted creature loses a Tick of HP when they are damaged by a Physical- or Special-Category attack. The creature has Stunted while Splinter is active.",
           "slowed": "The afflicted creature’s Movement Scores are reduced by 50%, rounding down (minimum 2).",
           "hindered": "The afflicted creature has the EHR of its Attacks and Actions decreased by 15%.",
           "stunted": "When the afflicted creature gains HP, PP, or Shields that amount is reduced by 2 Ticks (to a minimum of 0 HP/PP/Shields gained).",
           "confused": "The afflicted creature has its RES decreased by 10%. At the end of the afflicted creature's Activations, it has a 50% chance of using Fumble.",
-          "hyper-mode": "While afflicted with Hyper Mode, the afflicted creature gains +20% to all of its Movement Scores, while dealing and taking 15% more damage. As well, the user’s Shadow-Type attacks gain [Crit 2], or have their [Crit X] value increase by +2. At the start of the afflicted creature’s Activations, it has:<ul><li>a 40% chance to act normally on that Activation.</li><li>a 25% chance to be Choice-Locked 1 to Shadow-Type attacks.</li><li>a 15% chance of ending its Activation and using Fumble.</li><li>a 15% chance of using Backlash.</li><li>a 5% chance to be cured of Hyper Mode.</li></ul>",
+          "hyper-mode": "While afflicted with Hyper Mode, the afflicted creature gains +20% to all of its Movement Scores, while dealing and taking 15% more damage. As well, the user’s Shadow-Type attacks have +2 default CRIT and +30% EHR. At the start of the afflicted creature’s Activations, it has:<ul><li>a 40% chance to act normally on that Activation.</li><li>a 25% chance to be Choice-Locked 1 to Shadow-Type attacks.</li><li>a 15% chance of ending its Activation and using Fumble.</li><li>a 15% chance of using Backlash.</li><li>a 5% chance to be cured of Hyper Mode.</li></ul>",
           "weary": "<p>While a creature is afflicted with Weary, its default ACC and EVA Stages and its EHR and RES are reduced based on how many Stacks of Weary they possess, and other rules might apply:</p><h4>1 Stack</h4><ul><li>-1 default ACC & EVA Stages</li><li>-10% EHR</li><li>-5% RES</li></ul><h4>2 Stacks</h4><ul><li>-3 default ACC & EVA Stages</li><li>-30% EHR</li><li>-20% RES</li></ul><h4>3 Stacks</h4><ul><li>-1 default ACC & EVA Stages</li><li>-50% EHR</li><li>-35% RES</li></ul><h4>4+ Stacks</h4><ul><li>The afflicted creature is unable to battle.</li></ul><p>A creature gains 1 Stack of Weary whenever they gain @Affliction[fainted]. Weary cannot wear off on its own - a creature must deliberately Rest or consume Items to remove Stacks of Weary.</p>",
           "exposed": "An afflicted creature has its effect RES decreased by 15% and it cannot remove Weary.",
           "blinded": "The afflicted creature is unable to see, ocularly. The creature has their \"seeing-based\" vision options disabled (standard vision, Darkvision, X-Ray Vision, etc.) and can only perceive using their other senses (as listed in their Traits). If they do not have a way to see, or have someone guiding them, they are unable to target other creatures with Attacks or Actions.",
@@ -1070,8 +1071,7 @@
           "argute": "An afflicted creature has the EHR of its Attacks and Actions increase by 25%.",
           "loafing": "<p>A creature automatically gains this Affliction automatically if they are 2+ levels above their Team Leader's level. This Affliction's Stack Count is dynamically determined based on the level of the Afflicted creature and that of their Team Leader. This Affliction applies an assortment of penalties that scale up based on how many Stacks are present:</p><h4>1 Stack</h4><ul><li>-15% to all Damage dealt with Physical- and Special-Category Attacks</li><li>-15% to all Skill checks</li><li>-1 default SPD Stage</li><li>+15% PP Cost</li></ul><h4>2 Stacks</h4><ul><li>-30% to all Damage dealt with Physical- and Special-Category Attacks</li><li>-30% to all Skill Checks</li><li>-1 default SPD Stage</li><li>+30% PP Cost</li><li>-10 flat Accuracy</li><li>Gain @Affliction[unlucky]</li></ul><h4>3 Stacks</h4><ul><li>-50% to all Damage dealt with Physical- and Special-Category Attacks</li><li>-50% to all Skill checks</li><li>-2 default SPD Stage</li><li>+50% PP Cost</li><li>-20 flat Accuracy</li><li>Gain @Affliction[unlucky]</li><li>-2 to all Movement Scores</li></ul><h4>4 Stacks</h4><ul><li>-80% to all Damage dealt with Physical- and Special-Category Attacks</li><li>-80% to all Skill checks</li><li>-2 default SPD Stage</li><li>+80% PP Cost</li><li>-30 flat Accuracy</li><li>Gain @Affliction[unlucky]</li><li>-5 to all Movement Scores</li></ul>",
           "advance": "The afflicted creature's next Activation is Advanced by XY%. Default is 10%.",
-          "delay": "The afflicted creature's next Activation is Delayed by XY%. Default is 10%.",
-          "desync": "<p>When a creature is afflicted with @Affliction[desync], it cannot perform any Actions with the @Trait[interrupt-x] trait. When the afflicted creature is hit, it gains +1 stack of @Affliction[desync]. <br><br>At the end of the afflicted creature's next activation, all stacks of @Affliction[desync] are removed.</p><p>On removal of @Affliction[desync], the afflicted creature suffers a number of ticks of @Trait[dot] damage equal to the number of stacks removed. This is inclusive of the use of curative effects.</p>"
+          "delay": "The afflicted creature's next Activation is Delayed by XY%. Default is 10%."
         }
       }
     },

--- a/static/traits.json
+++ b/static/traits.json
@@ -3664,6 +3664,12 @@
     "description": "Denotes if an attack or ability features social interaction."
   },
   {
+    "slug": "attention",
+    "label": "Attention",
+    "related": [],
+    "description": "Denotes if an effect affects a creature's ability to focus."
+  },
+  {
     "slug": "sonic",
     "label": "Sonic",
     "related": [],
@@ -4652,9 +4658,9 @@
   },
   {
     "slug": "closed-heart",
-    "label": "Closed-Heart",
+    "label": "Closed Heart",
     "related": [],
-    "description": "Creatures with this Trait possess a heart that's been forcefully closed, gaining the following changes:\n1) +50% SPD\n2) The Extra Abilities \"Hyper Agressive\" and \"Coldhearted\"\n3) +1 Active List Slot\n4) Access to the [Shadow] %lt;Type&gt;Learnlist\n5) The Anguish Skill (100 by default) and its associated mechanics\n6) Are susceptible to the \"Hyper Mode\" Affliction\n7) Cannot undergo Evolution or other miscellaneous transformations\n8. Placed onto a slower EXP Track, based on their Species"
+    "description": "Creatures with this Trait possess a heart that's been forcefully closed."
   },
   {
     "slug": "ignore-immunity",


### PR DESCRIPTION
Adding Attention Trait (a categorical trait not unlike Control), adding Attention to Afflictions and adding missing traits to Afflictions.
Hyper Mode revised (to include Shadow Crit effect and new Shadow EHR effect).
Call! Revised (to cure Attention afflictions and given an Interrupt Action).