### PR TITLE
Foundry Data Sync - Other missing ball traits

### DIFF
--- a/packs/core-gear/safari-ball.json
+++ b/packs/core-gear/safari-ball.json
@@ -30,7 +30,8 @@
     "traits": [
       "stack-20",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
     "description": "<p>A ball given for use in specific catching contests. 1.5x Capture Rate Modifier.</p>",
     "modifier": 1.5,
@@ -48,7 +49,8 @@
       ],
       "notes": ""
     },
-    "actions": []
+    "actions": [],
+    "ammoType": []
   },
   "_id": "SfFSplgjlMMgZesh",
   "effects": [],

--- a/packs/core-gear/sport-ball.json
+++ b/packs/core-gear/sport-ball.json
@@ -30,7 +30,8 @@
     "traits": [
       "stack-10",
       "belt",
-      "fling"
+      "fling",
+      "ball"
     ],
     "description": "<p>A ball given for use in specific catching contests. 2x Catch Rate modifier.</p>",
     "modifier": 2,
@@ -48,7 +49,8 @@
       ],
       "notes": ""
     },
-    "actions": []
+    "actions": [],
+    "ammoType": []
   },
   "_id": "dcMRu1DwEVSnpwkD",
   "effects": [],

--- a/packs/core-gear/timer-ball.json
+++ b/packs/core-gear/timer-ball.json
@@ -22,7 +22,12 @@
       "type": "untyped",
       "power": 0,
       "accuracy": 95,
-      "hide": null
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "rarity": "uncommon",
     "consumableType": "pokeball",
@@ -30,7 +35,7 @@
       "stack-5",
       "belt",
       "fling",
-      "training-ball"
+      "ball"
     ],
     "description": "Catch Rate modifier increases by 1x at the end of each round, up to a maximum of 8x.",
     "modifier": 1,
@@ -48,7 +53,8 @@
       ],
       "notes": ""
     },
-    "actions": []
+    "actions": [],
+    "ammoType": []
   },
   "_id": "RJMD48otYg9d88AO",
   "effects": [],


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Consumable: Timer Ball
- Update Consumable: Sport Ball
- Update Consumable: Safari Ball