### PR TITLE
Update Zenith trait to inherently Pierce.

### DIFF
--- a/static/traits.json
+++ b/static/traits.json
@@ -3733,8 +3733,22 @@
     "slug": "zenith",
     "label": "Zenith",
     "related": [],
-    "description": "These attacks deal 1/4 of the damage they would deal if they are negated by a @Trait[shield] effect."
-  },
+    "description": "These attacks naturally possess the @Trait[pierce] trait and follow the rules for Z-Moves.",
+    "type": "automated",
+    "changes": [
+      {
+          "type": "alter-attack",
+          "value": "pierce",
+          "phase": "initial",
+          "predicate": [],
+          "property": "traits",
+          "definition": [],
+          "key": "zenith-trait-attack",
+          "method": 2,
+          "ignored": false
+      }
+    ]
+    },
   {
     "slug": "connection",
     "label": "Connection",

--- a/static/traits.json
+++ b/static/traits.json
@@ -3733,7 +3733,7 @@
     "slug": "zenith",
     "label": "Zenith",
     "related": [],
-    "description": "These attacks naturally possess the @Trait[pierce] trait and follow the rules for Z-Moves.",
+    "description": "Gear, creatures, and Actions with this Attacks with this Trait are mechanically involved with the Z-Move @Trait[phenomenon]. Moves with this Trait also possess @Trait[pierce] and @Trait[danger-close].",
     "type": "automated",
     "changes": [
       {
@@ -3747,6 +3747,17 @@
           "method": 2,
           "ignored": false
       }
+      {
+          "type": "alter-attack",
+          "value": "danger-close",
+          "phase": "initial",
+          "predicate": [],
+          "property": "traits",
+          "definition": [],
+          "key": "zenith-trait-attack",
+          "method": 2,
+          "ignored": false
+      }      
     ]
     },
   {


### PR DESCRIPTION
Updates traits.json to reflect rule changes for Z Moves and add automation to them.