### PR TITLE
Foundry Data Sync - Shadow Move Updates

### DIFF
--- a/packs/core-moves/backlash.json
+++ b/packs/core-moves/backlash.json
@@ -11,7 +11,10 @@
         "type": "attack",
         "traits": [
           "basic",
-          "contact"
+          "contact",
+          "recoil-1-6",
+          "crit-1",
+          "flinch-15"
         ],
         "range": {
           "target": "creature",
@@ -20,29 +23,32 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 0,
           "trigger": "<p>Activated by an Effect.</p>"
         },
         "category": "physical",
-        "power": 70,
-        "accuracy": 90,
+        "power": 85,
+        "accuracy": 85,
         "types": [
           "shadow"
         ],
-        "description": "<p>Trigger: Activated by an Effect.</p><p>Effect: The user freely Moves up to the Score of a Movement Type it possesses and attacks the nearest creature with this Attack. If multiple creatures are equally close to the user, the target is selected randomly. If the nearest target or a randomly-selected target cannot be moved to using the creature's Movement, the next-closest creature is selected or another creature is randomly selected. If the user cannot resolve this Attack against a target, it hits itself with Fumble.</p>",
-        "contestType": "",
-        "contestEffect": "",
+        "description": "<p>Trigger: Activated by an Effect.</p><p>Effect: The user freely Moves up to the Score of a Movement Type it possesses and attacks the nearest creature with this Attack. If multiple creatures are equally close to the user, the target is selected randomly. If the nearest target or a randomly-selected target cannot be moved to using the creature's Movement, the next-closest creature is selected or another creature is randomly selected. If the user cannot resolve this Attack against a target, it hits itself with @UUID[Compendium.ptr2e.core-moves.Item.xoFyO6Z8yZJ9Ko8e]{Fumble}.</p>",
         "free": true,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "E",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "3RvYsD6CXrWCW0YS",

--- a/packs/core-moves/shadow-barrage.json
+++ b/packs/core-moves/shadow-barrage.json
@@ -15,7 +15,7 @@
         ],
         "range": {
           "target": "creature",
-          "distance": 5,
+          "distance": 6,
           "unit": "m"
         },
         "cost": {
@@ -23,25 +23,27 @@
           "powerPoints": 5
         },
         "category": "physical",
-        "power": 25,
-        "accuracy": 100,
+        "power": 28,
+        "accuracy": 90,
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B",
+    "grade": "C",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "nvwHiIfxfZtSPk0d",

--- a/packs/core-moves/shadow-blast.json
+++ b/packs/core-moves/shadow-blast.json
@@ -20,7 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7
+          "powerPoints": 9
         },
         "category": "special",
         "power": 100,
@@ -28,20 +28,22 @@
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "A",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "GamlRgOVyXhO3elq",

--- a/packs/core-moves/shadow-blitz.json
+++ b/packs/core-moves/shadow-blitz.json
@@ -13,7 +13,8 @@
           "push-1",
           "dash",
           "basic",
-          "contact"
+          "contact",
+          "recoil-1-10"
         ],
         "range": {
           "target": "creature",
@@ -22,28 +23,30 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 0
+          "powerPoints": 1
         },
         "category": "physical",
         "power": 40,
-        "accuracy": 100,
+        "accuracy": 95,
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "LqjdVMLkvMdh22y2",

--- a/packs/core-moves/shadow-bolt.json
+++ b/packs/core-moves/shadow-bolt.json
@@ -9,7 +9,9 @@
         "slug": "shadow-bolt",
         "name": "Shadow Bolt",
         "type": "attack",
-        "traits": [],
+        "traits": [
+          "pulse"
+        ],
         "range": {
           "target": "creature",
           "distance": 10,
@@ -17,7 +19,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 6
         },
         "category": "special",
         "power": 90,
@@ -25,8 +27,8 @@
         "types": [
           "shadow"
         ],
-        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[paralysis 5].</p>",
-        "img": "icons/svg/explosion.svg",
+        "description": "<p>Effect: On hit, the target has a 15% chance of gaining @Affliction[paralysis 5].</p>",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
         "predicate": []
       }
     ],
@@ -40,7 +42,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "9QeNvziOB80xdTut",
@@ -57,23 +60,31 @@
             "key": "shadow-bolt-attack",
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.paralysisconditi",
             "predicate": [],
-            "chance": 10,
+            "chance": 15,
             "affects": "target",
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -85,13 +96,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.5",
+        "systemVersion": "1.7.2.beta",
         "createdTime": 1737317680157,
-        "modifiedTime": 1737317699884,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1775575214465,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-moves/shadow-boost.json
+++ b/packs/core-moves/shadow-boost.json
@@ -9,25 +9,27 @@
         "slug": "shadow-boost",
         "name": "Shadow Boost",
         "type": "attack",
-        "traits": [],
+        "traits": [
+          "flinch-20"
+        ],
         "range": {
           "target": "self",
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7
+          "powerPoints": 6
         },
         "category": "status",
         "types": [
           "shadow"
         ],
         "description": "<p>Effect: The user's DEF and SPDEF Stages are reduced by -1, and their ATK and SPATK Stages are increased by +3 for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
         "predicate": []
       }
     ],
-    "grade": "A",
+    "grade": "B",
     "traits": [],
     "_migration": {
       "version": null,
@@ -37,7 +39,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "8XIuyqZaczFmCebp",
@@ -55,10 +58,14 @@
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.bdYCJcqjMNqTpJJQ",
             "predicate": [],
             "chance": 100,
-            "affects": "target",
+            "affects": "self",
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -66,10 +73,14 @@
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.qe5aLBJuwb9eYqvv",
             "predicate": [],
             "chance": 100,
-            "affects": "target",
+            "affects": "self",
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -77,10 +88,14 @@
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.tH75RuGeGEDpXSah",
             "predicate": [],
             "chance": 100,
-            "affects": "target",
+            "affects": "self",
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -88,22 +103,30 @@
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.1TqcwIUNl32wJCAz",
             "predicate": [],
             "chance": 100,
-            "affects": "target",
+            "affects": "self",
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -115,13 +138,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.5",
+        "systemVersion": "1.7.2.beta",
         "createdTime": 1737317785606,
-        "modifiedTime": 1737317922811,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1775575295864,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-moves/shadow-break.json
+++ b/packs/core-moves/shadow-break.json
@@ -20,7 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3
+          "powerPoints": 5
         },
         "category": "physical",
         "power": 80,
@@ -28,22 +28,91 @@
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "description": "<p>Effect: On hit, the target loses @Tick[-3 shield].</p>",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "D",
+    "grade": "C",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "CE4K7G368hesRDY5",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shadow Break",
+      "type": "passive",
+      "_id": "dKSHiPXGjbTE9wzm",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.k1FukpHKnZGqjSNc",
+            "phase": "initial",
+            "predicate": [],
+            "key": "shadow-break-attack",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": -3
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775575892327,
+        "modifiedTime": 1775576293328,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shadow-chill.json
+++ b/packs/core-moves/shadow-chill.json
@@ -19,7 +19,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 6
         },
         "category": "special",
         "power": 90,
@@ -27,12 +27,12 @@
         "types": [
           "shadow"
         ],
-        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[frozen 2].</p>",
-        "img": "icons/svg/explosion.svg",
+        "description": "<p>Effect: On hit, the target has a 15% chance of gaining @Affliction[frozen 2].</p>",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
         "predicate": []
       }
     ],
-    "grade": "B",
+    "grade": "A",
     "traits": [],
     "_migration": {
       "version": null,
@@ -42,7 +42,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "bfcVVK88b5gpmWXP",
@@ -59,24 +60,31 @@
             "key": "shadow-chill-attack",
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.frozencondition0",
             "predicate": [],
-            "chance": 10,
+            "chance": 15,
             "affects": "target",
             "priority": null,
-            "ignored": false,
             "alterations": [],
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -88,13 +96,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.2.1",
+        "systemVersion": "1.7.2.beta",
         "createdTime": 1737744929481,
-        "modifiedTime": 1737744944641,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+        "modifiedTime": 1775575372794,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-moves/shadow-corruption.json
+++ b/packs/core-moves/shadow-corruption.json
@@ -9,7 +9,10 @@
         "slug": "shadow-corruption",
         "name": "Shadow Corruption",
         "type": "attack",
-        "traits": [],
+        "traits": [
+          "aura",
+          "pulse"
+        ],
         "range": {
           "target": "creature",
           "distance": 1,
@@ -17,19 +20,20 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1
+          "powerPoints": 3
         },
         "category": "special",
-        "power": 30,
-        "accuracy": 90,
+        "power": 60,
+        "accuracy": 85,
         "types": [
           "shadow"
         ],
-        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[poison 5], and a 50% chance of gaining @Affliction[burn 5].</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: On hit, the target has a 50% chance of gaining @Affliction[poison 5] and @Affliction[burn 5].</p>",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "_migration": {
       "version": null,
       "previous": null
@@ -38,8 +42,10 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "traits": []
   },
   "_id": "NVPL4V25PvYi04If",
   "effects": [
@@ -59,7 +65,11 @@
             "affects": "target",
             "priority": null,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false
           },
           {
             "type": "roll-effect",
@@ -70,19 +80,27 @@
             "affects": "target",
             "priority": null,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -94,13 +112,17 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-moves.Item.NVPL4V25PvYi04If.ActiveEffect.2YY1tBzXaHb9aq1m",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.5.0",
         "createdTime": 1735910698847,
         "modifiedTime": 1735910762141,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+        "lastModifiedBy": "Kc3DOunCh3ClAeHS",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-moves/shadow-crash.json
+++ b/packs/core-moves/shadow-crash.json
@@ -10,10 +10,11 @@
         "name": "Shadow Crash",
         "type": "attack",
         "traits": [
-          "crash-1-2",
           "crushing",
           "dash",
-          "contact"
+          "contact",
+          "crash-1-3",
+          "priority-15"
         ],
         "range": {
           "target": "creature",
@@ -22,28 +23,30 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3
+          "powerPoints": 4
         },
         "category": "physical",
-        "power": 90,
-        "accuracy": 90,
+        "power": 115,
+        "accuracy": 85,
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "C",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "qplstizUyKOJIybM",

--- a/packs/core-moves/shadow-crush.json
+++ b/packs/core-moves/shadow-crush.json
@@ -28,7 +28,7 @@
           "shadow"
         ],
         "description": "<p>Effect: On hit, the target has a 80% chance of losing -1 DEF Stage for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
         "predicate": []
       }
     ],
@@ -42,7 +42,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "18ZKiSXENwifLgHV",
@@ -63,19 +64,27 @@
             "affects": "target",
             "priority": null,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -87,13 +96,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.5.1.5",
         "createdTime": 1737317959832,
         "modifiedTime": 1737317982675,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-moves/shadow-devastation.json
+++ b/packs/core-moves/shadow-devastation.json
@@ -11,8 +11,9 @@
         "type": "attack",
         "traits": [
           "ray",
-          "blast-4",
-          "recoil-1-3"
+          "recoil-1-9",
+          "flinch-60",
+          "blast-3"
         ],
         "range": {
           "target": "blast",
@@ -21,28 +22,30 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 10
+          "powerPoints": 8
         },
         "category": "special",
-        "power": 130,
+        "power": 140,
         "accuracy": 85,
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "A",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "678pWxOGkuV9cx9M",

--- a/packs/core-moves/shadow-down.json
+++ b/packs/core-moves/shadow-down.json
@@ -10,7 +10,8 @@
         "name": "Shadow Down",
         "type": "attack",
         "traits": [
-          "friendly"
+          "friendly",
+          "flinch-30"
         ],
         "range": {
           "target": "emanation",
@@ -19,7 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 9
+          "powerPoints": 7
         },
         "category": "status",
         "accuracy": 85,
@@ -27,11 +28,11 @@
           "shadow"
         ],
         "description": "<p>Effect: On hit, all valid targets lose -2 DEF Stage for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
         "predicate": []
       }
     ],
-    "grade": "A",
+    "grade": "B",
     "traits": [],
     "_migration": {
       "version": null,
@@ -41,9 +42,74 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "R4t5pLgeDvmZ3fd6",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shadow Down",
+      "type": "passive",
+      "_id": "FlBIMXO22uqg7yRs",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.B79G2s6TauIlmsno",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "origin:ally"
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "shadow-down-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775576199818,
+        "modifiedTime": 1775576267948,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shadow-end.json
+++ b/packs/core-moves/shadow-end.json
@@ -12,7 +12,8 @@
         "traits": [
           "recoil-1-2",
           "dash",
-          "contact"
+          "contact",
+          "flinch-20"
         ],
         "range": {
           "target": "creature",
@@ -21,28 +22,30 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6
+          "powerPoints": 7
         },
         "category": "physical",
-        "power": 120,
+        "power": 160,
         "accuracy": 100,
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "B",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "GnTe76YFcBJc6BDB",

--- a/packs/core-moves/shadow-engorge.json
+++ b/packs/core-moves/shadow-engorge.json
@@ -1,0 +1,55 @@
+{
+  "name": "Shadow Engorge",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "shadow-engorge",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Shadow Engorge",
+        "slug": "shadow-engorge",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "traits": [
+          "contact",
+          "jaw",
+          "drain-3-5",
+          "flinch-20",
+          "8-strike"
+        ],
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "types": [
+          "shadow"
+        ],
+        "category": "physical",
+        "predicate": [],
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "power": 14,
+        "accuracy": 85
+      }
+    ],
+    "grade": "C"
+  },
+  "_id": "mkKCaJofaGSIagcl",
+  "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-moves/shadow-fire.json
+++ b/packs/core-moves/shadow-fire.json
@@ -19,7 +19,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 6
         },
         "category": "special",
         "power": 90,
@@ -27,8 +27,8 @@
         "types": [
           "shadow"
         ],
-        "description": "<p>Effect: On hit, the target has a 10% chance of gaining @Affliction[burn 5].</p>",
-        "img": "icons/svg/explosion.svg",
+        "description": "<p>Effect: On hit, the target has a 15% chance of gaining @Affliction[burn 5].</p>",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
         "predicate": []
       }
     ],
@@ -42,7 +42,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "O57gfX8AHRF03KUM",
@@ -59,23 +60,31 @@
             "key": "shadow-fire-attack",
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.burncondition000",
             "predicate": [],
-            "chance": 10,
+            "chance": 15,
             "affects": "target",
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -87,13 +96,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.5",
+        "systemVersion": "1.7.2.beta",
         "createdTime": 1737318063895,
-        "modifiedTime": 1737318080178,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1775576432710,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-moves/shadow-half.json
+++ b/packs/core-moves/shadow-half.json
@@ -10,7 +10,7 @@
         "name": "Shadow Half",
         "type": "attack",
         "traits": [
-          "contact"
+          "flinch-40"
         ],
         "range": {
           "target": "emanation",
@@ -26,7 +26,7 @@
         "types": [
           "shadow"
         ],
-        "description": "<p>Effect: On hit, all valid targets lose 1/2 of their current HP. The user also loses half of its current HP. This attack always deals a minimum of 1 HP in damage.</p>",
+        "description": "<p>Effect: On hit, all valid targets lose 50% of the current value of the HP and Shields, minimum 1.</p>",
         "img": "systems/ptr2e/img/svg/shadow_icon.svg",
         "predicate": []
       }

--- a/packs/core-moves/shadow-hold.json
+++ b/packs/core-moves/shadow-hold.json
@@ -11,11 +11,12 @@
         "type": "attack",
         "traits": [
           "social",
-          "friendly"
+          "friendly",
+          "flinch-20"
         ],
         "range": {
           "target": "cone",
-          "distance": 4,
+          "distance": 6,
           "unit": "m"
         },
         "cost": {
@@ -23,27 +24,147 @@
           "powerPoints": 4
         },
         "category": "status",
-        "power": null,
-        "accuracy": 90,
+        "accuracy": 70,
         "types": [
           "shadow"
         ],
-        "description": "<p>Effect: All valid targets are @Affliction[bound 5]. While @Affliction[bound], targets suffer from @Affliction[fear] and @Affliction [wracked]. This @Affliction[bound] effect can be removed with a Challenging Psychology Skill Check taken as a Simple Action.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "description": "<p>Effect: All valid targets are @Affliction[bound 5]. While @Affliction[bound], targets suffer from @Affliction[hindered], @Affliction[stuck], and @Affliction[wracked]. This @Affliction[bound] effect can be removed with a Challenging Psychology Skill Check taken as a Simple Action.</p>",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "C",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "CyMi4XRCGuVLIGPW",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shadow Hold",
+      "type": "passive",
+      "_id": "6O5uw2NQdaU4urn9",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.boundconditiitem",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "origin:ally"
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "shadow-hold-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.hinderedconditem",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "origin:ally"
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "shadow-hold-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.stuckconditiitem",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "origin:ally"
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "shadow-hold-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.wrackedcondiitem",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "origin:ally"
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "shadow-hold-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775576588956,
+        "modifiedTime": 1775577481091,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shadow-lift.json
+++ b/packs/core-moves/shadow-lift.json
@@ -9,26 +9,29 @@
         "slug": "shadow-lift",
         "name": "Shadow Lift",
         "type": "attack",
-        "traits": [],
+        "traits": [
+          "flinch-25"
+        ],
         "range": {
           "target": "creature",
-          "distance": 5,
+          "distance": 3,
           "unit": "m"
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 8
+          "powerPoints": 4
         },
         "category": "status",
         "types": [
           "shadow"
         ],
-        "description": "<p>Effect: The target is @Affliction[lifted 5]. Shadow Lift fails if the target is @Affliction[grounded].</p>",
-        "img": "icons/svg/explosion.svg",
-        "predicate": []
+        "description": "<p>Effect: The target is @Affliction[lifted 3]. This Attack fails if the target is @Affliction[grounded].</p>",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": [],
+        "accuracy": 70
       }
     ],
-    "grade": "A",
+    "grade": "D",
     "traits": [],
     "_migration": {
       "version": null,
@@ -38,7 +41,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "XL2mwxQG7Po2BpvP",
@@ -58,21 +62,34 @@
             "chance": 100,
             "affects": "target",
             "priority": null,
-            "ignored": false,
-            "alterations": [],
-            "method": 2
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -84,13 +101,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.2.1",
+        "systemVersion": "1.7.2.beta",
         "createdTime": 1737746877425,
-        "modifiedTime": 1737746900121,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+        "modifiedTime": 1775576924048,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 0,
+      "folder": null
     }
   ]
 }

--- a/packs/core-moves/shadow-mist.json
+++ b/packs/core-moves/shadow-mist.json
@@ -19,15 +19,15 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6
+          "powerPoints": 7
         },
         "category": "status",
-        "accuracy": 85,
+        "accuracy": 75,
         "types": [
           "shadow"
         ],
-        "description": "<p>Effect: On hit, all valid targets lose -2 EVA Stage for 5 Activations and are Delayed by 30%.</p>",
-        "img": "icons/svg/explosion.svg",
+        "description": "<p>Effect: On hit, all valid targets lose -2 EVA Stage for 5 Activations and are @Affliction[delay 30].</p>",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
         "predicate": []
       }
     ],
@@ -41,7 +41,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "joTVpu34LTla2KBr",
@@ -57,25 +58,60 @@
             "type": "roll-effect",
             "key": "shadow-mist-attack",
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.5MQzVTuubNTERPjS",
-            "predicate": [],
+            "predicate": [
+              {
+                "not": "origin:ally"
+              }
+            ],
             "chance": 100,
             "affects": "target",
             "priority": null,
-            "ignored": false,
             "alterations": [],
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "origin:ally"
+              }
+            ],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": -30
+              }
+            ],
+            "dontMerge": false,
+            "key": "shadow-mist-attack",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -87,56 +123,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.2.1",
+        "systemVersion": "1.7.2.beta",
         "createdTime": 1737745027309,
-        "modifiedTime": 1737745048259,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
-    },
-    {
-      "name": "Shadow Mist",
-      "type": "passive",
-      "_id": "z7y1zzA2z4Rf7Nwm",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
-      "system": {
-        "changes": [
-          {
-            "type": "roll-effect",
-            "key": "shadow-mist-attack",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advanceffectitem",
-            "predicate": [],
-            "chance": 100,
-            "dontMerge": true,
-            "affects": "target",
-            "priority": null,
-            "ignored": false,
-            "alterations": [
-              {
-                "property": "system.amount",
-                "value": -30,
-                "method": 5
-              },
-              {
-                "property": "name",
-                "value": "Delay 30%",
-                "method": 5
-              }
-            ],
-            "method": 2
-          }
-        ],
-        "slug": null,
-        "traits": [],
-        "removeAfterCombat": true,
-        "removeOnRecall": false,
-        "stacks": 0
+        "modifiedTime": 1775577072790,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "exportSource": null
       },
-      "duration": {
-        "units": "turns",
-        "value": null
-      }
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-moves/shadow-panic.json
+++ b/packs/core-moves/shadow-panic.json
@@ -10,7 +10,8 @@
         "name": "Shadow Panic",
         "type": "attack",
         "traits": [
-          "sonic"
+          "sonic",
+          "social"
         ],
         "range": {
           "target": "cone",
@@ -19,19 +20,19 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1
+          "powerPoints": 3
         },
         "category": "status",
-        "accuracy": 60,
+        "accuracy": 65,
         "types": [
           "shadow"
         ],
-        "description": "<p>Effect: On hit, all valid targets become @Affliction[confused 5].</p>",
-        "img": "icons/svg/explosion.svg",
+        "description": "<p>Effect: On hit, all valid targets become @Affliction[confused 5] and @Affliction[fear 5].</p>",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
         "predicate": []
       }
     ],
-    "grade": "E",
+    "grade": "D",
     "traits": [],
     "_migration": {
       "version": null,
@@ -41,9 +42,86 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "PsxctPOZBM3u4RWF",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shadow Panic",
+      "type": "passive",
+      "_id": "FRWvbSY8FVRrJUsN",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "key": "shadow-panic-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.confusedconditem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "priority": null,
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "shadow-panic-attack",
+            "value": "Compendium.ptr2e.core-effects.Item.fearconditioitem",
+            "predicate": [],
+            "chance": 100,
+            "affects": "target",
+            "priority": null,
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775577520215,
+        "modifiedTime": 1775577634995,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shadow-pummel.json
+++ b/packs/core-moves/shadow-pummel.json
@@ -22,28 +22,30 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2
+          "powerPoints": 3
         },
         "category": "physical",
-        "power": 22,
+        "power": 18,
         "accuracy": 90,
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "67mmF9q42XXgSrMr",

--- a/packs/core-moves/shadow-rave.json
+++ b/packs/core-moves/shadow-rave.json
@@ -12,12 +12,12 @@
         "traits": [],
         "range": {
           "target": "wide-line",
-          "distance": 5,
+          "distance": 8,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 6
         },
         "category": "special",
         "power": 70,
@@ -25,20 +25,22 @@
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "B",
+    "grade": "C",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "mVvVRkHiW6XlzkCr",

--- a/packs/core-moves/shadow-reprisal.json
+++ b/packs/core-moves/shadow-reprisal.json
@@ -10,7 +10,9 @@
         "name": "Shadow Reprisal",
         "type": "attack",
         "traits": [
-          "contact"
+          "contact",
+          "flinch-20",
+          "recoil-1-6"
         ],
         "range": {
           "target": "creature",
@@ -19,7 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3
+          "powerPoints": 4
         },
         "category": "physical",
         "power": 20,
@@ -32,7 +34,7 @@
         "predicate": []
       }
     ],
-    "grade": "A",
+    "grade": "C",
     "traits": [],
     "publication": {
       "source": "PTR 2e Core",
@@ -65,7 +67,8 @@
             "property": "power",
             "definition": [],
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -79,7 +82,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -90,14 +95,18 @@
       "_stats": {
         "compendiumSource": "Item.48mv2v1fZIB425Wn.ActiveEffect.3Igoq5pxc0DPxQXN",
         "duplicateSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.5.0.beta",
         "createdTime": 1740187281641,
         "modifiedTime": 1767161813127,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-moves/shadow-rush.json
+++ b/packs/core-moves/shadow-rush.json
@@ -29,20 +29,22 @@
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "C",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "9BG9Rx5i54zyKpU5",

--- a/packs/core-moves/shadow-scythe.json
+++ b/packs/core-moves/shadow-scythe.json
@@ -22,7 +22,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 6
         },
         "category": "physical",
         "power": 70,
@@ -30,20 +30,22 @@
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "B",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "F1C7Qg0khwkYwkz9",

--- a/packs/core-moves/shadow-shard.json
+++ b/packs/core-moves/shadow-shard.json
@@ -11,38 +11,40 @@
         "type": "attack",
         "traits": [
           "missile",
-          "priority-10"
+          "priority-15",
+          "double-strike"
         ],
         "range": {
           "target": "creature",
-          "distance": 5,
+          "distance": 4,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
-          "priority": 1
+          "powerPoints": 2
         },
         "category": "physical",
-        "power": 40,
-        "accuracy": 100,
+        "power": 35,
+        "accuracy": 95,
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "rVgqrgTOiwSxO7pR",

--- a/packs/core-moves/shadow-shave.json
+++ b/packs/core-moves/shadow-shave.json
@@ -11,7 +11,8 @@
         "type": "attack",
         "traits": [
           "sharp",
-          "contact"
+          "contact",
+          "flinch-20"
         ],
         "range": {
           "target": "creature",
@@ -20,28 +21,31 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 0
+          "powerPoints": 3
         },
         "category": "physical",
-        "power": 40,
-        "accuracy": 100,
+        "power": 65,
+        "accuracy": 90,
         "types": [
           "shadow"
         ],
         "description": "<p>Effect: The target cannot fall below 1 HP by damage from this Attack.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "7UijKUHK9fjJfmh7",

--- a/packs/core-moves/shadow-shed.json
+++ b/packs/core-moves/shadow-shed.json
@@ -20,25 +20,26 @@
           "powerPoints": 8
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "shadow"
         ],
         "description": "<p>Effect: All valid targets lose -1 EVA Stage for 5 Activations. All [Hazard] and [Shield] attack effects in the attacks range are cleared.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "A",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "Rj8ivicVD7ivlzvo",

--- a/packs/core-moves/shadow-siphon.json
+++ b/packs/core-moves/shadow-siphon.json
@@ -1,0 +1,155 @@
+{
+  "name": "Shadow Siphon",
+  "type": "move",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "shadow-siphon",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Shadow Siphon",
+        "slug": "shadow-siphon",
+        "type": "attack",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "traits": [
+          "ray",
+          "drain-3-5"
+        ],
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 6
+        },
+        "types": [
+          "shadow"
+        ],
+        "category": "special",
+        "predicate": [],
+        "description": "<p>Effect: On hit, the target has a 15% chance of losing -1 ATK, SPATK, SPD, or EVA Stage for 5 Activations.</p>",
+        "range": {
+          "target": "creature",
+          "distance": 3,
+          "unit": "m"
+        },
+        "power": 65,
+        "accuracy": 100
+      }
+    ],
+    "grade": "B"
+  },
+  "_id": "BLCIshiJpPZG0259",
+  "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+  "effects": [
+    {
+      "name": "Shadow Siphon",
+      "type": "passive",
+      "_id": "mrDdZCpKNagJGfpU",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.ikCAv5w4iNfHHqaE",
+            "phase": "initial",
+            "predicate": [],
+            "key": "shadow-siphon-attack",
+            "chance": 15,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.1JXumQz0QqthT9Iv",
+            "phase": "initial",
+            "predicate": [],
+            "key": "shadow-siphon-attack",
+            "chance": 15,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.HLAV9dhz632Rfp1K",
+            "phase": "initial",
+            "predicate": [],
+            "key": "shadow-siphon-attack",
+            "chance": 15,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.hIE6W3Y5E9CyHiTy",
+            "phase": "initial",
+            "predicate": [],
+            "key": "shadow-siphon-attack",
+            "chance": 15,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775662460620,
+        "modifiedTime": 1775662460620,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-moves/shadow-storm.json
+++ b/packs/core-moves/shadow-storm.json
@@ -12,16 +12,17 @@
         "traits": [
           "sky",
           "wind",
+          "flinch-20",
           "blast-3"
         ],
         "range": {
           "target": "blast",
-          "distance": 15,
+          "distance": 9,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 10
+          "powerPoints": 9
         },
         "category": "special",
         "power": 95,
@@ -29,22 +30,109 @@
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "description": "<p>Effect: This Attack deals 50% more damage and increases its Blast Value by +2 in Rainy, Windy, or Shady Weather.</p>",
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "A",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "Xsf7hZPJfwGNWpcK",
-  "effects": []
+  "effects": [
+    {
+      "name": "Shadow Storm",
+      "type": "passive",
+      "_id": "R8YdfJ0eG5uTpZog",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": 1.5,
+            "phase": "initial",
+            "predicate": [
+              {
+                "or": [
+                  "effect:summon:rainy-weather",
+                  "effect:summon:windy-weather",
+                  "effect:summon:shady-weather"
+                ]
+              }
+            ],
+            "property": "power",
+            "definition": [],
+            "method": 1,
+            "key": "shadow-storm-attack",
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "Blast 5",
+            "phase": "initial",
+            "predicate": [
+              {
+                "or": [
+                  "effect:summon:rainy-weather",
+                  "effect:summon:windy-weather",
+                  "effect:summon:shady-weather"
+                ]
+              }
+            ],
+            "property": "traits",
+            "definition": [],
+            "key": "shadow-storm-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775579261331,
+        "modifiedTime": 1775579505018,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-moves/shadow-strike.json
+++ b/packs/core-moves/shadow-strike.json
@@ -12,7 +12,9 @@
         "traits": [
           "dash",
           "priority-20",
-          "contact"
+          "contact",
+          "crit-4",
+          "recoil-1-3"
         ],
         "range": {
           "target": "creature",
@@ -21,29 +23,30 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
-          "priority": 2
+          "powerPoints": 3
         },
         "category": "physical",
-        "power": 30,
-        "accuracy": 100,
+        "power": 55,
+        "accuracy": 90,
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
-    "grade": "E",
+    "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "CWZLhRp8Qx4PxaZ8",

--- a/packs/core-moves/shadow-surge.json
+++ b/packs/core-moves/shadow-surge.json
@@ -12,33 +12,36 @@
         "traits": [],
         "range": {
           "target": "wide-line",
-          "distance": 4,
+          "distance": 8,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 6
         },
         "category": "special",
         "power": 90,
-        "accuracy": 100,
+        "accuracy": 90,
         "types": [
           "shadow"
         ],
         "description": "<p>Effect: The user may freely move to any open square in Range.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "B",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "CIz1Fn41ISohF6uG",

--- a/packs/core-moves/shadow-wave.json
+++ b/packs/core-moves/shadow-wave.json
@@ -11,11 +11,13 @@
         "type": "attack",
         "traits": [
           "pulse",
-          "basic"
+          "basic",
+          "aura",
+          "flinch-20"
         ],
         "range": {
           "target": "cone",
-          "distance": 3,
+          "distance": 5,
           "unit": "m"
         },
         "cost": {
@@ -24,24 +26,26 @@
         },
         "category": "special",
         "power": 50,
-        "accuracy": 90,
+        "accuracy": 85,
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "E",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "PFRFSwoTeCyovxoJ",

--- a/packs/core-moves/shadow-wrath.json
+++ b/packs/core-moves/shadow-wrath.json
@@ -10,38 +10,40 @@
         "name": "Shadow Wrath",
         "type": "attack",
         "traits": [
-          "flinch-40",
-          "pulse"
+          "pulse",
+          "flinch-50"
         ],
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 14,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5
+          "powerPoints": 7
         },
         "category": "special",
-        "power": 150,
+        "power": 180,
         "accuracy": 90,
         "types": [
           "shadow"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "systems/ptr2e/img/svg/shadow_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "A",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "Ntzj9rWnx0WV4PqF",


### PR DESCRIPTION
Automations, PP reformulations, assorted reworks.
- Update Move: Backlash
- Update Move: Shadow Barrage
- Update Move: Shadow Blast
- Update Move: Shadow Blitz
- Update Move: Shadow Bolt
- Update Move: Shadow Boost
- Update Move: Shadow Break
- Update Move: Shadow Chill
- Update Move: Shadow Corruption
- Update Move: Shadow Crash
- Update Move: Shadow Crush
- Update Move: Shadow Devastation
- Update Move: Shadow Down
- Update Move: Shadow End
- Update Move: Shadow Engorge
- Update Move: Shadow Fire
- Update Move: Shadow Half
- Update Move: Shadow Hold
- Update Move: Shadow Lift
- Update Move: Shadow Mist
- Update Move: Shadow Panic
- Update Move: Shadow Pummel
- Update Move: Shadow Rave
- Update Move: Shadow Reprisal
- Update Move: Shadow Rush
- Update Move: Shadow Scythe
- Update Move: Shadow Shard
- Update Move: Shadow Shave
- Update Move: Shadow Shed
- Update Move: Shadow Siphon
- Update Move: Shadow Storm
- Update Move: Shadow Strike
- Update Move: Shadow Surge
- Update Move: Shadow Wave
- Update Move: Shadow Wrath