### PR TITLE
Foundry Data Sync - Weapon Pass: E-Sh

### DIFF
--- a/packs/core-gear/aegislash-weapon.json
+++ b/packs/core-gear/aegislash-weapon.json
@@ -8,8 +8,10 @@
     },
     "slug": "aegislash-weapon",
     "publication": {
-      "source": "",
-      "authors": [],
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
       "notes": ""
     },
     "traits": [
@@ -137,7 +139,12 @@
       "type": "steel",
       "power": 55,
       "accuracy": 70,
-      "hide": false
+      "hide": false,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "common",
@@ -150,7 +157,8 @@
         "description": "<p>Unidentified Item</p>"
       }
     },
-    "weaponType": "Living Weapon"
+    "weaponType": "Living Weapon",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -168,7 +176,8 @@
             "predicate": [],
             "priority": null,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -182,7 +191,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -195,14 +206,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "folder": "V4skAU6G3OH5fXaf",
-  "flags": {},
   "_id": "ZmJea43J6wpbgdXr"
 }

--- a/packs/core-gear/altru-tera-dp7-laser-rifle.json
+++ b/packs/core-gear/altru-tera-dp7-laser-rifle.json
@@ -9,8 +9,10 @@
     },
     "slug": "altru-tera-dp7-laser-rifle",
     "publication": {
-      "source": "",
-      "authors": [],
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
       "notes": ""
     },
     "traits": [
@@ -170,7 +172,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "14.359",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.5.0.beta",
         "lastModifiedBy": null,

--- a/packs/core-gear/anti-materiel-rifle.json
+++ b/packs/core-gear/anti-materiel-rifle.json
@@ -57,11 +57,11 @@
         "type": "attack",
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 10
+          "unit": "m"
         },
         "cost": {
-          "activation": "complex"
+          "activation": "complex",
+          "powerPoints": 2
         },
         "predicate": []
       },
@@ -200,7 +200,7 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "14.359",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743971623486,

--- a/packs/core-gear/chainsaw.json
+++ b/packs/core-gear/chainsaw.json
@@ -9,8 +9,10 @@
     },
     "slug": "chainsaw",
     "publication": {
-      "source": "",
-      "authors": [],
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
       "notes": ""
     },
     "traits": [
@@ -351,7 +353,7 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "14.359",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.5.0.beta",
         "lastModifiedBy": null,

--- a/packs/core-gear/flintlock-carbine.json
+++ b/packs/core-gear/flintlock-carbine.json
@@ -35,8 +35,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "range": {
           "target": "creature",
@@ -46,11 +45,13 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "defensiveStat": "def",
+        "category": "physical",
         "predicate": [],
         "power": 90,
-        "accuracy": 80
+        "accuracy": 80,
+        "description": "<p>Ammo Use: 1</p>",
+        "free": true,
+        "offensiveStat": "spa"
       }
     ],
     "description": "<p>Flintlock is a general term for any firearm that uses a flint-striking ignition mechanism, replacing earlier firearm-ignition technologies, such as the matchlock and the wheellock. Flintlock weapons were commonly used until they were superceded by percussion lock systems. A carbine is merely a shortened musket, designed for cavalry use, though most cavalry of the era find them a poor substitute for a saber or lance, and infantry (mounted or no) would prefer a musket.</p>",
@@ -76,7 +77,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -85,7 +86,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "B",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -104,7 +107,8 @@
             "label": "Shot",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -118,7 +122,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -130,13 +136,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "S0tnoLhWJSEXG9ua"
 }

--- a/packs/core-gear/flintlock-musket.json
+++ b/packs/core-gear/flintlock-musket.json
@@ -36,8 +36,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "range": {
           "target": "creature",
@@ -47,11 +46,13 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "defensiveStat": "def",
+        "category": "physical",
         "predicate": [],
         "power": 120,
-        "accuracy": 85
+        "accuracy": 85,
+        "description": "<p>Ammo Use: 1</p>",
+        "free": true,
+        "offensiveStat": "spa"
       }
     ],
     "description": "<p>Flintlock is a general term for any firearm that uses a flint-striking ignition mechanism, replacing earlier firearm-ignition technologies, such as the matchlock and the wheellock. Flintlock weapons were commonly used until they were superceded by percussion lock systems. A musket is a muzzle-loaded long gun, usually smoothbore, designed to counter heavy armor and provide effective firepower at medium to long range, <em>en masse</em>.</p>",
@@ -77,7 +78,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -86,7 +87,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "C",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -105,7 +108,8 @@
             "label": "Shot",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -119,7 +123,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -131,13 +137,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "75cnsNrbZlS8F4MA"
 }

--- a/packs/core-gear/flintlock-musketoon.json
+++ b/packs/core-gear/flintlock-musketoon.json
@@ -9,8 +9,10 @@
     },
     "slug": "flintlock-musketoon",
     "publication": {
-      "source": "",
-      "authors": [],
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
       "notes": "<p>Note: \"Shot\" attack to eventually be converted into a \"Spread 2\", 5m attack, 75 Power, 80 Accuracy, once spread rules are finalized.</p>"
     },
     "traits": [
@@ -36,8 +38,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "range": {
           "target": "creature",
@@ -47,11 +48,13 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "defensiveStat": "def",
+        "category": "physical",
         "predicate": [],
         "power": 75,
-        "accuracy": 80
+        "accuracy": 80,
+        "description": "<p>Ammo Use: 1</p>",
+        "free": true,
+        "offensiveStat": "spa"
       },
       {
         "name": "Flintlock Musketoon Ball",
@@ -65,8 +68,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "range": {
           "target": "creature",
@@ -76,11 +78,13 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "defensiveStat": "def",
+        "category": "physical",
         "predicate": [],
         "power": 120,
-        "accuracy": 75
+        "accuracy": 75,
+        "free": true,
+        "offensiveStat": "spa",
+        "description": "<p>Ammo Use: 1</p>"
       }
     ],
     "description": "<p>Flintlock is a general term for any firearm that uses a flint-striking ignition mechanism, replacing earlier firearm-ignition technologies, such as the matchlock and the wheellock. Flintlock weapons were commonly used until they were superceded by percussion lock systems. Similar in length to carbines, musketoons feature a wider-bore barrel for use as a shotgun or firing larger balls.</p>",
@@ -115,7 +119,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "C",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -134,7 +140,8 @@
             "label": "Shot",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -144,7 +151,8 @@
             "label": "Shot",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -158,7 +166,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -170,13 +180,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "5O2FQFtypAsAg4Rx"
 }

--- a/packs/core-gear/flintlock-pistol.json
+++ b/packs/core-gear/flintlock-pistol.json
@@ -36,8 +36,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "range": {
           "target": "creature",
@@ -47,11 +46,13 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "defensiveStat": "def",
+        "category": "physical",
         "predicate": [],
         "power": 60,
-        "accuracy": 75
+        "accuracy": 75,
+        "description": "<p>Ammo Use: 1</p>",
+        "free": true,
+        "offensiveStat": "spa"
       }
     ],
     "description": "<p>Flintlock is a general term for any firearm that uses a flint-striking ignition mechanism, replacing earlier firearm-ignition technologies, such as the matchlock and the wheellock. Flintlock weapons were commonly used until they were superceded by percussion lock systems. Flintlock pistols were used as self-defense weapons and they were frequently used as an adjunct to a sword or cutlass in battle. Their compact size and relatively long reload meant that it was faster to carry multiple loaded pistols into battle and fire between those rather than reload.</p>",
@@ -86,7 +87,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "C",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -105,7 +108,8 @@
             "label": "Shot",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "basic",
@@ -113,7 +117,8 @@
             "value": 0,
             "predicate": [],
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -127,7 +132,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -139,13 +146,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "IWdROLKEXjYQ13tc"
 }

--- a/packs/core-gear/flintlock-rifle.json
+++ b/packs/core-gear/flintlock-rifle.json
@@ -37,8 +37,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "range": {
           "target": "creature",
@@ -48,11 +47,12 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "defensiveStat": "def",
+        "category": "physical",
         "predicate": [],
         "power": 150,
-        "accuracy": 90
+        "accuracy": 90,
+        "free": true,
+        "offensiveStat": "spa"
       }
     ],
     "description": "<p>Flintlock is a general term for any firearm that uses a flint-striking ignition mechanism, replacing earlier firearm-ignition technologies, such as the matchlock and the wheellock. Flintlock weapons were commonly used until they were superceded by percussion lock systems. Rifled weapons have their barrel cut with a helical or spiralling pattern of grooves, which imparts a spin on the projectile, making the missle fly straighter. However, ball-firing muzzle-loading rifles are slower to clean and more likely to jam than a smoothbore musket is, and are better used as a specialist's weapon.</p>",
@@ -78,7 +78,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -87,7 +87,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "B",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -106,7 +108,8 @@
             "label": "Shot",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -120,7 +123,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -132,13 +137,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "ce9O1rTsgYrVOjzV"
 }

--- a/packs/core-gear/grenade-rifle.json
+++ b/packs/core-gear/grenade-rifle.json
@@ -42,7 +42,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 100,
         "accuracy": 80,
         "free": true,
@@ -53,7 +53,7 @@
         ],
         "name": "Grenade Rifle",
         "slug": "grenade-rifle",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,10 +62,10 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "description": "<p>A grenade rifle is a single-shot, shoulder-fired, break-action grenade launcher, designed for both law enforcement and military use. By default, the grenade rifle is armed with fragmentation grenades.</p>",
@@ -93,7 +93,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "otBmE8cY242G5Qzx",
   "effects": [
@@ -113,7 +114,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -127,7 +129,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -138,14 +142,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743884395729,
         "modifiedTime": 1757632004738,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "fwBg1GB1fMcgPklo"

--- a/packs/core-gear/halberd.json
+++ b/packs/core-gear/halberd.json
@@ -33,10 +33,10 @@
         "description": "<p>Effect: On hit, the target has a 30% chance to lose -1 DEF Stage for 5 Activations, and a 30% chance to gain @Affliction[delay 30].</p>",
         "traits": [
           "weapon",
-          "sharp",
           "adaptable",
           "flinch-20",
-          "contact"
+          "contact",
+          "sharp"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -55,7 +55,8 @@
         "category": "physical",
         "predicate": [],
         "power": 95,
-        "accuracy": 90
+        "accuracy": 90,
+        "free": true
       },
       {
         "name": "Halberd Spike",
@@ -93,7 +94,8 @@
           "weapon",
           "adaptable",
           "crit-1",
-          "flinch-30"
+          "flinch-30",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -111,7 +113,8 @@
         "category": "physical",
         "predicate": [],
         "power": 90,
-        "accuracy": 80
+        "accuracy": 80,
+        "free": true
       },
       {
         "name": "Halberd Thrust (Braced)",
@@ -121,7 +124,8 @@
           "weapon",
           "adaptable",
           "crit-1",
-          "interrupt"
+          "interrupt",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -167,7 +171,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -176,7 +180,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "C",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -195,7 +201,8 @@
             "label": "Halberd",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -205,7 +212,8 @@
             "label": "Halberd Chop",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -224,7 +232,8 @@
             ],
             "dontMerge": true,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -237,7 +246,8 @@
             "alterations": [],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -247,7 +257,8 @@
             "label": "Halberd Spike",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -256,7 +267,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -270,7 +282,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -282,13 +296,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "umsTE2xfAKf017k8"
 }

--- a/packs/core-gear/hand-slingshot.json
+++ b/packs/core-gear/hand-slingshot.json
@@ -9,8 +9,10 @@
     },
     "slug": "hand-slingshot",
     "publication": {
-      "source": "",
-      "authors": [],
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
       "notes": ""
     },
     "traits": [
@@ -35,8 +37,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "range": {
           "target": "creature",
@@ -50,7 +51,8 @@
         "free": true,
         "predicate": [],
         "power": 60,
-        "accuracy": 95
+        "accuracy": 95,
+        "description": "<p>Ammo Use: 1</p>"
       },
       {
         "name": "Hand Slingshot Snapshot",
@@ -80,7 +82,8 @@
         "category": "physical",
         "predicate": [],
         "power": 30,
-        "accuracy": 80
+        "accuracy": 80,
+        "description": "<p>Ammo Use: 1</p>"
       }
     ],
     "description": "<p>A slingshot is a small hand-powered projectile weapon. The classic form consists of a Y-shaped frame, strung with elastic material and a pouch in the middle of the elastic string to hold a projectile. One hand holds the frame, while the other hand grasps the pocket and draws it back to the desired extent to provide power for the projectile. Most associated with children and hoodlums, higher-tensile bands and longer draw designs are surprisingly effective for hunting.</p>",
@@ -136,7 +139,8 @@
             "label": "Fire",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "basic",
@@ -145,7 +149,8 @@
             "predicate": [],
             "label": "Snapshot",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -159,7 +164,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -171,13 +178,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.5.0.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "datQlOPNAx8cCJgu"
 }

--- a/packs/core-gear/hand-weapon.json
+++ b/packs/core-gear/hand-weapon.json
@@ -34,7 +34,8 @@
         "traits": [
           "weapon",
           "adaptable",
-          "contact"
+          "contact",
+          "hammer"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -87,10 +88,11 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "E",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [],
-  "flags": {},
   "_id": "rRb0uqppb5elSTfA"
 }

--- a/packs/core-gear/hatchet.json
+++ b/packs/core-gear/hatchet.json
@@ -143,7 +143,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -152,7 +152,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "E",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -171,7 +173,8 @@
             "label": "Hatchet",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -181,7 +184,8 @@
             "label": "Hatchet Swing",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -195,7 +199,8 @@
             "dontMerge": false,
             "label": "Cleave Defense",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -215,7 +220,8 @@
             "dontMerge": false,
             "label": "Cleave Delay",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -225,7 +231,8 @@
             "label": "Hatchet Chop",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -239,7 +246,8 @@
             "dontMerge": false,
             "label": "Chop Defense",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -259,7 +267,8 @@
             "dontMerge": false,
             "label": "Chop Delay",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -269,7 +278,8 @@
             "label": "Fling Crit",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -279,7 +289,8 @@
             "label": "Fling Flat",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -293,7 +304,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -305,13 +318,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "J4r79gpVgEP8DzGe"
 }

--- a/packs/core-gear/heavy-crossbow.json
+++ b/packs/core-gear/heavy-crossbow.json
@@ -50,13 +50,14 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 60,
         "accuracy": 90,
         "free": true,
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "predicate": [],
-        "defensiveStat": "def"
+        "description": "<p>Ammo Use: 1</p>",
+        "offensiveStat": "spa"
       }
     ],
     "description": "<p>A crossbow is a ranged weapon using an elastic launching device consisting of a bow-like assembly mounted horizontally on a main frame, which is hand-held in a similar fashion to the stock of a long gun. Crossbows shoot arrow-like projectiles called bolts or quarrels. Crossbows can be cocked and readed to shoot, allowing the user to aim and shoot with the exertion of a normal bow.</p>",
@@ -82,7 +83,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -91,7 +92,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "B",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -110,7 +113,8 @@
             "label": "Heavy Crossbow",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -124,7 +128,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -136,11 +142,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "_id": "CpftADaPQ4izAvSi"

--- a/packs/core-gear/heavy-machinegun.json
+++ b/packs/core-gear/heavy-machinegun.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "A",
+    "grade": "S",
     "fling": {
       "type": "steel",
       "power": 70,
@@ -43,7 +43,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 70,
         "accuracy": 90,
         "free": true,
@@ -53,7 +53,7 @@
         ],
         "name": "Heavy Machinegun",
         "slug": "heavy-machinegun",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,26 +62,27 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 160,
         "accuracy": 80,
         "free": true,
         "traits": [
           "missile",
-          "firearm"
+          "firearm",
+          "flinch-20"
         ],
         "name": "Heavy Machinegun (Burst)",
         "slug": "heavy-machinegun-burst",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 3</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -90,17 +91,17 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 3
+          "activation": "complex"
         },
         "variant": "heavy-machinegun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 44,
         "accuracy": 75,
         "free": true,
@@ -112,7 +113,7 @@
         ],
         "name": "Heavy Machinegun (Salvo)",
         "slug": "heavy-machinegun-salvo",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 8</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -121,28 +122,29 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 8,
-          "delay": 3
+          "activation": "complex"
         },
         "variant": "heavy-machinegun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 110,
         "accuracy": 65,
         "free": true,
         "traits": [
           "missile",
-          "firearm"
+          "firearm",
+          "dash",
+          "flinch-30"
         ],
         "name": "Heavy Machinegun (Hip Fire)",
         "slug": "heavy-machinegun-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 4</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -151,11 +153,11 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 4
+          "activation": "complex"
         },
         "variant": "heavy-machinegun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -182,7 +184,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A machine gun (MG) is a fully automatic and rifled firearm designed for sustained direct fire with rifle cartridges. A heavy machine gun (HMG) is significantly larger than light, medium or general-purpose machine guns. HMGs are typically too heavy to be man-portable (carried by one person) and require mounting onto a weapons platform to be operably stable or tactically mobile, have more formidable firepower, and generally require a team of personnel for operation and maintenance.</p>"
+    "description": "<p>A machine gun (MG) is a fully automatic and rifled firearm designed for sustained direct fire with rifle cartridges. A heavy machine gun (HMG) is significantly larger than light, medium or general-purpose machine guns. HMGs are typically too heavy to be man-portable (carried by one person) and require mounting onto a weapons platform to be operably stable or tactically mobile, have more formidable firepower, and generally require a team of personnel for operation and maintenance.</p>",
+    "ammoType": []
   },
   "_id": "TJMOmuMwyLSuCWZD",
   "effects": [
@@ -202,7 +205,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -212,7 +216,8 @@
             "label": "Burst",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -222,7 +227,8 @@
             "label": "Hip Fire",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -236,7 +242,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -247,14 +255,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743893056846,
         "modifiedTime": 1757632068754,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "Tn65RZTafVbxqEXT"

--- a/packs/core-gear/lance.json
+++ b/packs/core-gear/lance.json
@@ -32,7 +32,8 @@
           "adaptable",
           "crit-1",
           "contact",
-          "flinch-20"
+          "flinch-20",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -63,7 +64,8 @@
           "contact",
           "pass-1",
           "dash",
-          "flinch-40"
+          "flinch-40",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -118,7 +120,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "B",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -137,7 +141,8 @@
             "label": "Lance",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -147,7 +152,8 @@
             "label": "Lance Charge",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -161,7 +167,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -173,13 +181,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "nf4wHnAEdQ1e8H3J"
 }

--- a/packs/core-gear/lever-action-rifle.json
+++ b/packs/core-gear/lever-action-rifle.json
@@ -25,7 +25,7 @@
         "unit": "m"
       }
     },
-    "rarity": "uncommon",
+    "rarity": "rare",
     "traits": [
       "weapon",
       "fling",
@@ -43,7 +43,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 40,
         "accuracy": 95,
         "free": true,
@@ -61,23 +61,25 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "description": "<p>Ammo Use: 1</p>",
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 28,
-        "accuracy": 85,
+        "accuracy": 90,
         "free": true,
         "traits": [
           "missile",
-          "3-strike",
-          "firearm"
+          "firearm",
+          "double-strike",
+          "flinch-10"
         ],
         "name": "Lever-Action Rifle (Snap Shot)",
         "slug": "lever-action-rifle-snap-shot",
@@ -89,23 +91,26 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 3
+          "activation": "complex"
         },
         "variant": "lever-action-rifle",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa",
+        "description": "<p>Ammo Use: 1</p>"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 40,
         "accuracy": 80,
         "free": true,
         "traits": [
           "missile",
-          "firearm"
+          "firearm",
+          "dash",
+          "priority-15"
         ],
         "name": "Lever-Action Rifle (Hip Fire)",
         "slug": "lever-action-rifle-hip-fire",
@@ -113,15 +118,16 @@
         "type": "attack",
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 8,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "variant": "lever-action-rifle",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa",
+        "description": "<p>Ammo Use: 1</p>"
       }
     ],
     "description": "<p>A lever-action rifle is a firearm where the loading, firing, and unloading processes are all cycled by a lever located behind the trigger, which extracts and ejects the cartridge case and recocks the weapon. The contemporary version of these rifles utilize smaller calibres, primarily for small game-hunting.</p>",
@@ -149,7 +155,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "RWXsZNovxO0dstWt",
   "effects": [
@@ -169,7 +176,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -183,7 +191,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -195,14 +205,17 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.1.3.beta",
         "createdTime": 1743880813905,
         "modifiedTime": 1743883281938,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "folder": "GPebepuiQbZSuf35"

--- a/packs/core-gear/lever-action-shotgun.json
+++ b/packs/core-gear/lever-action-shotgun.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "D",
+    "grade": "C",
     "fling": {
       "type": "steel",
       "power": 75,
@@ -25,7 +25,7 @@
         "unit": "m"
       }
     },
-    "rarity": "uncommon",
+    "rarity": "rare",
     "traits": [
       "weapon",
       "fling",
@@ -43,7 +43,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 70,
         "accuracy": 90,
         "free": true,
@@ -53,7 +53,7 @@
         ],
         "name": "Lever-Action Shotgun",
         "slug": "lever-action-shotgun",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,16 +62,16 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 140,
         "accuracy": 75,
         "free": true,
@@ -82,7 +82,7 @@
         ],
         "name": "Lever-Action Shotgun (Quick Shots)",
         "slug": "lever-action-shotgun-quick-shot",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 3</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -92,17 +92,17 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
           "priority": 1
         },
         "variant": "lever-action-shotgun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 70,
         "accuracy": 80,
         "free": true,
@@ -114,7 +114,7 @@
         ],
         "name": "Lever-Action Shotgun (Hip Fire)",
         "slug": "lever-action-shotgun-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -124,11 +124,11 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
           "priority": 1
         },
         "variant": "lever-action-shotgun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -155,7 +155,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A lever-action shotgun is a shotgun where the loading, firing, and unloading processes are all cycled by a lever located behind the trigger, which extracts and ejects the cartridge case and recocks the weapon. Contemporary lever-action shotguns are generally smaller gauge, for hunting small game and personal defense.</p>"
+    "description": "<p>A lever-action shotgun is a shotgun where the loading, firing, and unloading processes are all cycled by a lever located behind the trigger, which extracts and ejects the cartridge case and recocks the weapon. Contemporary lever-action shotguns are generally smaller gauge, for hunting small game and personal defense.</p>",
+    "ammoType": []
   },
   "_id": "OqtyemHRq5CXKLyF",
   "effects": [
@@ -175,7 +176,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -184,7 +186,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -198,7 +201,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -209,14 +214,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743883292416,
         "modifiedTime": 1757631557056,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "GPebepuiQbZSuf35"

--- a/packs/core-gear/light-crossbow.json
+++ b/packs/core-gear/light-crossbow.json
@@ -50,13 +50,14 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 35,
         "accuracy": 95,
         "free": true,
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "predicate": [],
-        "defensiveStat": "def"
+        "description": "<p>Ammo Use: 1</p>",
+        "offensiveStat": "spa"
       }
     ],
     "description": "<p>A crossbow is a ranged weapon using an elastic launching device consisting of a bow-like assembly mounted horizontally on a main frame, which is hand-held in a similar fashion to the stock of a long gun. Crossbows shoot arrow-like projectiles called bolts or quarrels. Crossbows can be cocked and readed to shoot, allowing the user to aim and shoot with the exertion of a normal bow.</p>",
@@ -82,7 +83,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -91,7 +92,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "C",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -110,7 +113,8 @@
             "label": "Light Crossbow",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -124,7 +128,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -136,11 +142,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "_id": "x7PDkq6rxPxOIRLf"

--- a/packs/core-gear/light-machinegun.json
+++ b/packs/core-gear/light-machinegun.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "C",
+    "grade": "B",
     "fling": {
       "type": "steel",
       "power": 75,
@@ -43,7 +43,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 30,
         "accuracy": 95,
         "free": true,
@@ -53,7 +53,7 @@
         ],
         "name": "Light Machinegun",
         "slug": "light-machinegun",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,26 +62,27 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 110,
         "accuracy": 90,
         "free": true,
         "traits": [
           "missile",
-          "firearm"
+          "firearm",
+          "flinch-10"
         ],
         "name": "Light Machinegun (Burst)",
         "slug": "light-machinegun-burst",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 4</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -90,17 +91,17 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 4
+          "activation": "complex"
         },
         "variant": "light-machinegun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 24,
         "accuracy": 80,
         "free": true,
@@ -108,11 +109,11 @@
           "missile",
           "12-strike",
           "firearm",
-          "flinch-20"
+          "flinch-30"
         ],
         "name": "Light Machinegun (Salvo)",
         "slug": "light-machinegun-salvo",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 12</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -121,29 +122,29 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 12,
-          "delay": 3
+          "activation": "complex"
         },
         "variant": "light-machinegun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 125,
         "accuracy": 70,
         "free": true,
         "traits": [
           "missile",
           "dash",
-          "firearm"
+          "firearm",
+          "flinch-20"
         ],
         "name": "Light Machinegun (Hip Fire)",
         "slug": "light-machinegun-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 5</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -152,11 +153,11 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 5
+          "activation": "complex"
         },
         "variant": "light-machinegun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -183,7 +184,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A machine gun (MG) is a fully automatic and rifled firearm designed for sustained direct fire with rifle cartridges. Light machine guns are designed to provide mobile fire support to a squad and are typically air-cooled weapons fitted with a box magazine or drum and a bipod; they may use full-size rifle rounds, but modern examples often use intermediate rounds.</p>"
+    "description": "<p>A machine gun (MG) is a fully automatic and rifled firearm designed for sustained direct fire with rifle cartridges. Light machine guns are designed to provide mobile fire support to a squad and are typically air-cooled weapons fitted with a box magazine or drum and a bipod; they may use full-size rifle rounds, but modern examples often use intermediate rounds.</p>",
+    "ammoType": []
   },
   "_id": "8cJ2IWNrP813g8ca",
   "effects": [
@@ -203,7 +205,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -213,7 +216,8 @@
             "label": "Burst",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "basic",
@@ -222,7 +226,8 @@
             "predicate": [],
             "label": "Hip Fire",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -236,7 +241,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -247,14 +254,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743891318943,
         "modifiedTime": 1757635969022,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "MKaFm5Pvt7tvgdAa"

--- a/packs/core-gear/long-spear.json
+++ b/packs/core-gear/long-spear.json
@@ -34,7 +34,8 @@
           "adaptable",
           "crit-1",
           "contact",
-          "flinch-20"
+          "flinch-20",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -65,7 +66,8 @@
           "adaptable",
           "crit-1",
           "contact",
-          "priority-10"
+          "priority-10",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -99,7 +101,7 @@
       "slot": "held",
       "handsHeld": 2
     },
-    "grade": "E",
+    "grade": "D",
     "fling": {
       "type": "untyped",
       "power": 100,
@@ -112,7 +114,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -121,7 +123,8 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -140,7 +143,8 @@
             "label": "Long Spear",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -149,7 +153,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -163,7 +168,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -175,13 +182,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "fskeL078Y2ixTTlm"
 }

--- a/packs/core-gear/longbow.json
+++ b/packs/core-gear/longbow.json
@@ -43,8 +43,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "types": [
           "untyped"
@@ -54,7 +53,8 @@
         "accuracy": 80,
         "free": true,
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
-        "predicate": []
+        "predicate": [],
+        "description": "<p>Ammo Use: 1</p>"
       }
     ],
     "description": "<p>A longbow is a type of tall bow that makes a fairly long draw possible. The historical longbow was a simple bow made of a single piece of wood, but modern longbows may also be made from modern materials or by gluing different timbers together. </p>",
@@ -68,7 +68,7 @@
       "slot": "held",
       "handsHeld": 2
     },
-    "grade": "E",
+    "grade": "C",
     "fling": {
       "type": "untyped",
       "power": 40,
@@ -81,7 +81,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -90,7 +90,8 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -109,7 +110,8 @@
             "label": "Longbow",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -123,7 +125,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -135,12 +139,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
         "lastModifiedBy": "r8rxDx9bzq5ASx3l",
-        "modifiedTime": 1764810904149
-      }
+        "modifiedTime": 1764810904149,
+        "createdTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "_id": "kcONNhYYQmn2dEKX"

--- a/packs/core-gear/mace.json
+++ b/packs/core-gear/mace.json
@@ -29,7 +29,8 @@
           "weapon",
           "contact",
           "flinch-20",
-          "crit-2"
+          "crit-2",
+          "hammer"
         ],
         "type": "attack",
         "range": {
@@ -54,7 +55,7 @@
     ],
     "description": "<p>A mace is a blunt weapon, a type of club or virge that uses a heavy head on the end of a handle to deliver powerful strikes. A mace typically consists of a strong, heavy, wooden or metal shaft, often reinforced with metal.</p>",
     "crafting": {
-      "skill": "Blacksmith or Handiwork",
+      "skill": "",
       "spans": null,
       "materials": []
     },
@@ -63,7 +64,7 @@
       "handsHeld": 1,
       "slot": "held"
     },
-    "grade": "E",
+    "grade": "B",
     "fling": {
       "type": "steel",
       "power": 80,
@@ -94,7 +95,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "NIGq9GWSV7beSr6J",
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -113,7 +115,8 @@
             "predicate": [],
             "label": "Mace",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -132,7 +135,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -146,7 +150,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -158,13 +164,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1757543131224,
         "modifiedTime": 1757553446231,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-gear/machine-pistol.json
+++ b/packs/core-gear/machine-pistol.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "A",
+    "grade": "B",
     "fling": {
       "type": "steel",
       "power": 40,
@@ -43,7 +43,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 35,
         "accuracy": 95,
         "free": true,
@@ -52,25 +52,25 @@
         ],
         "name": "Machine Pistol",
         "slug": "machine-pistol",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
           "target": "creature",
-          "distance": 6,
+          "distance": 8,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 22,
         "accuracy": 85,
         "free": true,
@@ -81,26 +81,26 @@
         ],
         "name": "Machine Pistol (Auto)",
         "slug": "machine-pistol-auto",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 7</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
           "target": "creature",
-          "distance": 6,
+          "distance": 7,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 7
+          "activation": "complex"
         },
         "variant": "machine-pistol",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 95,
         "accuracy": 75,
         "free": true,
@@ -108,11 +108,11 @@
           "missile",
           "dash",
           "firearm",
-          "priority-10"
+          "priority-15"
         ],
         "name": "Machine Pistol (Hip Fire)",
         "slug": "machine-pistol-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 4</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -121,11 +121,11 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 4
+          "activation": "complex"
         },
         "variant": "machine-pistol",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -152,7 +152,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A machine pistol is a handgun that is capable of fully automatic fire, including stockless handgun-style submachine guns.</p>"
+    "description": "<p>A machine pistol is a handgun that is capable of fully automatic fire, including stockless handgun-style submachine guns.</p>",
+    "ammoType": []
   },
   "_id": "f7hfwLFTRLq8Xdq0",
   "effects": [
@@ -172,7 +173,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -182,7 +184,8 @@
             "label": "Hip Fire",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -196,7 +199,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -207,14 +212,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743901856213,
         "modifiedTime": 1757632077786,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "Tn65RZTafVbxqEXT"

--- a/packs/core-gear/marksman-rifle.json
+++ b/packs/core-gear/marksman-rifle.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "A",
+    "grade": "B",
     "fling": {
       "type": "steel",
       "power": 50,
@@ -55,7 +55,7 @@
         ],
         "name": "Marksman Rifle",
         "slug": "marksman-rifle",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -64,8 +64,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "predicate": []
       },
@@ -78,7 +77,7 @@
         "traits": [
           "defensive",
           "set-up",
-          "flinch-20"
+          "priority-25"
         ],
         "name": "Marksman Rifle (Set-Up)",
         "slug": "marksman-rifle-set-up",
@@ -90,7 +89,8 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex"
+          "activation": "complex",
+          "powerPoints": 2
         },
         "variant": "marksman-rifle",
         "predicate": []
@@ -98,18 +98,18 @@
       {
         "name": "Marksman Rifle (Resolution)",
         "slug": "marksman-rifle-resolution",
-        "description": "<p>Trigger: The user used Marksman Rifle (Set Up) on their previous Activation.</p><p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Trigger: The user used Marksman Rifle (Set-Up) on their previous Activation.</p><p>Ammo Use: 1</p>",
         "traits": [
           "weapon",
           "missile",
           "crit-2",
-          "firearm"
+          "firearm",
+          "set-up"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "cost": {
           "activation": "complex",
-          "powerPoints": 1,
           "trigger": "The user used Marksman Rifle (Set Up) on their previous Activation."
         },
         "range": {
@@ -122,7 +122,7 @@
         ],
         "category": "physical",
         "predicate": [],
-        "power": 125,
+        "power": 130,
         "accuracy": 100
       }
     ],
@@ -150,7 +150,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A designated marksman rifle (DMR) is a modern scoped high-precision rifle used by infantry in the designated marksman (DM) role. DMRs are distinguished from sniper rifles in that they are semi-automatic to provide higher rates of fire and have larger magazine capacities to allow rapid engagement of multiple targets.</p>"
+    "description": "<p>A designated marksman rifle (DMR) is a modern scoped high-precision rifle used by infantry in the designated marksman (DM) role. DMRs are distinguished from sniper rifles in that they are semi-automatic to provide higher rates of fire and have larger magazine capacities to allow rapid engagement of multiple targets.</p>",
+    "ammoType": []
   },
   "_id": "pfBrCmn8zAAMmONO",
   "effects": [
@@ -168,9 +169,10 @@
             "predicate": [],
             "label": "Marksman Rifle",
             "priority": null,
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "roll-effect",
@@ -178,18 +180,19 @@
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.Smwu5LWbBYgjUmPc",
             "predicate": [],
             "chance": 100,
-            "isFixedChance": false,
+            "isFixedChance": true,
             "affects": "self",
             "alterations": [
               {
+                "method": 5,
                 "property": "duration.turns",
-                "value": 2,
-                "method": 5
+                "value": 2
               }
             ],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -203,7 +206,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -214,14 +219,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1743904713324,
-        "modifiedTime": 1757632647609,
-        "lastModifiedBy": "UTlFSVhgfIUeTsoW",
+        "modifiedTime": 1777947870252,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "Tn65RZTafVbxqEXT"

--- a/packs/core-gear/medium-machinegun.json
+++ b/packs/core-gear/medium-machinegun.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "B",
+    "grade": "A",
     "fling": {
       "type": "steel",
       "power": 85,
@@ -44,7 +44,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 50,
         "accuracy": 90,
         "free": true,
@@ -54,7 +54,7 @@
         ],
         "name": "Medium Machinegun",
         "slug": "medium-machinegun",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -63,26 +63,27 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 125,
         "accuracy": 85,
         "free": true,
         "traits": [
           "missile",
-          "firearm"
+          "firearm",
+          "flinch-15"
         ],
         "name": "Medium Machinegun (Burst)",
         "slug": "medium-machinegun-burst",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 3</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -91,29 +92,29 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 3
+          "activation": "complex"
         },
         "variant": "medium-machinegun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 32,
         "accuracy": 80,
         "free": true,
         "traits": [
           "missile",
           "10-strike",
-          "flinch-30",
-          "firearm"
+          "firearm",
+          "flinch-35"
         ],
         "name": "Medium Machinegun (Salvo)",
         "slug": "medium-machinegun-salvo",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 10</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -122,29 +123,29 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 10,
-          "delay": 3
+          "activation": "complex"
         },
         "variant": "medium-machinegun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 105,
         "accuracy": 60,
         "free": true,
         "traits": [
           "missile",
           "dash",
-          "firearm"
+          "firearm",
+          "flinch-25"
         ],
         "name": "Medium Machinegun (Hip Fire)",
         "slug": "medium-machinegun-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 4</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -153,11 +154,11 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 4
+          "activation": "complex"
         },
         "variant": "medium-machinegun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -184,7 +185,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A machine gun (MG) is a fully automatic and rifled firearm designed for sustained direct fire with rifle cartridges.  Medium machine guns use full-sized rifle rounds and are designed to be used from fixed positions mounted on a tripod.</p>"
+    "description": "<p>A machine gun (MG) is a fully automatic and rifled firearm designed for sustained direct fire with rifle cartridges.  Medium machine guns use full-sized rifle rounds and are designed to be used from fixed positions mounted on a tripod.</p>",
+    "ammoType": []
   },
   "_id": "XtRwBNGmJN12N2z9",
   "effects": [
@@ -204,7 +206,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -213,7 +216,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -222,7 +226,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -236,7 +241,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -247,14 +254,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743892843449,
         "modifiedTime": 1757631998546,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "fwBg1GB1fMcgPklo"

--- a/packs/core-gear/pickaxe.json
+++ b/packs/core-gear/pickaxe.json
@@ -37,7 +37,8 @@
           "adaptable",
           "contact",
           "flinch-10",
-          "crit-1"
+          "crit-1",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -99,7 +100,9 @@
           "adaptable",
           "contact",
           "crit-2",
-          "flinch-40"
+          "flinch-40",
+          "hammer",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -145,7 +148,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -154,7 +157,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "D",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -173,7 +178,8 @@
             "label": "Pickaxe",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -183,7 +189,8 @@
             "label": "Swing",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -197,7 +204,8 @@
             "alterations": [],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -217,7 +225,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -227,7 +236,8 @@
             "label": "Smash",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -241,7 +251,8 @@
             "dontMerge": false,
             "label": "Smash Defense",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -254,7 +265,8 @@
             "alterations": [],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -267,7 +279,8 @@
             "alterations": [],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -280,7 +293,8 @@
             "alterations": [],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -294,7 +308,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -306,15 +322,18 @@
         "compendiumSource": "Item.CKKHxTGLWFlK7jxe.ActiveEffect.dRMRrs9MBQAuqTjh",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
         "createdTime": 1764809995472,
         "modifiedTime": 1764809995472,
         "lastModifiedBy": "r8rxDx9bzq5ASx3l"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "csSm3lt6nLmOZxn5"
 }

--- a/packs/core-gear/pike.json
+++ b/packs/core-gear/pike.json
@@ -34,7 +34,8 @@
           "adaptable",
           "crit-1",
           "contact",
-          "flinch-40"
+          "flinch-40",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -66,7 +67,8 @@
           "adaptable",
           "crit-1",
           "contact",
-          "flinch-10"
+          "flinch-10",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -100,7 +102,7 @@
       "slot": "held",
       "handsHeld": 2
     },
-    "grade": "E",
+    "grade": "D",
     "fling": {
       "type": "untyped",
       "power": 110,
@@ -113,7 +115,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -122,7 +124,8 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -141,7 +144,8 @@
             "label": "Pike",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -150,7 +154,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -164,7 +169,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -176,13 +183,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "foHYwqZ3rC2JPJkH"
 }

--- a/packs/core-gear/pocket-knife.json
+++ b/packs/core-gear/pocket-knife.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": 1
     },
-    "grade": "D",
+    "grade": "E",
     "fling": {
       "type": "dark",
       "power": 60,
@@ -25,7 +25,7 @@
         "unit": "m"
       }
     },
-    "rarity": "common",
+    "rarity": "uncommon",
     "traits": [
       "weapon",
       "fling",
@@ -65,7 +65,8 @@
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "predicate": [],
         "power": 30,
-        "accuracy": 95
+        "accuracy": 95,
+        "free": true
       },
       {
         "name": "Pocket Knife Thrust",
@@ -75,7 +76,8 @@
           "contact",
           "crit-1",
           "grapple",
-          "priority-10"
+          "priority-10",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -93,7 +95,8 @@
         "category": "physical",
         "predicate": [],
         "power": 55,
-        "accuracy": 90
+        "accuracy": 90,
+        "free": true
       }
     ],
     "description": "<p>A pocket knife is a knife with one or more blades that fold into the handle. Pocket knives are versatile tools, and may be used for anything from whittling and woodcarving, to butchering small game, gutting and filleting small fish, aiding in the preparation of tinder and kindling for fires, boring holes in soft material, to opening an envelope, cutting twine, slicing fruits and vegetables or as a means of self-defense.</p>",
@@ -120,7 +123,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "kvrgCQjgU2sDuLal",
   "effects": [
@@ -139,7 +143,8 @@
             "label": "Pocket Knife",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "basic",
@@ -148,7 +153,8 @@
             "predicate": [],
             "label": "Thrust",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "basic",
@@ -156,7 +162,8 @@
             "value": 9,
             "predicate": [],
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -170,7 +177,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -182,13 +191,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1757547044775,
         "modifiedTime": 1757553354211,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "GPebepuiQbZSuf35"

--- a/packs/core-gear/pocket-pistol.json
+++ b/packs/core-gear/pocket-pistol.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "E",
+    "grade": "D",
     "fling": {
       "type": "steel",
       "power": 60,
@@ -25,7 +25,7 @@
         "unit": "m"
       }
     },
-    "rarity": "uncommon",
+    "rarity": "rare",
     "traits": [
       "weapon",
       "fling",
@@ -47,19 +47,18 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 35,
         "accuracy": 95,
         "free": true,
         "traits": [
-          "load-adaptive",
           "missile",
           "readied",
           "firearm"
         ],
         "name": "Pocket Pistol",
         "slug": "pocket-pistol",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -68,31 +67,30 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 35,
-        "accuracy": 95,
+        "accuracy": 100,
         "free": true,
         "traits": [
-          "load-adaptive",
           "interrupt",
           "contact",
-          "crit-2",
           "missile",
-          "flinch-20",
-          "firearm"
+          "firearm",
+          "crit-1",
+          "flinch-30"
         ],
         "name": "Pocket Pistol (Palmed Shot)",
         "slug": "pocket-pistol-palmed-shot",
-        "description": "<p>Trigger: The user hits with and resolves a @Trait[contact] Attack.</p><p>Effect: The user attacks the hit creature with this Attacks. This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Trigger: The user hits with and resolves a @Trait[contact] Attack.</p><p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -103,10 +101,11 @@
         "cost": {
           "activation": "free",
           "powerPoints": 1,
-          "trigger": "<p>The user hits with and resolves a @Trait[contact] Attack.</p>"
+          "trigger": "The user hits with and resolves a @Trait[contact] Attack."
         },
         "variant": "pocket-pistol",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -133,7 +132,8 @@
       ],
       "notes": "<p>A pocket pistol is any small, pocket-sized semi-automatic pistol (or less commonly referencing either derringers, or revolvers), and is suitable for concealed carry in a pocket or a similar small space. Best used in scenarios where you need a self-defense weapon and don't have a lot of storage space to work with.</p>"
     },
-    "description": "<p>A pocket pistol is any small, pocket-sized semi-automatic pistol (or less commonly referencing either derringers, or revolvers), and is suitable for concealed carry in a pocket or a similar small space.</p>"
+    "description": "<p>A pocket pistol is any small, pocket-sized semi-automatic pistol (or less commonly referencing either derringers, or revolvers), and is suitable for concealed carry in a pocket or a similar small space.</p>",
+    "ammoType": []
   },
   "_id": "jCTocegK9bXTiIWU",
   "effects": [
@@ -153,7 +153,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -167,7 +168,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -179,14 +182,17 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.1.3.beta",
         "createdTime": 1743879953422,
         "modifiedTime": 1743879978926,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "folder": "PhrQtZzEwKPjfmK2"

--- a/packs/core-gear/pump-action-shotgun.json
+++ b/packs/core-gear/pump-action-shotgun.json
@@ -55,35 +55,36 @@
         ],
         "name": "Pump-Action Shotgun",
         "slug": "pump-action-shotgun",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
           "target": "wide-line",
-          "distance": 8,
+          "distance": 9,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "power": 180,
+        "category": "physical",
+        "power": 190,
         "accuracy": 85,
         "free": true,
         "traits": [
           "missile",
-          "firearm"
+          "firearm",
+          "flinch-15"
         ],
         "name": "Pump-Action Shotgun (Slam Trigger)",
         "slug": "pump-action-shotgun-slam-trigger",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 3</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -92,17 +93,17 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 3
+          "activation": "complex"
         },
         "variant": "pump-action-shotgun",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 85,
         "accuracy": 80,
         "free": true,
@@ -113,7 +114,7 @@
         ],
         "name": "Pump-Action Shotgun (Hip Fire)",
         "slug": "pump-action-shotgun-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -122,9 +123,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1,
-          "priority": 1
+          "activation": "complex"
         },
         "variant": "pump-action-shotgun",
         "predicate": []
@@ -154,7 +153,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A pump-action shotgun is a shotgun with a manual firearm action that is operated by moving a sliding handguard on the gun's forestock, typically using the slide to eject spent casings, chamber a new round, and prime the weapon. These weapons are typically fed from a tubular magazine underneath the barrel, though some more modern designs utilize detachable box magazines.</p>"
+    "description": "<p>A pump-action shotgun is a shotgun with a manual firearm action that is operated by moving a sliding handguard on the gun's forestock, typically using the slide to eject spent casings, chamber a new round, and prime the weapon. These weapons are typically fed from a tubular magazine underneath the barrel, though some more modern designs utilize detachable box magazines.</p>",
+    "ammoType": []
   },
   "_id": "cKsYET7mSIuV0Qhw",
   "effects": [
@@ -174,7 +174,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -183,7 +184,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -197,7 +199,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -208,14 +212,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743970446605,
         "modifiedTime": 1757631979494,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "fwBg1GB1fMcgPklo"

--- a/packs/core-gear/rocket-launcher.json
+++ b/packs/core-gear/rocket-launcher.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "A",
+    "grade": "S",
     "fling": {
       "type": "steel",
       "power": 80,
@@ -25,7 +25,7 @@
         "unit": "m"
       }
     },
-    "rarity": "uncommon",
+    "rarity": "rare",
     "traits": [
       "weapon",
       "fling",
@@ -49,11 +49,12 @@
         "traits": [
           "explode",
           "blast-1",
-          "firearm"
+          "firearm",
+          "flinch-25"
         ],
         "name": "Rocket Launcher",
         "slug": "rocket-launcher",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF. On resolution, the user is @Affliction[delay 20].</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,8 +63,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "predicate": []
       }
@@ -92,7 +92,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A rocket launcher is a weapon that launches an unguided, rocket-propelled projectile. Modern rocket launchers includes shoulder-fired weapons, any weapon that fires a rocket-propelled projectile at a target yet is small enough to be carried by a single person and fired while held on one's shoulder.</p>"
+    "description": "<p>A rocket launcher is a weapon that launches an unguided, rocket-propelled projectile. Modern rocket launchers includes shoulder-fired weapons, any weapon that fires a rocket-propelled projectile at a target yet is small enough to be carried by a single person and fired while held on one's shoulder.</p>",
+    "ammoType": []
   },
   "_id": "K3a5ILims233TLsp",
   "effects": [
@@ -112,7 +113,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -126,7 +128,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -137,14 +141,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743904735453,
         "modifiedTime": 1757632918983,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "Tn65RZTafVbxqEXT"

--- a/packs/core-gear/rpg.json
+++ b/packs/core-gear/rpg.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "B",
+    "grade": "A",
     "fling": {
       "type": "steel",
       "power": 60,
@@ -25,7 +25,7 @@
         "unit": "m"
       }
     },
-    "rarity": "uncommon",
+    "rarity": "rare",
     "traits": [
       "weapon",
       "fling",
@@ -42,7 +42,7 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
+        "category": "physical",
         "power": 145,
         "accuracy": 85,
         "free": true,
@@ -54,7 +54,7 @@
         ],
         "name": "RPG",
         "slug": "rpg",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -63,11 +63,10 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 4,
-          "delay": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -94,7 +93,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A a rocket-propelled grenade (RPG) is a shoulder-fired anti-tank weapon that launches rockets equipped with a shaped-charge explosive warhead. Most RPGs can be carried by an individual soldier, and are frequently used as anti-tank weapons.</p>"
+    "description": "<p>A a rocket-propelled grenade (RPG) is a shoulder-fired anti-tank weapon that launches rockets equipped with a shaped-charge explosive warhead. Most RPGs can be carried by an individual soldier, and are frequently used as anti-tank weapons.</p>",
+    "ammoType": []
   },
   "_id": "24x8eUACHx1is6Lj",
   "effects": [
@@ -114,7 +114,8 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -128,7 +129,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -139,14 +142,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1743905710613,
         "modifiedTime": 1757631988382,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "fwBg1GB1fMcgPklo"

--- a/packs/core-gear/saber.json
+++ b/packs/core-gear/saber.json
@@ -66,7 +66,8 @@
           "adaptable",
           "crit-1",
           "grapple",
-          "flinch-10"
+          "flinch-10",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -96,13 +97,13 @@
           "adaptable",
           "pass-3",
           "dash",
-          "flinch-25"
+          "flinch-30"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "cost": {
           "activation": "complex",
-          "powerPoints": 1
+          "powerPoints": 6
         },
         "range": {
           "target": "creature",
@@ -115,7 +116,7 @@
         "category": "physical",
         "free": true,
         "predicate": [],
-        "power": 110,
+        "power": 125,
         "accuracy": 90
       }
     ],
@@ -142,7 +143,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -151,7 +152,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "C",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -170,7 +173,8 @@
             "label": "Saber",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -180,7 +184,8 @@
             "label": "Saber Thrust",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -190,7 +195,8 @@
             "label": "Saber Charge",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -200,7 +206,8 @@
             "label": "Saber (Fling)",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -214,7 +221,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -226,12 +235,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
         "lastModifiedBy": "r8rxDx9bzq5ASx3l",
-        "modifiedTime": 1762640671454
-      }
+        "modifiedTime": 1762640671454,
+        "createdTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "_id": "KCghcBlfNSfb2ZEk"

--- a/packs/core-gear/semi-auto-rifle.json
+++ b/packs/core-gear/semi-auto-rifle.json
@@ -25,7 +25,7 @@
         "unit": "m"
       }
     },
-    "rarity": "rare",
+    "rarity": "uncommon",
     "traits": [
       "weapon",
       "fling",
@@ -43,8 +43,8 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "power": 45,
+        "category": "physical",
+        "power": 70,
         "accuracy": 95,
         "free": true,
         "traits": [
@@ -53,7 +53,7 @@
         ],
         "name": "Semi-Auto Rifle",
         "slug": "semi-auto-rifle",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,28 +62,28 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "power": 35,
+        "category": "physical",
+        "power": 40,
         "accuracy": 85,
         "free": true,
         "traits": [
           "missile",
-          "3-strike",
           "firearm",
-          "priority-10"
+          "double-strike",
+          "flinch-10"
         ],
         "name": "Semi-Auto Rifle (Snap Shot)",
         "slug": "semi-auto-rifle-snap-shot",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -92,19 +92,18 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 3,
-          "priority": 1
+          "activation": "complex"
         },
         "variant": "semi-auto-rifle",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "power": 45,
+        "category": "physical",
+        "power": 55,
         "accuracy": 80,
         "free": true,
         "traits": [
@@ -115,7 +114,7 @@
         ],
         "name": "Semi-Auto Rifle (Hip Fire)",
         "slug": "semi-auto-rifle-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -124,12 +123,11 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 4,
-          "priority": 1
+          "activation": "complex"
         },
         "variant": "semi-auto-rifle",
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       }
     ],
     "weaponType": "untyped",
@@ -156,7 +154,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>A semi-automatic rifle is a type of rifle that fires a single round each time the trigger is pulled while automatically loading the next cartridge. The actions of semi-automatic rifles use a portion of the fired cartridge's energy to eject the spent casing and load a new round into the chamber, readying the rifle to be fired again.</p>"
+    "description": "<p>A semi-automatic rifle is a type of rifle that fires a single round each time the trigger is pulled while automatically loading the next cartridge. The actions of semi-automatic rifles use a portion of the fired cartridge's energy to eject the spent casing and load a new round into the chamber, readying the rifle to be fired again.</p>",
+    "ammoType": []
   },
   "_id": "zdAxZicLlZ87xO4S",
   "effects": [
@@ -170,13 +169,23 @@
           {
             "type": "flat-modifier",
             "key": "{item|id}-attack-damage-flat",
-            "value": 29,
+            "value": 31,
             "predicate": [],
-            "label": "Assault Rifle",
+            "label": "Semi-Auto Rifle",
             "priority": null,
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
+          },
+          {
+            "type": "basic",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [],
+            "key": "",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -190,7 +199,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -201,14 +212,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1743972846415,
-        "modifiedTime": 1757632037154,
-        "lastModifiedBy": "UTlFSVhgfIUeTsoW",
+        "modifiedTime": 1777948936383,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "MKaFm5Pvt7tvgdAa"

--- a/packs/core-gear/semi-auto-shotgun.json
+++ b/packs/core-gear/semi-auto-shotgun.json
@@ -13,7 +13,7 @@
       "carryType": "stowed",
       "handsHeld": null
     },
-    "grade": "A",
+    "grade": "B",
     "fling": {
       "type": "steel",
       "power": 75,
@@ -43,8 +43,8 @@
         "types": [
           "untyped"
         ],
-        "category": "special",
-        "power": 65,
+        "category": "physical",
+        "power": 75,
         "accuracy": 95,
         "free": true,
         "traits": [
@@ -53,7 +53,7 @@
         ],
         "name": "Semi-Auto Shotgun",
         "slug": "semi-auto-shotgun",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -62,17 +62,17 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
-        "predicate": []
+        "predicate": [],
+        "offensiveStat": "spa"
       },
       {
         "types": [
           "untyped"
         ],
         "category": "special",
-        "power": 145,
+        "power": 180,
         "accuracy": 75,
         "free": true,
         "traits": [
@@ -82,7 +82,7 @@
         ],
         "name": "Semi-Auto Shotgun (Breaching Shots)",
         "slug": "semi-auto-shotgun-breaching-shots",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 3</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -91,8 +91,7 @@
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 3
+          "activation": "complex"
         },
         "variant": "semi-auto-shotgun",
         "predicate": []
@@ -113,7 +112,7 @@
         ],
         "name": "Semi-Auto Shotgun (Hip Fire)",
         "slug": "semi-auto-shotgun-hip-fire",
-        "description": "<p>Effect: This attack calculates damage against the target's DEF, rather than SPDEF.</p>",
+        "description": "<p>Ammo Use: 3</p>",
         "img": "systems/ptr2e/img/svg/untyped_icon.svg",
         "type": "attack",
         "range": {
@@ -123,8 +122,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3,
-          "priority": 1
+          "powerPoints": 3
         },
         "variant": "semi-auto-shotgun",
         "predicate": []
@@ -155,7 +153,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "PGwWe0q5WpokJsq9",
   "effects": [
@@ -168,33 +167,37 @@
         "changes": [
           {
             "type": "flat-modifier",
-            "key": "{item|id}-attack-damage-flat",
+            "key": "{item|id}-attack-damage",
             "value": 32,
             "predicate": [],
             "label": "Semi-Auto Shotgun",
             "priority": null,
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "flat-modifier",
-            "key": "semi-auto-shotgun-breaching-shots-attack-damage-flat",
+            "key": "semi-auto-shotgun-breaching-shots-attack-damage",
             "value": 64,
             "predicate": [],
             "label": "Breaching Shots",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
-            "type": "basic",
-            "key": "semi-auto-shotgun-hip-fire-attack-damage-flat",
+            "type": "flat-modifier",
+            "key": "semi-auto-shotgun-hip-fire-attack-damage",
             "value": 32,
             "predicate": [],
             "label": "Hip Fire",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "method": 2
+            "hideIfDisabled": false
           }
         ],
         "slug": null,
@@ -208,7 +211,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -219,14 +224,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Ba3EyqpUePgGrfQk.ActiveEffect.uOxpw5kHcRtpv4pa",
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1743972346372,
-        "modifiedTime": 1757633258502,
-        "lastModifiedBy": "UTlFSVhgfIUeTsoW",
+        "modifiedTime": 1777949235438,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "Tn65RZTafVbxqEXT"

--- a/packs/core-gear/sheathed-knife.json
+++ b/packs/core-gear/sheathed-knife.json
@@ -25,7 +25,7 @@
         "unit": "m"
       }
     },
-    "rarity": "common",
+    "rarity": "uncommon",
     "traits": [
       "weapon",
       "fling",
@@ -78,7 +78,8 @@
           "contact",
           "crit-1",
           "grapple",
-          "adaptable"
+          "adaptable",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -142,7 +143,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -151,7 +153,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -160,7 +163,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -174,7 +178,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -186,13 +192,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.5.0.beta",
         "createdTime": 1757553244816,
         "modifiedTime": 1770678695273,
         "lastModifiedBy": "Bk6N5iKyebvEVXhL"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "MKaFm5Pvt7tvgdAa"

--- a/packs/core-gear/short-spear.json
+++ b/packs/core-gear/short-spear.json
@@ -34,7 +34,8 @@
           "weapon",
           "adaptable",
           "crit-1",
-          "contact"
+          "contact",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -65,7 +66,8 @@
           "adaptable",
           "crit-1",
           "priority-30",
-          "contact"
+          "contact",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -112,7 +114,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -121,7 +123,8 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -140,7 +143,8 @@
             "label": "Short Spear",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -150,7 +154,8 @@
             "label": "Short Spear (Fling)",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -164,7 +169,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -176,13 +183,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "59jMPim78LPZLF1r"
 }

--- a/packs/core-gear/spear.json
+++ b/packs/core-gear/spear.json
@@ -30,7 +30,8 @@
           "flinch-10",
           "adaptable",
           "crit-1",
-          "contact"
+          "contact",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -61,7 +62,8 @@
           "interrupt",
           "adaptable",
           "crit-1",
-          "contact"
+          "contact",
+          "horn"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -95,7 +97,7 @@
       "handsHeld": 1,
       "slot": "held"
     },
-    "grade": "E",
+    "grade": "D",
     "fling": {
       "type": "untyped",
       "power": 90,
@@ -124,7 +126,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "_id": "FX8evEUsSSejSEI2",
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -144,7 +147,8 @@
             "label": "Spear",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -153,7 +157,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -167,7 +172,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -179,13 +186,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1757543945278,
         "modifiedTime": 1758068541951,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }


### PR DESCRIPTION
Updating Grades+Rarities, revising Traits (except for PMD and Fantasy items).
- Update Weapon: Aegislash (Weapon)
- Update Weapon: Altru-Tera DP7 Laser Rifle
- Update Weapon: Chainsaw
- Update Weapon: Flintlock Carbine
- Update Weapon: Flintlock Musket
- Update Weapon: Flintlock Musketoon
- Update Weapon: Flintlock Pistol
- Update Weapon: Flintlock Rifle
- Update Weapon: Grenade Rifle
- Update Weapon: Halberd
- Update Weapon: Hand Slingshot
- Update Weapon: Hand Weapon
- Update Weapon: Hatchet
- Update Weapon: Heavy Crossbow
- Update Weapon: Light Crossbow
- Update Weapon: Light Machinegun
- Update Weapon: Medium Machinegun
- Update Weapon: Heavy Machinegun
- Update Weapon: Lance
- Update Weapon: Lever-Action Rifle
- Update Weapon: Lever-Action Shotgun
- Update Weapon: Long Spear
- Update Weapon: Short Spear
- Update Weapon: Spear
- Update Weapon: Longbow
- Update Weapon: Mace
- Update Weapon: Machine Pistol
- Update Weapon: Marksman Rifle
- Update Weapon: Anti-Materiel Rifle
- Update Weapon: Pickaxe
- Update Weapon: Pike
- Update Weapon: Pocket Knife
- Update Weapon: Pocket Pistol
- Update Weapon: Pump-Action Shotgun
- Update Weapon: Rocket Launcher
- Update Weapon: RPG
- Update Weapon: Saber
- Update Weapon: Semi-Auto Rifle
- Update Weapon: Semi-Auto Shotgun
- Update Weapon: Sheathed Knife