### PR TITLE
Foundry Data Sync - Mega Updates (Champions Launch: Batch 1)

### DIFF
--- a/packs/core-abilities/mega-sol.json
+++ b/packs/core-abilities/mega-sol.json
@@ -1,0 +1,87 @@
+{
+  "name": "Mega Sol",
+  "type": "ability",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "mega-sol",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "environ"
+    ],
+    "actions": [],
+    "description": "<p>Effect: The user is always considered to be under the effect of Sunny Weather for the purposes of their Attacks, Actions, Abilities, and Perks.</p>"
+  },
+  "_id": "VB6Zni58SFGuiSet",
+  "img": "icons/svg/sun.svg",
+  "effects": [
+    {
+      "name": "Mega Sol",
+      "type": "passive",
+      "_id": "defRBJNDS3moYlOq",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "effect:summon:sunny-weather",
+            "phase": "initial",
+            "predicate": [],
+            "domain": "all",
+            "toggleable": false,
+            "count": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": [],
+            "state": true
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776787829506,
+        "modifiedTime": 1776787877571,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-abilities/spicy-spray.json
+++ b/packs/core-abilities/spicy-spray.json
@@ -1,0 +1,93 @@
+{
+  "name": "Spicy Spray",
+  "type": "ability",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "spicy-spray",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "defensive"
+    ],
+    "actions": [],
+    "description": "<p>Effect: When the user is hit with an Attack, the attacking creature gains @Affliction[burn 3].</p>"
+  },
+  "_id": "Vfu3VWefaCYbTOIx",
+  "img": "icons/consumables/fruit/pepper-scorpion-chili-red.webp",
+  "effects": [
+    {
+      "name": "Spicy Spray",
+      "type": "passive",
+      "_id": "ftH7WDHwXgUJGO2f",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.burncondition000",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "origin",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "key": "attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776791652200,
+        "modifiedTime": 1776791689972,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-species/braixen.json
+++ b/packs/core-species/braixen.json
@@ -43,7 +43,7 @@
       ],
       "basic": [
         {
-          "slug": "magic-guard"
+          "slug": "psychic-surge"
         },
         {
           "slug": "witchery"
@@ -54,12 +54,12 @@
           "slug": "pyromancy"
         },
         {
-          "slug": "foretold"
+          "slug": "magic-guard"
         }
       ],
       "master": [
         {
-          "slug": "psychic-surge"
+          "slug": "foretold"
         },
         {
           "slug": "equinox"

--- a/packs/core-species/chandelure.json
+++ b/packs/core-species/chandelure.json
@@ -625,5 +625,135 @@
     }
   },
   "_id": "vnfzRnCS8xNregTB",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Chandelure",
+      "type": "form",
+      "_id": "cJKaFKkBDzJXy350",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-chandelure:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Chandelure Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.iotInErMkWzaKpKP",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-chandelure:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-chandelure:active"
+            ],
+            "hp": null,
+            "atk": null,
+            "def": 20,
+            "spa": 35,
+            "spd": 25,
+            "spe": 20,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.flight.value",
+            "value": 3,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-chandelure:active"
+            ],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.overland.value",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-chandelure:active"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776789097945,
+        "modifiedTime": 1776789215042,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/chesnaught.json
+++ b/packs/core-species/chesnaught.json
@@ -744,6 +744,10 @@
                 "item": null,
                 "level": null,
                 "knownMove": null
+              },
+              "perk": {
+                "x": 26,
+                "y": 26
               }
             }
           ],
@@ -752,19 +756,151 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 26,
+            "y": 26
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.wFhuc9uoClTaQ0Nh"
+      "uuid": "Compendium.ptr2e.core-species.Item.wFhuc9uoClTaQ0Nh",
+      "methods": [],
+      "perk": {
+        "x": 26,
+        "y": 26
+      }
     },
     "publication": {
       "source": "PTR 2e Core - Kalos Dex",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "f6jpUrrw7tMsxgeC",
-  "effects": [],
-  "folder": null
+  "effects": [
+    {
+      "name": "Mega Chesnaught",
+      "type": "form",
+      "_id": "uVYjEsAGDgo0XHED",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-chesnaught:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Chesnaught Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.F9uVTV0KKHivVmWL",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-chesnaught:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-chesnaught:active"
+            ],
+            "hp": null,
+            "atk": 35,
+            "def": 50,
+            "spa": -20,
+            "spd": 45,
+            "spe": -10,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.overland.value",
+            "value": -1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-chesnaught:active"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776789284728,
+        "modifiedTime": 1776789382015,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/chimecho.json
+++ b/packs/core-species/chimecho.json
@@ -679,10 +679,19 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 26,
+            "y": 26
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.y5lxdl8nq0TmWq9Y"
+      "uuid": "Compendium.ptr2e.core-species.Item.y5lxdl8nq0TmWq9Y",
+      "methods": [],
+      "perk": {
+        "x": 26,
+        "y": 26
+      }
     },
     "habitats": [
       "woodland",
@@ -694,10 +703,144 @@
       "source": "PTR 2e Core - Hoenn Dex",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "6THltAMaj0ldckUs",
-  "effects": [],
-  "folder": null
+  "effects": [
+    {
+      "name": "Mega Chimecho",
+      "type": "form",
+      "_id": "wwKTvksuJX7a7CQX",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-chimecho:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Chimecho Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.vEXfzPFttBFhylJ9",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-chimecho:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-chimecho:active"
+            ],
+            "hp": null,
+            "atk": -5,
+            "def": 30,
+            "spa": 40,
+            "spd": 35,
+            "spe": null,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.type.types",
+            "value": "steel",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-chimecho:active"
+            ],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "add-trait",
+            "value": "noisy",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-chimecho:active"
+            ],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776788389695,
+        "modifiedTime": 1776788548876,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/clefable.json
+++ b/packs/core-species/clefable.json
@@ -988,13 +988,25 @@
                 "level": null,
                 "knownMove": null
               },
-              "evolutions": []
+              "evolutions": [],
+              "perk": {
+                "x": 26,
+                "y": 26
+              }
             }
-          ]
+          ],
+          "perk": {
+            "x": 26,
+            "y": 26
+          }
         }
       ],
       "uuid": "Compendium.ptr2e.core-species.Item.Tm4pFKxxlOBlQSKc",
-      "methods": []
+      "methods": [],
+      "perk": {
+        "x": 26,
+        "y": 26
+      }
     },
     "habitats": [
       "mountain"
@@ -1004,9 +1016,177 @@
       "source": "PTR 2e Core - Kanto Dex",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "XskHWYVrmKXXhrj6",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Clefable",
+      "type": "form",
+      "_id": "p7fOQXLlcnRSYmEM",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-clefable:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Clefable Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "basic",
+            "key": "system.type.types",
+            "value": "flying",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-clefable:active"
+            ],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "add-trait",
+            "value": "winged",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-clefable:active"
+            ],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-clefable:active"
+            ],
+            "hp": null,
+            "atk": null,
+            "def": 20,
+            "spa": 40,
+            "spd": 25,
+            "spe": 15,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.jaJfAYMqABXmyrY0",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-clefable:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "basic",
+            "value": 2,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-clefable:active"
+            ],
+            "key": "system.movement.overland.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 2,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-clefable:active"
+            ],
+            "key": "system.movement.flight.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-clefable:active"
+            ],
+            "key": "system.movement.swim.value",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776786431118,
+        "modifiedTime": 1776786577522,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/crabominable.json
+++ b/packs/core-species/crabominable.json
@@ -407,10 +407,19 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 26,
+            "y": 26
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.kobN2qTt2grUHdC9"
+      "uuid": "Compendium.ptr2e.core-species.Item.kobN2qTt2grUHdC9",
+      "methods": [],
+      "perk": {
+        "x": 26,
+        "y": 26
+      }
     },
     "number": 740,
     "slug": "crabominable",
@@ -598,10 +607,133 @@
       "source": "PTR 2e Core - Alola Dex",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "4qSoD6IQqOV0iOqd",
-  "effects": [],
-  "folder": null
+  "effects": [
+    {
+      "name": "Mega Crabominable",
+      "type": "form",
+      "_id": "PKEa3S2nW43z1gg0",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-crabominable:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Crabominable Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.Vco8VcwFpM3zB1Dw",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-crabominable:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-crabominable:active"
+            ],
+            "hp": null,
+            "atk": 45,
+            "def": 40,
+            "spa": -15,
+            "spd": 40,
+            "spe": -10,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.overland.value",
+            "value": -1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-crabominable:active"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776791073931,
+        "modifiedTime": 1776791176104,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/delphox.json
+++ b/packs/core-species/delphox.json
@@ -51,7 +51,7 @@
       ],
       "basic": [
         {
-          "slug": "magic-guard"
+          "slug": "psychic-surge"
         },
         {
           "slug": "witchery"
@@ -62,12 +62,12 @@
           "slug": "pyromancy"
         },
         {
-          "slug": "foretold"
+          "slug": "magic-guard"
         }
       ],
       "master": [
         {
-          "slug": "psychic-surge"
+          "slug": "foretold"
         },
         {
           "slug": "equinox"
@@ -748,5 +748,190 @@
     }
   },
   "_id": "ddcdH1mJmV6vJhFg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Delphox",
+      "type": "form",
+      "_id": "pvDhYQ5G6JQZofWD",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-delphox:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Delphox Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.FWdXCBjg2c6deJyP",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-delphox:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-delphox:active"
+            ],
+            "hp": null,
+            "atk": null,
+            "def": null,
+            "spa": 45,
+            "spd": 25,
+            "spe": 30,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "add-trait",
+            "value": "hover",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-delphox:active"
+            ],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": "flight",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-delphox:active"
+            ],
+            "key": "system.movement.flight.method",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-delphox:active"
+            ],
+            "key": "system.skills.flying.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 20,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-delphox:active"
+            ],
+            "key": "system.movement.flight.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 3,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-delphox:active"
+            ],
+            "key": "system.movement.overland.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 3,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-delphox:active"
+            ],
+            "key": "system.movement.teleport.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 3,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-delphox:active"
+            ],
+            "key": "system.movement.swim.value",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776790259835,
+        "modifiedTime": 1776790583430,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/drampa.json
+++ b/packs/core-species/drampa.json
@@ -414,7 +414,8 @@
       "serpentine",
       "fully-evolved",
       "incubator",
-      "jump-1"
+      "jump-1",
+      "underdog"
     ],
     "diet": [
       "herbivore"
@@ -630,5 +631,146 @@
     }
   },
   "_id": "chFOSHC5UcgPgwp2",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Drampa",
+      "type": "form",
+      "_id": "h0p3DqzwIvTP1iYB",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-drampa:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Drampa Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.DkBaiEXasPXCcpWw",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-drampa:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-drampa:active"
+            ],
+            "hp": null,
+            "atk": 20,
+            "def": 20,
+            "spa": 25,
+            "spd": 20,
+            "spe": 15,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 2,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-drampa:active"
+            ],
+            "key": "system.movement.overland.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 4,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-drampa:active"
+            ],
+            "key": "system.movement.flight.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 2,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-drampa:active"
+            ],
+            "key": "system.movement.swim.value",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776791232325,
+        "modifiedTime": 1776791371538,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/fennekin.json
+++ b/packs/core-species/fennekin.json
@@ -42,10 +42,10 @@
       ],
       "basic": [
         {
-          "slug": "pickup"
+          "slug": "psychic-surge"
         },
         {
-          "slug": "cute-charm"
+          "slug": "witchery"
         }
       ],
       "advanced": [
@@ -53,15 +53,15 @@
           "slug": "pyromancy"
         },
         {
-          "slug": "psy-potential"
+          "slug": "magic-guard"
         }
       ],
       "master": [
         {
-          "slug": "moody"
+          "slug": "foretold"
         },
         {
-          "slug": "magic-guard"
+          "slug": "equinox"
         }
       ]
     },
@@ -558,6 +558,10 @@
                 "item": null,
                 "level": null,
                 "knownMove": null
+              },
+              "perk": {
+                "x": 26,
+                "y": 26
               }
             }
           ],
@@ -566,19 +570,32 @@
             "item": null,
             "level": null,
             "knownMove": null
+          },
+          "perk": {
+            "x": 26,
+            "y": 26
           }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.Tdxc0rMERleIVQZ5"
+      "uuid": "Compendium.ptr2e.core-species.Item.Tdxc0rMERleIVQZ5",
+      "methods": [],
+      "perk": {
+        "x": 26,
+        "y": 26
+      }
     },
     "publication": {
       "source": "PTR 2e Core - Kalos Dex",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "Tdxc0rMERleIVQZ5",
-  "effects": [],
-  "folder": null
+  "effects": []
 }

--- a/packs/core-species/feraligatr.json
+++ b/packs/core-species/feraligatr.json
@@ -763,5 +763,124 @@
     }
   },
   "_id": "IdeCj7OGKWQfNSwz",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Feraligatr",
+      "type": "form",
+      "_id": "vdedfeVvUXjJPg5T",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-feraligatr:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Feraligatr Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.csRO06WcXCGCfSYu",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-feraligatr:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-feraligatr:active"
+            ],
+            "hp": null,
+            "atk": 55,
+            "def": 25,
+            "spa": 10,
+            "spd": 10,
+            "spe": null,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.type.types",
+            "value": "dragon",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-feraligatr:active"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776787393663,
+        "modifiedTime": 1776787476998,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/froslass.json
+++ b/packs/core-species/froslass.json
@@ -34,7 +34,8 @@
       "hex-caster",
       "illusionist",
       "hover",
-      "fully-evolved"
+      "fully-evolved",
+      "underdog"
     ],
     "abilities": {
       "starting": [
@@ -684,5 +685,146 @@
     }
   },
   "_id": "4RzfeE6zqAQkfwZT",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Froslass",
+      "type": "form",
+      "_id": "MHOIMccrMdjs9Aci",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-froslass:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Froslass Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.CNKfFD2LtrnuqHQB",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-froslass:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-froslass:active"
+            ],
+            "hp": null,
+            "atk": null,
+            "def": null,
+            "spa": 60,
+            "spd": 30,
+            "spe": 10,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": -5,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-froslass:active"
+            ],
+            "key": "system.movement.flight.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-froslass:active"
+            ],
+            "key": "system.movement.overland.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-froslass:active"
+            ],
+            "key": "system.movement.swim.value",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776788612740,
+        "modifiedTime": 1776788731892,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/glimmora.json
+++ b/packs/core-species/glimmora.json
@@ -447,5 +447,113 @@
     }
   },
   "_id": "4EcyYLUUncw5VfWS",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Glimmora",
+      "type": "form",
+      "_id": "Fa2G0CNpGBs1CLYm",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-glimmora:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Glimmora Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "key": "Compendium.ptr2e.core-abilities.Item.vEXfzPFttBFhylJ9",
+            "value": "Compendium.ptr2e.core-abilities.Item.vEXfzPFttBFhylJ9",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-glimmora:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-glimmora:active"
+            ],
+            "hp": null,
+            "atk": 35,
+            "def": 20,
+            "spa": 25,
+            "spd": 20,
+            "spe": null,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776791404988,
+        "modifiedTime": 1776791451975,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/greninja.json
+++ b/packs/core-species/greninja.json
@@ -682,5 +682,179 @@
     }
   },
   "_id": "vY8gAoHLFZ7fChvA",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Greninja",
+      "type": "form",
+      "_id": "1ECtVaL3Xf3bcbQE",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-greninja:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Greninja Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.Bv3BgHjhVYResUR8",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-greninja:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-greninja:active"
+            ],
+            "hp": null,
+            "atk": 30,
+            "def": 10,
+            "spa": 30,
+            "spd": 10,
+            "spe": 20,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "add-trait",
+            "value": "hover",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-greninja:active"
+            ],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": "flight",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-greninja:active"
+            ],
+            "key": "system.movement.flight.method",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 40,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-greninja:active"
+            ],
+            "key": "system.skills.flying.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.flight.value",
+            "value": 7,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-greninja:active"
+            ],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.overland.value",
+            "value": 2,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-greninja:active"
+            ],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.swim.value",
+            "value": 2,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-greninja:active"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776790628537,
+        "modifiedTime": 1776790920805,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/hawlucha.json
+++ b/packs/core-species/hawlucha.json
@@ -33,7 +33,8 @@
       "bipedal",
       "well-built",
       "fully-evolved",
-      "jump-5"
+      "jump-5",
+      "underdog"
     ],
     "abilities": {
       "starting": [
@@ -699,5 +700,146 @@
     }
   },
   "_id": "XDDv2UwNEcW9p29H",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Hawlucha",
+      "type": "form",
+      "_id": "UisKKkynAKbk5eCG",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-hawlucha:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Hawlucha Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.YrPhPet3F4ECWLyc",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-hawlucha:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-hawlucha:active"
+            ],
+            "hp": null,
+            "atk": 50,
+            "def": 25,
+            "spa": -10,
+            "spd": 30,
+            "spe": 5,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-hawlucha:active"
+            ],
+            "key": "system.movement.overland.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-hawlucha:active"
+            ],
+            "key": "system.movement.swim.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-hawlucha:active"
+            ],
+            "key": "system.movement.flight.value",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776790852682,
+        "modifiedTime": 1776791022214,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/lopunny.json
+++ b/packs/core-species/lopunny.json
@@ -690,5 +690,223 @@
     }
   },
   "_id": "DRz7zePfs5CZFLMt",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Lopunny",
+      "type": "form",
+      "_id": "yny92LstRJP3NJiV",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-lopunny:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Lopunny Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.YrPhPet3F4ECWLyc",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "alterations": [
+              {
+                "method": 2,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "hp": null,
+            "atk": 60,
+            "def": 10,
+            "spa": null,
+            "spd": null,
+            "spe": 30,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.overland.value",
+            "value": 3,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.swim.value",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 20,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "key": "system.skills.acrobatics.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 10,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "key": "system.skills.climb.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 10,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "key": "system.skills.intimidate.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 10,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "key": "system.skills.lift.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 20,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "key": "system.skills.running.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 15,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "key": "system.skills.swim.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.type.types",
+            "value": "fighting",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-lopunny:active"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776785905775,
+        "modifiedTime": 1776786392329,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/meganium.json
+++ b/packs/core-species/meganium.json
@@ -639,5 +639,124 @@
     }
   },
   "_id": "N4UD73FfRmYSRWLT",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Meganium",
+      "type": "form",
+      "_id": "IVJaMLwbWxezi6Rz",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-meganium:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Meganium Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.VB6Zni58SFGuiSet",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-meganium:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-meganium:active"
+            ],
+            "hp": null,
+            "atk": null,
+            "def": 20,
+            "spa": 60,
+            "spd": 20,
+            "spe": null,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.type.types",
+            "value": "fairy",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-meganium:active"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776787980210,
+        "modifiedTime": 1776788040669,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/scovillain.json
+++ b/packs/core-species/scovillain.json
@@ -263,10 +263,19 @@
             "level": null,
             "knownMove": null
           },
-          "evolutions": []
+          "evolutions": [],
+          "perk": {
+            "x": 26,
+            "y": 26
+          }
         }
       ],
-      "uuid": "Compendium.ptr2e.core-species.Item.KDH54QZSvua6M2gf"
+      "uuid": "Compendium.ptr2e.core-species.Item.KDH54QZSvua6M2gf",
+      "methods": [],
+      "perk": {
+        "x": 26,
+        "y": 26
+      }
     },
     "number": 952,
     "traits": [
@@ -437,10 +446,133 @@
       "source": "PTR 2e Core - Paldea Dex",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "RayxOugZY5FoWKZA",
-  "effects": [],
-  "folder": null
+  "effects": [
+    {
+      "name": "Mega Scovillain",
+      "type": "form",
+      "_id": "7FXOxaLtl3uDyYmw",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-scovillain:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Scovillain Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.Vfu3VWefaCYbTOIx",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-scovillain:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-scovillain:active"
+            ],
+            "hp": null,
+            "atk": 35,
+            "def": 25,
+            "spa": 35,
+            "spd": 25,
+            "spe": -20,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.overland.value",
+            "value": -1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-scovillain:active"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776791764883,
+        "modifiedTime": 1776791877328,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/skarmory.json
+++ b/packs/core-species/skarmory.json
@@ -28,7 +28,8 @@
       "winged",
       "natural-steel",
       "fully-evolved",
-      "jump-3"
+      "jump-3",
+      "underdog"
     ],
     "abilities": {
       "starting": [
@@ -596,5 +597,146 @@
     }
   },
   "_id": "Mdx7vdTa4ZyY8Hn7",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Skarmory",
+      "type": "form",
+      "_id": "PaLnYKOu1yjX6aOD",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-skarmory:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Skarmory Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.AlmUQylaD09D0833",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-skarmory:active"
+            ],
+            "allowDuplicate": false,
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-skarmory:active"
+            ],
+            "hp": null,
+            "atk": 60,
+            "def": -15,
+            "spa": null,
+            "spd": 25,
+            "spe": 30,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 4,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-skarmory:active"
+            ],
+            "key": "system.movement.flight.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-skarmory:active"
+            ],
+            "key": "system.movement.overland.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "add-trait",
+            "value": "bladed",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-skarmory:active"
+            ],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776788094810,
+        "modifiedTime": 1776788346124,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/starmie.json
+++ b/packs/core-species/starmie.json
@@ -642,5 +642,168 @@
     "genderRatio": -1
   },
   "_id": "hWhbKY2pduvsxjvy",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Starmie",
+      "type": "form",
+      "_id": "QiakQgbDt5gULpTm",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-starmie:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Starmie Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.Ip8dZ0Iu8R3vz7Io",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-starmie:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-starmie:active"
+            ],
+            "hp": null,
+            "atk": 25,
+            "def": 20,
+            "spa": 30,
+            "spd": 20,
+            "spe": 5,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "remove-trait",
+            "value": "jump 3",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-starmie:active"
+            ],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "add-trait",
+            "value": "jump 5",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-starmie:active"
+            ],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": -6,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-starmie:active"
+            ],
+            "key": "system.movement.flight.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": 15,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-starmie:active"
+            ],
+            "key": "system.movement.overland.value",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "add-trait",
+            "value": "rapid",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-starmie:active"
+            ],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776786906424,
+        "modifiedTime": 1776787057665,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-species/victreebel.json
+++ b/packs/core-species/victreebel.json
@@ -28,7 +28,8 @@
       "legless",
       "plant-grower",
       "fully-evolved",
-      "jump-2"
+      "jump-2",
+      "underdog"
     ],
     "abilities": {
       "starting": [
@@ -625,5 +626,135 @@
     }
   },
   "_id": "18tH9pj1w597iToh",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mega Victreebel",
+      "type": "form",
+      "_id": "tv0YNgRYGPDvPn5C",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "manual-forme-toggle",
+            "value": "forme:mega-victreebel:active",
+            "domain": "all",
+            "toggleable": true,
+            "label": "Toggle: Mega Victreebel Forme",
+            "predicate": [],
+            "phase": "initial",
+            "state": true,
+            "alwaysActive": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.slX9donFBumFr05N",
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-victreebel:active"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-victreebel:active"
+            ],
+            "hp": null,
+            "atk": 25,
+            "def": 20,
+            "spa": 40,
+            "spd": 25,
+            "spe": -10,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.overland.value",
+            "value": -1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-victreebel:active"
+            ],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.threaded.value",
+            "value": -1,
+            "phase": "initial",
+            "predicate": [
+              "forme:mega-victreebel:active"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "trigger": "manual",
+        "conditions": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.2.beta",
+        "createdTime": 1776786683088,
+        "modifiedTime": 1776786819361,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Adding missing Mega Lopunny. Adding batch of Z-A Megas included in Champions (types, stats, and basic movements only).
- Update Species: lopunny
- Update Species: clefable
- Update Species: victreebel
- Update Species: starmie
- Create Species: dragonite
- Update Species: feraligatr
- Update Ability: Mega Sol
- Update Species: meganium
- Update Species: skarmory
- Update Species: chimecho
- Update Species: froslass
- Create Species: emboar
- Update Species: chandelure
- Update Species: chesnaught
- Update Species: fennekin
- Update Species: braixen
- Update Species: delphox
- Update Species: greninja
- Update Species: hawlucha
- Update Species: crabominable
- Update Species: drampa
- Update Species: glimmora
- Update Ability: Spicy Spray
- Update Species: scovillain