### PR TITLE
Foundry Data Sync - Shield Perk Touch Ups and Revisions

### DIFF
--- a/packs/core-perks/reflection.json
+++ b/packs/core-perks/reflection.json
@@ -9,8 +9,10 @@
       {
         "name": "Reflection",
         "slug": "reflection",
-        "description": "<p>Effect: When the user suffers damage that would cause them their Shield to break, the user may spend 2 PP at @Trait[interrupt-2] to inflict @Tick[-1] on the attacker, and give them @Affliction[delay 30].</p>",
-        "traits": [],
+        "description": "<p>Effect: When the user suffers damage that would cause them their Shield to break, the user may spend @PP[-2] as a Free Action @Trait[interrupt] to inflict @Tick[-1] and @Affliction[delay 30]. on the attacker.</p>",
+        "traits": [
+          "interrupt"
+        ],
         "type": "generic",
         "img": "systems/ptr2e/img/perk-icons/Combat.svg",
         "cost": {
@@ -19,12 +21,13 @@
         },
         "range": {
           "target": "creature",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         }
       }
     ],
     "slug": "reflection",
-    "description": "<p>Effect: When the user suffers damage that would cause them their Shield to break, the user may spend 2 PP at @Trait[interrupt-2] to inflict @Tick[-1] on the attacker, and give them @Affliction[delay 30].</p>",
+    "description": "<p>Effect: When the user suffers damage that would cause them their Shield to break, the user may spend @PP[-2] as a Free Action @Trait[interrupt] to inflict @Tick[-1] and @Affliction[delay 30]. on the attacker.</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 2,
@@ -65,7 +68,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "effects": [
     {
@@ -86,7 +90,8 @@
             "alterations": [],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -105,7 +110,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -119,7 +125,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -131,13 +139,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
         "createdTime": 1764896883022,
-        "modifiedTime": 1764896934829,
-        "lastModifiedBy": "bDEGyOQfZwkb2ml2"
-      }
+        "modifiedTime": 1776353960348,
+        "lastModifiedBy": "dgye2I5sN06rQmNS"
+      },
+      "start": null,
+      "showIcon": 0,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-perks/resentment.json
+++ b/packs/core-perks/resentment.json
@@ -9,25 +9,28 @@
       {
         "name": "Resentment",
         "slug": "resentment",
-        "description": "<p>When your Shields are broken, you may spend 4PP to gain 2 ticks of Shields as a Complex Action at [Interrupt 2].</p>",
-        "traits": [],
+        "description": "<p>Effect: When the user's Shields are broken, they may spend @PP[-3] as a Complex Action @Trait[interrupt] at @Trait[priority-60] to gain @Tick[2 shield].</p>",
+        "traits": [
+          "interrupt",
+          "priority-60"
+        ],
         "type": "generic",
         "img": "systems/ptr2e/img/perk-icons/Combat.svg",
         "cost": {
-          "activation": "simple"
+          "activation": "complex",
+          "powerPoints": 3
         },
         "range": {
-          "target": "creature",
-          "distance": 10,
+          "target": "self",
           "unit": "m"
         }
       }
     ],
     "slug": "resentment",
-    "description": "<p>When your Shields are broken, you may spend 4PP to gain 2 ticks of Shields as a Complex Action at @Trait[interrupt-2].</p>",
+    "description": "<p>Effect: When the user's Shields are broken, they may spend @PP[-3] as a Complex Action @Trait[interrupt] at @Trait[priority-60] to gain @Tick[2 shield].</p>",
     "traits": [],
     "prerequisites": [],
-    "cost": 2,
+    "cost": 3,
     "_migration": {
       "version": null,
       "previous": null
@@ -65,7 +68,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "effects": [
     {
@@ -92,7 +96,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -106,7 +111,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -118,13 +125,17 @@
         "compendiumSource": "Compendium.ptr2e.core-perks.Item.1hbtcyVMpmrRmtVA.ActiveEffect.EWJRFhW6Yd9V3etk",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.359",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
         "createdTime": 1764897004051,
         "modifiedTime": 1764897017677,
         "lastModifiedBy": "bDEGyOQfZwkb2ml2"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-perks/shielded-fortune.json
+++ b/packs/core-perks/shielded-fortune.json
@@ -7,7 +7,7 @@
   "system": {
     "actions": [],
     "slug": "shielded-fortune",
-    "description": "<p>You gain +1 default CRIT while you have Shields.</p>",
+    "description": "<p>The user has +1 default CRIT and +10% EHR while they have Shields.</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 3,
@@ -17,29 +17,23 @@
     },
     "nodes": [
       {
+        "x": 84,
+        "y": 92,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "guard-up"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#408080",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Combat.svg",
-          "tint": null,
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 84,
-        "y": 92,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -53,7 +47,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "effects": [
     {
@@ -71,20 +66,36 @@
               "self:state:shielded"
             ],
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 10,
+            "phase": "initial",
+            "predicate": [
+              "self:state:shielded"
+            ],
+            "key": "system.modifiers.effectHitRate",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -96,14 +107,17 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-perks.Item.D1QCKKrT1mEcaRK2.ActiveEffect.ugRbKwSW0EdJx8s8",
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.1.0",
+        "systemVersion": "1.7.2.beta",
         "createdTime": 1729979534307,
-        "modifiedTime": 1729979652584,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS",
+        "modifiedTime": 1776354436626,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-perks/superlative-shields.json
+++ b/packs/core-perks/superlative-shields.json
@@ -5,44 +5,54 @@
   "_id": "U9oB0r4DmgOFZW5F",
   "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
   "system": {
-    "actions": [],
+    "actions": [
+      {
+        "name": "Superlative Shields",
+        "slug": "superlative-shields",
+        "description": "<p>Effect: When the user gains any amount of Shields, they gain @Affliction[resolved 2].</p>",
+        "traits": [],
+        "type": "generic",
+        "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+        "cost": {
+          "activation": "free"
+        },
+        "range": {
+          "target": "self",
+          "unit": "m"
+        }
+      }
+    ],
     "slug": "superlative-shields",
-    "description": "<p>Upon gaining Shields, you may spend 4PP to gain @Affliction[resolved 5].</p>",
+    "description": "<p>Effect: When the user gains any amount of Shields, they gain @Affliction[resolved 2].</p>",
     "traits": [],
     "prerequisites": [
       "item:perk:improved-shielding"
     ],
-    "cost": 4,
+    "cost": 3,
     "_migration": {
       "version": null,
       "previous": null
     },
     "nodes": [
       {
+        "x": 87,
+        "y": 105,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "improved-shielding",
           "fortress-doctrine"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#408080",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Arcana.svg",
-          "tint": null,
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 87,
-        "y": 105,
         "tier": null
       }
     ],
     "autoUnlock": [],
-    "originSlug": null,
-    "variant": null,
-    "mode": null,
     "global": true,
     "webs": [],
     "design": {
@@ -56,7 +66,68 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Superlative Shields",
+      "type": "passive",
+      "_id": "qYnaIkMmCm5wte8O",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.resolvedconditio",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [],
+            "dontMerge": true,
+            "key": "superlative-shields-generic",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776353771081,
+        "modifiedTime": 1776353838338,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Rewording of Reflection, small buff to Shielded Fortune, revision of Superlative Shields (to be a simple gain Resolved effect when gaining shields) and revision of Resentment (revised with a lower PP cost and inherent Priority, since the user is sacrificing an entire turn to use the Action preemptively).
- Update Perk: Superlative Shields
- Update Perk: Reflection
- Update Perk: Shielded Fortune
- Update Perk: Resentment