### PR TITLE
Foundry Data Sync - Physical Trait-Granting Perks

### DIFF
--- a/packs/core-perks/clenched-limb.json
+++ b/packs/core-perks/clenched-limb.json
@@ -1,0 +1,109 @@
+{
+  "name": "Clenched Limb",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "clenched-limb",
+    "description": "<p>The user has clenchable hands or limbs that could be wielded like a clenched fist.</p><p>The user gains @Trait[slugger].</p>",
+    "traits": [],
+    "prerequisites": [
+      "GM Permission"
+    ],
+    "autoUnlock": [
+      "trait:slugger"
+    ],
+    "cost": 2,
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 114,
+        "y": 90,
+        "connected": [
+          "minor-buff-6",
+          "fighting-spirit",
+          "minor-buff-47"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/skills/melee/unarmed-punch-fist.webp",
+  "effects": [
+    {
+      "name": "Clenched Limb",
+      "type": "passive",
+      "_id": "mJ6yAH8E67x3mp3F",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "value": "slugger",
+            "phase": "initial",
+            "predicate": [],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775831250193,
+        "modifiedTime": 1775831250193,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "41xUaOI8SglWJOsL"
+}

--- a/packs/core-perks/domain-extension.json
+++ b/packs/core-perks/domain-extension.json
@@ -1,0 +1,108 @@
+{
+  "name": "Domain Extension",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "domain-extension",
+    "description": "<p>The user has long or protractable limbs that allow it to reach out even farther with its limbs.</p><p>The user gains @Trait[reach].</p>",
+    "traits": [],
+    "prerequisites": [
+      "GM Permission"
+    ],
+    "autoUnlock": [
+      "trait:reach"
+    ],
+    "cost": 2,
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 60,
+        "y": 122,
+        "connected": [
+          "minor-buff-43",
+          "climatologist"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/magic/nature/root-vine-leaves-green.webp",
+  "effects": [
+    {
+      "name": "Domain Extension",
+      "type": "passive",
+      "_id": "mJ6yAH8E67x3mp3F",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "value": "reach",
+            "phase": "initial",
+            "predicate": [],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775831253114,
+        "modifiedTime": 1775831253114,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "UU9SCcvkSi1AYsbH"
+}

--- a/packs/core-perks/edged-for-your-displeasure.json
+++ b/packs/core-perks/edged-for-your-displeasure.json
@@ -1,0 +1,108 @@
+{
+  "name": "Edged for Your Displeasure",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "edged-for-your-displeasure",
+    "description": "<p>The user has appendages or bodily features that are likely pointy, but probably could be honed into a fine cutting edge.</p><p>The user gains @Trait[bladed].</p>",
+    "traits": [],
+    "prerequisites": [
+      "GM Permission"
+    ],
+    "autoUnlock": [
+      "trait:bladed"
+    ],
+    "cost": 2,
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 84,
+        "y": 65,
+        "connected": [
+          "iaido",
+          "thousand-folded"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/creatures/claws/claw-curved-jagged-yellow.webp",
+  "effects": [
+    {
+      "name": "Edged for Your Displeasure",
+      "type": "passive",
+      "_id": "mJ6yAH8E67x3mp3F",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "value": "bladed",
+            "phase": "initial",
+            "predicate": [],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775831254522,
+        "modifiedTime": 1775831254522,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "YyavsGCMw39r44ek"
+}

--- a/packs/core-perks/is-that-a-tail.json
+++ b/packs/core-perks/is-that-a-tail.json
@@ -1,0 +1,109 @@
+{
+  "name": "Is That a Tail?",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "is-that-a-tail",
+    "description": "<p>The user has a sizable, strong limb that is commonly identified as a tail of some kind.</p><p>The user gains @Trait[tailed].</p>",
+    "traits": [],
+    "prerequisites": [
+      "GM Permission"
+    ],
+    "autoUnlock": [
+      "trait:tailed"
+    ],
+    "cost": 2,
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 56,
+        "y": 70,
+        "connected": [
+          "tail-autonomy",
+          "minor-buff-38",
+          "dustoff"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/commodities/biological/tail-rodent-orange.webp",
+  "effects": [
+    {
+      "name": "Is That a Tail?",
+      "type": "passive",
+      "_id": "mJ6yAH8E67x3mp3F",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "value": "tailed",
+            "phase": "initial",
+            "predicate": [],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775831255843,
+        "modifiedTime": 1775831255843,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "NVwHvmGFqGeB16mG"
+}

--- a/packs/core-perks/pennacious.json
+++ b/packs/core-perks/pennacious.json
@@ -1,0 +1,109 @@
+{
+  "name": "Pennacious",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "pennacious",
+    "description": "<p>The user possesses a set of long limbs with feathers or some sort of membrane that can generate a fair amount of manual thrust.</p><p>The user gains @Trait[winged], and gains a +10 bonus to Jump and Breach Rolls. </p>",
+    "traits": [],
+    "prerequisites": [
+      "GM Permission"
+    ],
+    "autoUnlock": [
+      "trait:winged"
+    ],
+    "cost": 2,
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 118,
+        "y": 50,
+        "connected": [
+          "migration-formation",
+          "minor-buff-36",
+          "dustoff"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/commodities/materials/material-feathers-violet.webp",
+  "effects": [
+    {
+      "name": "Pennacious",
+      "type": "passive",
+      "_id": "mJ6yAH8E67x3mp3F",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "value": "winged",
+            "phase": "initial",
+            "predicate": [],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775831257224,
+        "modifiedTime": 1775831257224,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "ApYyF3Nmf68xkj9J"
+}

--- a/packs/core-perks/pointy-potrustion.json
+++ b/packs/core-perks/pointy-potrustion.json
@@ -1,0 +1,109 @@
+{
+  "name": "Pointy Potrustion",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "pointy-potrustion",
+    "description": "<p>The user has a hard, pointy bit on its body that resembles a horn, spike, or drill that seems like it would be good at poking and prodding.</p><p>The user gains @Trait[horned].</p>",
+    "traits": [],
+    "prerequisites": [
+      "GM Permission"
+    ],
+    "autoUnlock": [
+      "trait:horned"
+    ],
+    "cost": 2,
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 82,
+        "y": 40,
+        "connected": [
+          "minor-buff-37",
+          "minor-buff-25",
+          "minor-buff-10"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/commodities/bones/horns-pointed-grey.webp",
+  "effects": [
+    {
+      "name": "Pointy Potrustion",
+      "type": "passive",
+      "_id": "mJ6yAH8E67x3mp3F",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "value": "horned",
+            "phase": "initial",
+            "predicate": [],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775831258832,
+        "modifiedTime": 1775831258832,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "kxlvFtJhNK0X5aU1"
+}

--- a/packs/core-perks/showing-leg.json
+++ b/packs/core-perks/showing-leg.json
@@ -1,0 +1,109 @@
+{
+  "name": "Showing Leg",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "showing-leg",
+    "description": "<p>The user has flexible, sturdy legs that can be used to kick or limbs that could be used in a way resembling kicking or stomping.</p><p>The user gains @Trait[booter].</p>",
+    "traits": [],
+    "prerequisites": [
+      "GM Permission"
+    ],
+    "autoUnlock": [
+      "trait:booter"
+    ],
+    "cost": 2,
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 131,
+        "y": 21,
+        "connected": [
+          "minor-buff-26",
+          "sprint",
+          "freeclimber"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "img": "icons/svg/leg.svg",
+  "effects": [
+    {
+      "name": "Showing Leg",
+      "type": "passive",
+      "_id": "mJ6yAH8E67x3mp3F",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "value": "booter",
+            "phase": "initial",
+            "predicate": [],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775831260575,
+        "modifiedTime": 1775831260575,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {},
+  "_id": "oukFLABhNO3A8McP"
+}

--- a/packs/core-perks/toothy-grin.json
+++ b/packs/core-perks/toothy-grin.json
@@ -1,0 +1,108 @@
+{
+  "name": "Toothy Grin",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "slug": "toothy-grin",
+    "description": "<p>The user has a prominent mouth or set of teeth, or something resembling them, and can probably use them to bite pretty well.</p><p>The user gains @Trait[mouthy].</p>",
+    "traits": [],
+    "prerequisites": [
+      "GM Permission"
+    ],
+    "autoUnlock": [
+      "trait:mouthy"
+    ],
+    "cost": 2,
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 101,
+        "y": 69,
+        "connected": [
+          "devourer",
+          "minor-buff-5"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "iTAI4FGhJGVVtQ8m",
+  "img": "icons/creatures/abilities/mouth-teeth-crooked-blue.webp",
+  "effects": [
+    {
+      "name": "Toothy Grin",
+      "type": "passive",
+      "_id": "mJ6yAH8E67x3mp3F",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "value": "mouthy",
+            "phase": "initial",
+            "predicate": [],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1775831412684,
+        "modifiedTime": 1775831412684,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/static/traits.json
+++ b/static/traits.json
@@ -156,12 +156,13 @@
     "slug": "bladed",
     "label": "Bladed",
     "related": [],
-    "description": "This creature possesses effective edged limbs, body parts, or tools as part of its anatomy. Confers [Sharp] to @Trait[adaptable] actions, and grants access to the [Bladed] Tutor List.",
+    "description": "This creature possesses effective edged limbs, body parts, or tools as part of its anatomy.  The user can access the [Bladed] Tutor List and may add the @Trait[sharp] trait to its @Trait[adaptable] @Trait[contact] attacks.",
     "type": "automated",
     "changes": [
       {
         "type": "alter-attack",
         "key": "adaptable-trait-attack",
+        "definition": "self:action:trait:contact",
         "property": "traits",
         "method": "2",
         "value": "sharp"
@@ -211,6 +212,23 @@
         "type": "roll-option",
         "domain": "immunities",
         "value": "affliction:drowning"
+      }
+    ]
+  },
+  {
+    "slug": "booter",
+    "label": "Booter",
+    "related": [],
+    "description": "This creature has a powerful limb that can be thrust or swung in quick, powerful bursts, like humanoids can do with their legs. The user can access the [Booter] Tutor List and may add the @Trait[kick] trait to its @Trait[adaptable] @Trait[contact] attacks.",
+    "type": "automated",
+    "changes": [
+      {
+        "type": "alter-attack",
+        "key": "adaptable-trait-attack",
+        "definition": "self:action:trait:contact",
+        "property": "traits",
+        "method": "2",
+        "value": "kick"
       }
     ]
   },
@@ -915,12 +933,13 @@
     "slug": "horned",
     "label": "Horned",
     "related": [],
-    "description": "This creature possesses a prominent horn or spike. Confers [Horn] to @Trait[adaptable] actions. Grants access to the [Horn] Tutor list.",
+    "description": "This creature possesses a prominent horn or spike. The user can access the [Horned] Tutor List and may add the @Trait[horn] trait to its @Trait[adaptable] @Trait[contact] attacks.",
     "type": "automated",
     "changes": [
       {
         "type": "alter-attack",
         "key": "adaptable-trait-attack",
+        "definition": "self:action:trait:contact",
         "property": "traits",
         "method": "2",
         "value": "horn"
@@ -1507,6 +1526,23 @@
     "description": "This creature is hard to pin down, and makes Grapple checks against them Intense. If this creature is affected by Grapple, they have a +30 bonus to escape the Grapple."
   },
   {
+    "slug": "slugger",
+    "label": "Slugger",
+    "related": [],
+    "description": "This creature is able to clench their hand into a fist, and can throw a punch. Or, at least, has a sturdy enough limb that can function like a fist. The user can access the [Slugger] Tutor List and may add the @Trait[punch] trait to its @Trait[adaptable] @Trait[contact] attacks.",
+    "type": "automated",
+    "changes": [
+      {
+        "type": "alter-attack",
+        "key": "adaptable-trait-attack",
+        "definition": "self:action:trait:contact",
+        "property": "traits",
+        "method": "2",
+        "value": "punch"
+      }
+    ]
+  },
+  {
     "slug": "slumbering-statue",
     "label": "Slumbering Statue",
     "related": [],
@@ -1567,12 +1603,13 @@
     "slug": "mouthy",
     "label": "Mouthy",
     "related": [],
-    "description": "This creature has an advanced and developed mouth (or something resembling one) that allows them to bite, chew, rip and tear with decent offensive effectiveness. The user has access to the [Jaw] Tutor List.",
+    "description": "This creature has an advanced and developed mouth (or something resembling one) that allows them to bite, chew, rip and tear with decent offensive effectiveness. The user can access the [Mouthy] Tutor List and may add the @Trait[jaw] trait to its @Trait[adaptable] @Trait[contact] attacks.",
     "type": "automated",
     "changes": [
       {
         "type": "alter-attack",
         "key": "adaptable-trait-attack",
+        "definition": "self:action:trait:contact",
         "property": "traits",
         "method": "2",
         "value": "jaw"
@@ -1583,12 +1620,13 @@
     "slug": "tailed",
     "label": "Tailed",
     "related": [],
-    "description": "This creature has a sizeable tail. The user has access to the [Tailed] Tutor List.",
+    "description": "This creature has a lengthy appendage that it uses for balance or aiding its movements. The user can access the [Tailed] Tutor List and may add the @Trait[tail] trait to its @Trait[adaptable] @Trait[contact] attacks.",
     "type": "automated",
     "changes": [
       {
         "type": "alter-attack",
         "key": "adaptable-trait-attack",
+        "definition": "self:action:trait:contact",
         "property": "traits",
         "method": "2",
         "value": "tailed"
@@ -2172,7 +2210,7 @@
     "slug": "winged",
     "label": "Winged",
     "related": [],
-    "description": "This creature gains a flying speed by way of wings, requiring exertion to continue flight. Grants access to the [Winged] Tutor List.\nSUBJECT TO CHANGE"
+    "description": "This creature gains a flying speed by way of wings, requiring exertion to continue flight. Grants access to the [Winged] Tutor List."
   },
   {
     "slug": "wool-production",


### PR DESCRIPTION
Requiring GM Permission - for players to add these to creatures that might be missing features they think those creatures should have.

Also to include rewrites of nearly all of these Traits.
- Update Perk: Clenched Limb
- Update Perk: Domain Extension
- Update Perk: Edged for Your Displeasure
- Update Perk: Is That a Tail?
- Update Perk: Pennacious
- Update Perk: Pointy Potrustion
- Update Perk: Showing Leg
- Update Perk: Toothy Grin