### PR TITLE
Foundry Data Sync - Weapon Pass: A-D

### DIFF
--- a/packs/core-gear/altru-tera-dp4-laser-pistol.json
+++ b/packs/core-gear/altru-tera-dp4-laser-pistol.json
@@ -37,8 +37,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "types": [
           "untyped"
@@ -47,7 +46,8 @@
         "power": 65,
         "accuracy": 100,
         "free": true,
-        "predicate": []
+        "predicate": [],
+        "description": "<p>Ammo Use: 1</p>"
       },
       {
         "name": "Magnum Laser",
@@ -64,8 +64,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 4
+          "activation": "complex"
         },
         "types": [
           "untyped"
@@ -74,7 +73,8 @@
         "power": 140,
         "accuracy": 90,
         "predicate": [],
-        "variant": "las-shot"
+        "variant": "las-shot",
+        "description": "<p>Ammo Use: 4</p>"
       }
     ],
     "description": "<p>The DP4 is a specialty-manufactured directed energy weapon, designed to fit the role of a sidearm for security or military personnel. The DP4 is loaded with current generation capacitor bank magazines as their standard configuration, giving them a fair few number of shots at quite a significant punch and a “Beam Magnum” selector, to allow for higher output and stopping power.</p>",
@@ -88,7 +88,7 @@
       "handsHeld": null,
       "slot": "held"
     },
-    "grade": "B",
+    "grade": "C",
     "fling": {
       "type": "untyped",
       "power": 80,
@@ -131,7 +131,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -141,7 +142,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -155,7 +157,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -167,12 +171,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.5.0.beta",
         "lastModifiedBy": "5ImYyhOS2D6D7ypO",
-        "modifiedTime": 1767455878957
-      }
+        "modifiedTime": 1767455878957,
+        "createdTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "_id": "diU7kRmRRVoAsCX8"

--- a/packs/core-gear/altru-tera-dp7-laser-rifle.json
+++ b/packs/core-gear/altru-tera-dp7-laser-rifle.json
@@ -112,7 +112,8 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "C"
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -130,7 +131,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -139,7 +141,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -153,7 +156,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -165,13 +170,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.5.0.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "bl6lDzDCN1L8rPTD"
 }

--- a/packs/core-gear/anti-materiel-rifle.json
+++ b/packs/core-gear/anti-materiel-rifle.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "A",
+    "grade": "S",
     "fling": {
       "type": "steel",
       "power": 80,
@@ -21,22 +21,22 @@
       "hide": false,
       "range": {
         "target": "creature",
-        "distance": 10,
+        "distance": 2,
         "unit": "m"
       }
     },
-    "rarity": "rare",
+    "rarity": "uncommon",
     "traits": [
       "weapon",
       "fling",
       "firearm",
       "autoload",
       "steel",
-      "charge-pool-4",
-      "reload-4",
       "conventional",
       "modern",
-      "sci-fi"
+      "sci-fi",
+      "charge-pool-6",
+      "reload-5"
     ],
     "actions": [
       {
@@ -48,20 +48,20 @@
         "traits": [
           "set-up",
           "defensive",
-          "priority-20"
+          "priority-40"
         ],
         "name": "Anti-Materiel Rifle (Set Up)",
         "slug": "anti-materiel-rifle-set-up",
-        "description": "<p>Effect: The user spends 2 PP, and gains @Affliction[braced 2].</p>",
+        "description": "<p>Effect: The user gains @Affliction[braced 2].</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "cost": {
-          "activation": "complex",
-          "priority": 2
+          "activation": "complex"
         },
         "predicate": []
       },
@@ -69,20 +69,20 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 200,
         "accuracy": 95,
         "free": true,
         "traits": [
           "missile",
           "pierce",
-          "flinch-40",
           "firearm",
-          "crit-1"
+          "crit-2",
+          "flinch-20"
         ],
         "name": "Anti-Materiel Rifle (Resolution)",
         "slug": "anti-materiel-rifle-resolution",
-        "description": "<p>Trigger: The user used Anti-Materiel Rifle (Set Up) as their last Action.</p><p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Trigger: The user used Anti-Materiel Rifle (Set Up) as their last Action.</p><p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -92,37 +92,37 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
           "trigger": "<p>The user used Anti-Materiel Rifle (Set Up) as their last Action.</p>"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 200,
-        "accuracy": 45,
+        "accuracy": 55,
         "free": true,
         "traits": [
           "missile",
-          "pierce",
-          "firearm"
+          "firearm",
+          "crit-1",
+          "flinch-30"
         ],
         "name": "Anti-Materiel Rifle (Hip Fire)",
         "slug": "anti-materiel-rifle-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
           "target": "creature",
-          "distance": 15,
+          "distance": 10,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "predicate": []
       }
@@ -151,7 +151,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "sRQl1TkcK26ztomy",
   "effects": [
@@ -171,7 +172,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -185,7 +187,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -196,14 +200,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743971623486,
         "modifiedTime": 1757632056546,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "Tn65RZTafVbxqEXT"

--- a/packs/core-gear/assault-rifle.json
+++ b/packs/core-gear/assault-rifle.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "A",
+    "grade": "B",
     "fling": {
       "type": "steel",
       "power": 75,
@@ -43,8 +43,8 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "power": 35,
+        "category": "physical",
+        "power": 42,
         "accuracy": 95,
         "free": true,
         "traits": [
@@ -53,7 +53,7 @@
         ],
         "name": "Assault Rifle",
         "slug": "assault-rifle",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,17 +62,17 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "power": 60,
+        "category": "physical",
+        "power": 68,
         "accuracy": 90,
         "free": true,
         "traits": [
@@ -81,7 +81,7 @@
         ],
         "name": "Assault Rifle (Burst)",
         "slug": "assault-rifle-burst",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 3</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -90,18 +90,18 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 3
+          "activation": "complex"
         },
         "variant": "assault-rifle",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "power": 30,
+        "category": "physical",
+        "power": 22,
         "accuracy": 85,
         "free": true,
         "traits": [
@@ -111,27 +111,27 @@
         ],
         "name": "Assault Rifle (Auto)",
         "slug": "assault-rifle-auto",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 6</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
           "target": "creature",
-          "distance": 21,
+          "distance": 16,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 6
+          "activation": "complex"
         },
         "variant": "assault-rifle",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "power": 35,
+        "category": "physical",
+        "power": 26,
         "accuracy": 70,
         "free": true,
         "traits": [
@@ -142,7 +142,7 @@
         ],
         "name": "Assault Rifle (Hip Fire)",
         "slug": "assault-rifle-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 5</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -151,11 +151,11 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 5
+          "activation": "complex"
         },
         "variant": "assault-rifle",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -182,7 +182,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>An assault rifle is a select fire rifle that uses an intermediate-rifle cartridge and a detachable magazine. A common primary weapon of modern armies in contemporary settings.</p>"
+    "description": "<p>An assault rifle is a select fire rifle that uses an intermediate-rifle cartridge and a detachable magazine. A common primary weapon of modern armies in contemporary settings.</p>",
+    "ammoType": []
   },
   "_id": "Ba3EyqpUePgGrfQk",
   "effects": [
@@ -202,7 +203,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -212,7 +214,8 @@
             "label": "Burst",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -226,7 +229,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -237,14 +242,18 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743632386665,
         "modifiedTime": 1757632018306,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "fwBg1GB1fMcgPklo"

--- a/packs/core-gear/auto-pistol.json
+++ b/packs/core-gear/auto-pistol.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "C",
+    "grade": "B",
     "fling": {
       "type": "steel",
       "power": 55,
@@ -43,7 +43,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 35,
         "accuracy": 95,
         "free": true,
@@ -53,7 +53,7 @@
         ],
         "name": "Auto Pistol",
         "slug": "auto-pistol",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,18 +62,18 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 60,
-        "accuracy": 90,
+        "accuracy": 87,
         "free": true,
         "traits": [
           "missile",
@@ -81,7 +81,7 @@
         ],
         "name": "Auto Pistol (Double Tap)",
         "slug": "auto-pistol-double-tap",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 2</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -90,19 +90,19 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 2
+          "activation": "complex"
         },
         "variant": "auto-pistol",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 30,
-        "accuracy": 75,
+        "accuracy": 74,
         "free": true,
         "traits": [
           "missile",
@@ -112,7 +112,7 @@
         ],
         "name": "Auto Pistol (Hip Fire)",
         "slug": "auto-pistol-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -122,11 +122,11 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
           "priority": 1
         },
         "variant": "auto-p",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -153,7 +153,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A auto pistol is a repeating handgun that automatically ejects and loads cartridges in its chamber after every shot fired, but only one round of ammunition is fired each time the trigger is pulled. A ubiquitous design in contemporary settings, utilized by militaries and civilians as a sidearm and for personal defense.</p>"
+    "description": "<p>A auto pistol is a repeating handgun that automatically ejects and loads cartridges in its chamber after every shot fired, but only one round of ammunition is fired each time the trigger is pulled. A ubiquitous design in contemporary settings, utilized by militaries and civilians as a sidearm and for personal defense.</p>",
+    "ammoType": []
   },
   "_id": "TD3HM4XSYLbWAemQ",
   "effects": [
@@ -171,19 +172,21 @@
             "predicate": [],
             "label": "Auto Pistol",
             "priority": null,
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "flat-modifier",
             "key": "auto-pistol-double-tap-attack-damage-flat",
-            "value": 32,
+            "value": 24,
             "predicate": [],
             "label": "Double Tap",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           }
         ],
         "slug": null,
@@ -197,7 +200,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -208,14 +213,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
+        "systemVersion": "1.7.2.beta",
         "createdTime": 1743877436694,
-        "modifiedTime": 1757553567781,
-        "lastModifiedBy": "UTlFSVhgfIUeTsoW",
+        "modifiedTime": 1775571852582,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "MKaFm5Pvt7tvgdAa"

--- a/packs/core-gear/auto-shotgun.json
+++ b/packs/core-gear/auto-shotgun.json
@@ -18,7 +18,7 @@
       "type": "steel",
       "power": 50,
       "accuracy": 95,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 10,
@@ -43,7 +43,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 85,
         "accuracy": 95,
         "free": true,
@@ -53,7 +53,7 @@
         ],
         "name": "Auto Shotgun",
         "slug": "auto-shotgun",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,27 +62,27 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "atk"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "power": 45,
-        "accuracy": 85,
-        "free": true,
+        "category": "physical",
+        "power": 40,
+        "accuracy": 83,
         "traits": [
           "missile",
           "6-strike",
-          "firearm"
+          "firearm",
+          "flinch-10"
         ],
         "name": "Auto Shotgun (Auto)",
         "slug": "auto-shotgun-auto",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 6</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -91,20 +91,19 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 6
+          "activation": "complex"
         },
         "variant": "auto-shotgun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 85,
         "accuracy": 80,
-        "free": true,
         "traits": [
           "missile",
           "dash",
@@ -113,7 +112,7 @@
         ],
         "name": "Auto Shotgun (Hip Fire)",
         "slug": "auto-shotgun-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 4</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -122,12 +121,11 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 4,
-          "priority": 1
+          "activation": "complex"
         },
         "variant": "auto-shotgun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -154,7 +152,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>An automatic shotgun is an automatic firearm that fires shotgun shells (thereby making it a shotgun) and uses some of the energy of each shot to automatically cycle the action and load a new round. They generally store ammunition in detachable box or drum magazines in order to decrease reloading time, whereas most pump-action and semi-automatic shotguns use under-barrel tubular magazines.</p>"
+    "description": "<p>An automatic shotgun is an automatic firearm that fires shotgun shells (thereby making it a shotgun) and uses some of the energy of each shot to automatically cycle the action and load a new round. They generally store ammunition in detachable box or drum magazines in order to decrease reloading time, whereas most pump-action and semi-automatic shotguns use under-barrel tubular magazines.</p>",
+    "ammoType": []
   },
   "_id": "1JZaCsj2gzdyFMNb",
   "effects": [
@@ -174,7 +173,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -184,7 +184,8 @@
             "label": "Hip",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -198,7 +199,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -209,14 +212,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743971186221,
         "modifiedTime": 1757632062514,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "Tn65RZTafVbxqEXT"

--- a/packs/core-gear/axe.json
+++ b/packs/core-gear/axe.json
@@ -24,7 +24,8 @@
       "early-modern",
       "medieval",
       "ancient",
-      "fantasy"
+      "fantasy",
+      "2-handed"
     ],
     "actions": [
       {
@@ -152,7 +153,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "C",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -169,9 +172,10 @@
             "value": 16,
             "predicate": [],
             "label": "Axe",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "flat-modifier",
@@ -179,9 +183,10 @@
             "value": 6,
             "predicate": [],
             "label": "Axe Swing",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "roll-effect",
@@ -194,33 +199,30 @@
             "alterations": [],
             "dontMerge": false,
             "label": "Cleave Defense",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
             "key": "axe-cleave-attack",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advanceffectitem",
+            "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
             "predicate": [],
             "chance": 40,
             "isFixedChance": false,
             "affects": "target",
             "alterations": [
               {
+                "method": 5,
                 "property": "system.amount",
-                "value": -30,
-                "method": 5
-              },
-              {
-                "property": "name",
-                "value": "Delay 20%",
-                "method": 5
+                "value": -30
               }
             ],
             "dontMerge": false,
             "label": "Cleave Delay",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "flat-modifier",
@@ -228,9 +230,10 @@
             "value": 14,
             "predicate": [],
             "label": "Axe Chop",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "roll-effect",
@@ -243,33 +246,30 @@
             "alterations": [],
             "dontMerge": false,
             "label": "Chop Defense",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
             "key": "axe-chop-attack",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advanceffectitem",
+            "value": "Compendium.ptr2e.core-effects.Item.advancecondiitem",
             "predicate": [],
             "chance": 50,
             "isFixedChance": false,
             "affects": "target",
             "alterations": [
               {
+                "method": 5,
                 "property": "system.amount",
-                "value": -30,
-                "method": 5
-              },
-              {
-                "property": "name",
-                "value": "Delay 30%",
-                "method": 5
+                "value": -30
               }
             ],
             "dontMerge": false,
             "label": "Chop Delay",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "flat-modifier",
@@ -277,9 +277,10 @@
             "value": 1,
             "predicate": [],
             "label": "Fling Crit",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "flat-modifier",
@@ -287,9 +288,10 @@
             "value": 22,
             "predicate": [],
             "label": "Fling Flat",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           }
         ],
         "slug": null,
@@ -303,7 +305,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -315,13 +319,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "systemVersion": "1.7.2.beta",
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "createdTime": 1775700227386,
+        "modifiedTime": 1775700390061
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "4LJq1YCOJO2eMJwr"
 }

--- a/packs/core-gear/bat-aluminium.json
+++ b/packs/core-gear/bat-aluminium.json
@@ -47,8 +47,8 @@
         "free": true,
         "traits": [
           "adaptable",
-          "priority-15",
-          "contact"
+          "contact",
+          "priority-20"
         ],
         "name": "Bat (Aluminium)",
         "slug": "bat-aluminium",
@@ -89,7 +89,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "poulKoHX1ZWb4pVr",
   "effects": [
@@ -108,7 +109,8 @@
             "label": "Bat (Aluminium)",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -122,7 +124,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -134,13 +138,17 @@
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.ZewWbLPYdCt2qPzv.ActiveEffect.hKiDWsZdq14T4lXi",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1757542093820,
         "modifiedTime": 1757553419362,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "PhrQtZzEwKPjfmK2"

--- a/packs/core-gear/bat-wood.json
+++ b/packs/core-gear/bat-wood.json
@@ -89,7 +89,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "ZewWbLPYdCt2qPzv",
   "effects": [
@@ -103,12 +104,13 @@
           {
             "type": "flat-modifier",
             "key": "{item|id}-attack-damage-flat",
-            "value": 2,
+            "value": 4,
             "predicate": [],
             "label": "Bat (Wood)",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           }
         ],
         "slug": null,
@@ -122,7 +124,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -134,13 +138,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
+        "systemVersion": "1.7.2.beta",
         "createdTime": 1757541637710,
-        "modifiedTime": 1757553426726,
-        "lastModifiedBy": "UTlFSVhgfIUeTsoW"
-      }
+        "modifiedTime": 1775572170797,
+        "lastModifiedBy": "dgye2I5sN06rQmNS"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "PhrQtZzEwKPjfmK2"

--- a/packs/core-gear/battle-rifle.json
+++ b/packs/core-gear/battle-rifle.json
@@ -43,7 +43,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 55,
         "accuracy": 95,
         "free": true,
@@ -53,7 +53,7 @@
         ],
         "name": "Battle Rifle",
         "slug": "battle-rifle",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,16 +62,16 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 125,
         "accuracy": 80,
         "free": true,
@@ -81,7 +81,7 @@
         ],
         "name": "Battle Rifle (Auto)",
         "slug": "battle-rifle-auto",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 4</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -90,17 +90,17 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 4
+          "activation": "complex"
         },
         "variant": "battle-rifle",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 60,
         "accuracy": 75,
         "free": true,
@@ -111,7 +111,7 @@
         ],
         "name": "Battle Rifle (Hip Fire)",
         "slug": "battle-rifle-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -120,11 +120,11 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "variant": "battle-rifle",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -151,7 +151,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A battle rifle is a service rifle chambered to fire a fully powered cartridge. The terms was created largely out of a need to differentiate automatic rifles chambered for fully powered cartridges from automatic rifles chambered for intermediate cartridges, which were later categorized as assault rifles.</p>"
+    "description": "<p>A battle rifle is a service rifle chambered to fire a fully powered cartridge. The terms was created largely out of a need to differentiate automatic rifles chambered for fully powered cartridges from automatic rifles chambered for intermediate cartridges, which were later categorized as assault rifles.</p>",
+    "ammoType": []
   },
   "_id": "xPbMEBEaTsw02Ouy",
   "effects": [
@@ -171,7 +172,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -180,7 +182,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -194,7 +197,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -205,14 +210,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743893018184,
         "modifiedTime": 1757632011406,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "fwBg1GB1fMcgPklo"

--- a/packs/core-gear/bayonet.json
+++ b/packs/core-gear/bayonet.json
@@ -34,7 +34,8 @@
           "adaptable",
           "crit-1",
           "flinch-10",
-          "contact"
+          "contact",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -61,11 +62,12 @@
         "description": "<p>Trigger: A creature within range of this attack attempts to leave the range of this Attack, or that creature attempts to move adjacent to the user while the user is @Affliction[braced].</p>",
         "traits": [
           "weapon",
-          "interrupt-2",
           "adaptable",
           "crit-1",
           "priority-20",
-          "contact"
+          "contact",
+          "horn",
+          "interrupt"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -95,7 +97,8 @@
           "weapon",
           "contact",
           "adaptable",
-          "grapple"
+          "grapple",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -140,7 +143,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -149,7 +152,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "D",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -168,7 +173,8 @@
             "label": "Bayonet",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -178,7 +184,8 @@
             "label": "Bayonet",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -192,7 +199,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -204,12 +213,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
         "lastModifiedBy": "r8rxDx9bzq5ASx3l",
-        "modifiedTime": 1762640448796
-      }
+        "modifiedTime": 1762640448796,
+        "createdTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "_id": "9CKlrqUYYOFyi5fV"

--- a/packs/core-gear/beartic-mace.json
+++ b/packs/core-gear/beartic-mace.json
@@ -27,7 +27,7 @@
       {
         "name": "Beartic Mace Spray",
         "slug": "beartic-mace-spray",
-        "description": "<p>Effect: On hit, the target has a 50% chance to gain @Affliction[blinded 3] and a 70% chance to lose -1 ATK and ACC Stage for 5 Activations.</p>",
+        "description": "<p>Effect: On hit, the target has a 50% chance to gain @Affliction[blinded 3] and a 70% chance to lose -1 ATK and ACC Stage for 5 Activations.</p><p>Ammo Use: 1</p>",
         "traits": [
           "weapon",
           "powder"
@@ -35,8 +35,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "range": {
           "target": "creature",
@@ -66,7 +65,7 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 10,
@@ -74,7 +73,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -83,7 +82,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "D",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -112,7 +113,8 @@
             "dontMerge": false,
             "label": "Blind Chance",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -126,7 +128,8 @@
             "dontMerge": false,
             "label": "ATK Chance",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -140,7 +143,8 @@
             "dontMerge": false,
             "label": "ACC Chance",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -154,7 +158,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -166,13 +172,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "rr6i1w0gzPo7Qc8n"
 }

--- a/packs/core-gear/bolt-action-rifle.json
+++ b/packs/core-gear/bolt-action-rifle.json
@@ -18,14 +18,14 @@
       "type": "steel",
       "power": 75,
       "accuracy": 80,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 2,
         "unit": "m"
       }
     },
-    "rarity": "uncommon",
+    "rarity": "rare",
     "traits": [
       "weapon",
       "fling",
@@ -43,7 +43,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 65,
         "accuracy": 95,
         "free": true,
@@ -53,7 +53,7 @@
         ],
         "name": "Bolt-Action Rifle",
         "slug": "bolt-action-rifle",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,19 +62,18 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 55,
         "accuracy": 85,
-        "free": true,
         "traits": [
           "double-strike",
           "missile",
@@ -82,7 +81,7 @@
         ],
         "name": "Bolt-Action Rifle (Snap Shot)",
         "slug": "bolt-action-rifle-snap-shot",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 2</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -91,20 +90,19 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 2
+          "activation": "complex"
         },
         "variant": "bolt-action-rifle",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 65,
         "accuracy": 75,
-        "free": true,
         "traits": [
           "dash",
           "missile",
@@ -112,7 +110,7 @@
         ],
         "name": "Bolt-Action Rifle (Hip Fire)",
         "slug": "bolt-action-rifle-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -121,11 +119,11 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "variant": "bolt-action-rifle",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -152,7 +150,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>Bolt action is a type of manual firearm action that is operated by directly manipulating the turn-bolt via a bolt handle, most commonly placed on the right-hand side of the firearm (as most users are right-handed). The majority of bolt-action firearms are rifles, and generally are chambered in fuller powered calibers.</p>"
+    "description": "<p>Bolt action is a type of manual firearm action that is operated by directly manipulating the turn-bolt via a bolt handle, most commonly placed on the right-hand side of the firearm (as most users are right-handed). The majority of bolt-action firearms are rifles, and generally are chambered in fuller powered calibers.</p>",
+    "ammoType": []
   },
   "_id": "7SB0KILKuBpiLVmr",
   "effects": [
@@ -172,7 +171,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -186,7 +186,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -197,14 +199,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743901236922,
         "modifiedTime": 1757553621193,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "MKaFm5Pvt7tvgdAa"

--- a/packs/core-gear/bow.json
+++ b/packs/core-gear/bow.json
@@ -39,8 +39,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "types": [
           "untyped"
@@ -50,7 +49,8 @@
         "accuracy": 85,
         "free": true,
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
-        "predicate": []
+        "predicate": [],
+        "description": "<p>Ammo Use: 1</p>"
       }
     ],
     "description": "<p>The bow and arrow is a ranged weapon system consisting of an elastic launching device (bow) and long-shafted projectiles (arrows). Humans used bows and arrows for hunting and aggression long before recorded history, and the practice was common to many prehistoric cultures. They were important weapons of war from ancient history until the early modern period, when they were rendered increasingly obsolete by the development of the more powerful and accurate firearms. Today, bows and arrows are mostly used for hunting and sports. </p>",
@@ -64,7 +64,7 @@
       "handsHeld": 2,
       "slot": "held"
     },
-    "grade": "E",
+    "grade": "D",
     "fling": {
       "type": "untyped",
       "power": 25,
@@ -77,7 +77,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -93,7 +93,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "lvWIPtRom0SHwdMn",
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -114,7 +115,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -128,7 +130,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -139,14 +143,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
         "createdTime": 1743879487195,
         "modifiedTime": 1764810776600,
         "lastModifiedBy": "r8rxDx9bzq5ASx3l",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-gear/break-action-shotgun.json
+++ b/packs/core-gear/break-action-shotgun.json
@@ -13,12 +13,12 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "D",
+    "grade": "C",
     "fling": {
       "type": "steel",
       "power": 75,
       "accuracy": 80,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 2,
@@ -41,7 +41,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 100,
         "accuracy": 90,
         "free": true,
@@ -51,7 +51,7 @@
         ],
         "name": "Break-Action Shotgun",
         "slug": "break-action-shotgun",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 2</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -60,48 +60,46 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 170,
         "accuracy": 85,
-        "free": true,
         "traits": [
           "missile",
           "firearm"
         ],
         "name": "Break-Action Shotgun (Double)",
         "slug": "break-action-shotgun-double",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 2</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
           "target": "wide-line",
-          "distance": 8,
+          "distance": 9,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 2
+          "activation": "complex"
         },
         "variant": "break-action-shotgun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 100,
         "accuracy": 75,
-        "free": true,
         "traits": [
           "missile",
           "dash",
@@ -110,30 +108,28 @@
         ],
         "name": "Break-Action Shotgun (Hip Fire)",
         "slug": "break-action-shotgun-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
           "target": "cone",
-          "distance": 4,
+          "distance": 6,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1,
-          "priority": 1
+          "activation": "complex"
         },
         "variant": "break-action-shotgun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 170,
         "accuracy": 70,
-        "free": true,
         "traits": [
           "missile",
           "dash",
@@ -142,21 +138,20 @@
         ],
         "name": "Break-Action Shotgun (Double Hip Fire)",
         "slug": "break-action-shotgun-two-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 2</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
           "target": "cone",
-          "distance": 4,
+          "distance": 6,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 2,
-          "priority": 1
+          "activation": "complex"
         },
         "variant": "break-action-shotgun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -183,7 +178,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>Break action is a type of firearm action in which the barrel(s) are hinged much like a door and rotate perpendicularly to the bore axis to expose the breech and allow loading and unloading of cartridges. Nowadays, break-action shotguns are primarily used for home defense, being exceptionally reliable and effective.</p>"
+    "description": "<p>Break action is a type of firearm action in which the barrel(s) are hinged much like a door and rotate perpendicularly to the bore axis to expose the breech and allow loading and unloading of cartridges. Nowadays, break-action shotguns are primarily used for home defense, being exceptionally reliable and effective.</p>",
+    "ammoType": []
   },
   "_id": "HZjQpHFC9gZu7dZc",
   "effects": [
@@ -203,7 +199,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -212,7 +209,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -221,7 +219,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -235,7 +234,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -246,14 +247,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743885620764,
         "modifiedTime": 1757631515218,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "GPebepuiQbZSuf35"

--- a/packs/core-gear/chainsaw.json
+++ b/packs/core-gear/chainsaw.json
@@ -100,7 +100,7 @@
       "type": "steel",
       "power": 120,
       "accuracy": 60,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 2,
@@ -137,7 +137,8 @@
             "label": "Chainsaw Swing",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -151,7 +152,8 @@
             "dontMerge": false,
             "label": "Chainsaw Swing (Bleed)",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "create-clock",
@@ -163,7 +165,8 @@
             "private": false,
             "label": "Chainsaw Grind",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -173,7 +176,8 @@
             "label": "Chainsaw Grind (Damage)",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "alter-attack",
@@ -184,7 +188,8 @@
             "property": "accuracy",
             "definition": [],
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -204,7 +209,8 @@
             "dontMerge": true,
             "label": "Chainsaw Grind (Advance)",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -224,7 +230,8 @@
             "dontMerge": false,
             "label": "Chainsaw Grind (Bleed)",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -244,7 +251,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -264,7 +272,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "ephemeral-effect",
@@ -281,7 +290,8 @@
               }
             ],
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -301,7 +311,8 @@
             ],
             "dontMerge": true,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -311,7 +322,8 @@
             "label": "Chainsaw (Fling)",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -325,7 +337,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -337,13 +351,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.5.0.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "kEB4MUFx1SEM0W3P"
 }

--- a/packs/core-gear/club.json
+++ b/packs/core-gear/club.json
@@ -71,7 +71,7 @@
       "type": "untyped",
       "power": 90,
       "accuracy": 80,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 3,
@@ -79,7 +79,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -88,7 +88,10 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "slug": "club",
+    "grade": "E",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -107,7 +110,8 @@
             "label": "Club",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -131,7 +135,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -145,7 +150,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -157,13 +164,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "LUqbfyrTjvN8FEYd"
 }

--- a/packs/core-gear/dart.json
+++ b/packs/core-gear/dart.json
@@ -16,7 +16,8 @@
           "adaptable",
           "contact",
           "crit-1",
-          "grapple"
+          "grapple",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -61,8 +62,8 @@
         "unit": "m"
       }
     },
-    "quantity": 1,
-    "rarity": "common",
+    "quantity": 8,
+    "rarity": "uncommon",
     "publication": {
       "source": "",
       "authors": [],
@@ -80,7 +81,8 @@
     ],
     "consumableType": "other",
     "stack": 8,
-    "cost": 3
+    "cost": 3,
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -97,9 +99,10 @@
             "value": 4,
             "predicate": [],
             "label": "Dart",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "flat-modifier",
@@ -107,9 +110,32 @@
             "value": 7,
             "predicate": [],
             "label": "Dart (Fling)",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "missile",
+            "phase": "initial",
+            "predicate": [],
+            "key": "fling-dart-attack",
+            "property": "traits",
+            "definition": [],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "adaptable",
+            "phase": "initial",
+            "predicate": [],
+            "key": "fling-dart-attack",
+            "property": "traits",
+            "definition": [],
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -123,7 +149,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -135,13 +163,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "systemVersion": "1.7.2.beta",
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "createdTime": 1775701562458,
+        "modifiedTime": 1775701625272
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "35sZHVUQMo1g7jTO"
 }

--- a/packs/core-gear/devon-corp-impact-glove.json
+++ b/packs/core-gear/devon-corp-impact-glove.json
@@ -16,7 +16,7 @@
     "actions": [
       {
         "name": "Impact Glove Strike",
-        "slug": "impact-glove-action-1",
+        "slug": "impact-glove-strike",
         "traits": [
           "weapon",
           "grapple",
@@ -26,19 +26,19 @@
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "range": {
-          "target": "enemy",
+          "target": "creature",
           "distance": 1,
           "unit": "m"
         },
         "cost": {
-          "activation": "simple"
+          "activation": "complex"
         },
         "types": [
           "untyped"
         ],
         "category": "physical",
         "power": 45,
-        "accuracy": 100,
+        "accuracy": 95,
         "free": true,
         "predicate": []
       }
@@ -81,11 +81,90 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "DevonCorp Impact Glove",
+      "type": "passive",
+      "_id": "M1KFqoQhVw1iRi3u",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "value": 3,
+            "phase": "initial",
+            "predicate": [],
+            "key": "impact-glove-strike-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "punch-trait-attack-damage",
+            "value": 10,
+            "phase": "initial",
+            "predicate": [],
+            "method": 1,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.auJlcV40ua09ITga",
+            "phase": "initial",
+            "predicate": [],
+            "affects": "self",
+            "alterations": [],
+            "key": "punch-trait-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.359",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776189707312,
+        "modifiedTime": 1776192647171,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
   "folder": "PhrQtZzEwKPjfmK2",
   "_id": "evYBrqeBeAnOLew4"
 }


### PR DESCRIPTION
Updating Grades+Rarities, revising Traits
- Update Weapon: Altru-Tera DP4 Laser Pistol
- Update Weapon: Altru-Tera DP7 Laser Rifle
- Update Weapon: Anti-Materiel Rifle
- Update Weapon: Assault Rifle
- Update Weapon: Auto Pistol
- Update Weapon: Auto Shotgun
- Update Weapon: Axe
- Update Weapon: Bat (Wood)
- Update Weapon: Bat (Aluminium)
- Update Weapon: Bayonet
- Update Weapon: Battle Rifle
- Update Weapon: Beartic Mace
- Update Weapon: Bolt-Action Rifle
- Update Weapon: Bow
- Update Weapon: Break-Action Shotgun
- Update Weapon: Chainsaw
- Update Weapon: Club
- Update Consumable: Dart
- Update Weapon: DevonCorp Impact Glove