### PR TITLE
Foundry Data Sync - Fox New Perk Bundle (06/05/2026)

### DIFF
--- a/packs/core-perks/ace-up-my-sleeve.json
+++ b/packs/core-perks/ace-up-my-sleeve.json
@@ -1,0 +1,137 @@
+{
+  "folder": "E5JYWji5073kTXhD",
+  "name": "Ace Up My Sleeve",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Ace Up My Sleeve",
+        "slug": "ace-up-my-sleeve",
+        "description": "<p>Trigger: The user enters combat.</p><p>Effect: The user may immediately draw 1 card from the Metronome Deck. This action is considered to be the same as using the Metronome move for the purpose of Card Captor.</p>",
+        "traits": [
+          "gambler"
+        ],
+        "type": "generic",
+        "img": "icons/sundries/gaming/playing-cards.webp",
+        "cost": {
+          "activation": "free",
+          "powerPoints": 3
+        },
+        "range": {
+          "target": "self",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Trigger: The user enters combat.</p><p>Effect: The user may immediately draw 1 card from the Metronome Deck. This action is considered to be the same as using the Metronome move for the purpose of Card Captor.</p>",
+    "traits": [
+      "gambler"
+    ],
+    "prerequisites": [
+      "item:move:metronome"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "gambler"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 98,
+        "y": 194,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "the-devil-does-bargain",
+          "card-captor-1",
+          "minor-buff-23",
+          "pokerface",
+          "twist"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ]
+  },
+  "_id": "uk9aI6nJ0S64EaG8",
+  "img": "icons/sundries/gaming/playing-cards.webp",
+  "effects": [
+    {
+      "name": "Ace Up My Sleeve",
+      "type": "passive",
+      "_id": "pJjSudZvaznxaMmK",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-note",
+            "value": "{actor|link} enters combat and may spend {item|actions.contents.0.cost.powerPoints} PP to use {item|link}!",
+            "phase": "initial",
+            "predicate": [],
+            "visibility": null,
+            "key": "combat-enter",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778077593014,
+        "modifiedTime": 1778077593014,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/ace-up-my-sleeve.json
+++ b/packs/core-perks/ace-up-my-sleeve.json
@@ -20,7 +20,7 @@
         "slug": "ace-up-my-sleeve",
         "description": "<p>Trigger: The user enters combat.</p><p>Effect: The user may immediately draw 1 card from the Metronome Deck. This action is considered to be the same as using the Metronome move for the purpose of Card Captor.</p>",
         "traits": [
-          "gambler"
+          "interrupt"
         ],
         "type": "generic",
         "img": "icons/sundries/gaming/playing-cards.webp",

--- a/packs/core-perks/assert-dominance.json
+++ b/packs/core-perks/assert-dominance.json
@@ -1,0 +1,55 @@
+{
+  "folder": "6XbjR9qPWzZw4vEd",
+  "name": "Assert Dominance",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Target: A commanded ally.</p><p>Effect: As a Simple Action costing @PP[-2], you may target a commanded ally creature and inflict @Affliction[fear 5] on them. If used during a League Combat Rules scenario, this may be used as a @Trait[command] Action in the same way as Styles are.</p>",
+    "traits": [
+      "taskmaster",
+      "command"
+    ],
+    "prerequisites": [
+      "item:perk:commissar"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "taskmaster"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 41,
+        "y": 106,
+        "connected": [
+          "commissar",
+          "conscription",
+          "the-quality-of-quantity"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "EyEaFUeLsmcDsV2d",
+  "img": "systems/ptr2e/img/perk-icons/Trainer.svg",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/bait.json
+++ b/packs/core-perks/bait.json
@@ -1,0 +1,150 @@
+{
+  "folder": "c29hnIAtXgwB7FeY",
+  "name": "Bait",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Bait",
+        "slug": "bait",
+        "description": "<p>Effect: On entering combat, the user can spend @PP[-2] to inflict @Affliction[marked 5] on themselves.</p>",
+        "traits": [
+          "tank",
+          "social"
+        ],
+        "type": "generic",
+        "img": "icons/skills/social/intimidation-impressing.webp",
+        "cost": {
+          "activation": "free",
+          "powerPoints": 2
+        },
+        "range": {
+          "target": "self",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Effect: On entering combat, the user can spend @PP[-2] to inflict @Affliction[marked 5] on themselves.</p>",
+    "traits": [
+      "tank",
+      "social"
+    ],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.intimidate.mod}",
+          45
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "resilience",
+      "archetype": "tank"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 92,
+        "y": 91,
+        "connected": [
+          "shielded-fortune",
+          "ready-for-anything",
+          "punishment-ward"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "wugawQVqZ0z4FHHA",
+  "img": "icons/skills/social/intimidation-impressing.webp",
+  "effects": [
+    {
+      "name": "Bait",
+      "type": "passive",
+      "_id": "bIsrH6iFytKwLywv",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-note",
+            "value": "{actor|link} enters combat and may spend {item|actions.contents.0.cost.powerPoints} PP to use {item|link}!",
+            "phase": "initial",
+            "predicate": [],
+            "key": "combat-enter",
+            "visibility": null,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.markedcondititem",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "bait-generic",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778078077460,
+        "modifiedTime": 1778078077460,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/bait.json
+++ b/packs/core-perks/bait.json
@@ -18,7 +18,7 @@
       {
         "name": "Bait",
         "slug": "bait",
-        "description": "<p>Effect: On entering combat, the user can spend @PP[-2] to inflict @Affliction[marked 5] on themselves.</p>",
+        "description": "<p>Trigger: The user enters combat</p><p>Effect: The user gains @Affliction[marked 5].</p>",
         "traits": [
           "tank",
           "social"
@@ -35,7 +35,7 @@
         }
       }
     ],
-    "description": "<p>Effect: On entering combat, the user can spend @PP[-2] to inflict @Affliction[marked 5] on themselves.</p>",
+    "description": "<p>Trigger: The user enters combat</p><p>Effect: The user gains @Affliction[marked 5].</p>",
     "traits": [
       "tank",
       "social"

--- a/packs/core-perks/bondmate.json
+++ b/packs/core-perks/bondmate.json
@@ -17,7 +17,8 @@
       {
         "name": "Bondmate",
         "slug": "bondmate",
-        "description": "<p>Effect: The user creates a bondmate summon. This summon is attached to an ally, and lasts for 3 activations. The summon has an AV of 90. On the summon's activation, it grants the target ally @Tick[3 shield].</p><p>You may only have one Bondmate summon active at a time.</p>",
+        "description": "<p>Effect: The user creates a Bondmate Summon (AV 90, 3 Activations), attaching it to an Ally within range. On the Summon's Activation, the selected Ally gains @Tick[3 shield].</p><p>Restriction: The user may only have one Bondmate Summon active at any given time.</p>",
+
         "traits": [
           "tank"
         ],
@@ -35,7 +36,7 @@
         }
       }
     ],
-    "description": "<p>Effect: The user creates a bondmate summon. This summon is attached to an ally, and lasts for 3 activations. The summon has an AV of 90. On the summon's activation, it grants the target ally @Tick[3 shield].</p><p></p><p>You may only have one Bondmate summon active at a time.</p>",
+    "description": "<p>Effect: The user creates a Bondmate Summon (AV 90, 3 Activations), attaching it to an Ally within 10m. On the Summon's Activation, the selected Ally gains @Tick[3 shield].</p><p>Restriction: The user may only have one Bondmate Summon active at any given time. at a time.</p>",
     "traits": [
       "summon",
       "ranger"

--- a/packs/core-perks/bondmate.json
+++ b/packs/core-perks/bondmate.json
@@ -1,0 +1,74 @@
+{
+  "name": "Bondmate",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Bondmate",
+        "slug": "bondmate",
+        "description": "<p>Effect: The user creates a bondmate summon. This summon is attached to an ally, and lasts for 3 activations. The summon has an AV of 90. On the summon's activation, it grants the target ally @Tick[3 shield].</p><p>You may only have one Bondmate summon active at a time.</p>",
+        "traits": [
+          "tank"
+        ],
+        "type": "generic",
+        "img": "icons/magic/defensive/armor-green-hex.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "summon": "Compendium.ptr2e.core-summons.Item.4LTYjzwsQde6lytE",
+        "range": {
+          "target": "ally",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Effect: The user creates a bondmate summon. This summon is attached to an ally, and lasts for 3 activations. The summon has an AV of 90. On the summon's activation, it grants the target ally @Tick[3 shield].</p><p></p><p>You may only have one Bondmate summon active at a time.</p>",
+    "traits": [
+      "summon",
+      "ranger"
+    ],
+    "prerequisites": [
+      "trait:ranger"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "resilience",
+      "archetype": "ranger"
+    },
+    "webs": [],
+    "traitWebs": [
+      "ranger"
+    ],
+    "nodes": [
+      {
+        "x": 23,
+        "y": 14,
+        "connected": [
+          "ranger-cadet"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "a1dXU7rnC3RUsbqq",
+  "img": "icons/magic/defensive/armor-green-hex.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/building-momentum.json
+++ b/packs/core-perks/building-momentum.json
@@ -14,7 +14,7 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Effect: Grants @UUID[Compendium.ptr2e.core-abilities.Item.Jxbaa5q8xBqN1veZ]{Pendulum} as a tutored ability.</p>",
+    "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.Item.Jxbaa5q8xBqN1veZ]{Pendulum} as a Tutored Ability.</p>",
     "traits": [],
     "prerequisites": [],
     "autoUnlock": [],

--- a/packs/core-perks/building-momentum.json
+++ b/packs/core-perks/building-momentum.json
@@ -1,0 +1,116 @@
+{
+  "name": "Building Momentum",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Effect: Grants @UUID[Compendium.ptr2e.core-abilities.Item.Jxbaa5q8xBqN1veZ]{Pendulum} as a tutored ability.</p>",
+    "traits": [],
+    "prerequisites": [],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 122,
+        "y": 19,
+        "connected": [
+          "mankey-see-mankey-do",
+          "freeclimber",
+          "hurried-operator"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "9dc39v2qJF1SUTme",
+  "img": "icons/magic/control/hypnosis-mesmerism-watch.webp",
+  "effects": [
+    {
+      "name": "Building Momentum",
+      "type": "passive",
+      "_id": "tgnJfAkI7gFAQJVN",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.Jxbaa5q8xBqN1veZ",
+            "phase": "initial",
+            "predicate": [
+              "item:perk:building-momentum"
+            ],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778078015495,
+        "modifiedTime": 1778078015495,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/commissar.json
+++ b/packs/core-perks/commissar.json
@@ -1,0 +1,63 @@
+{
+  "folder": "6XbjR9qPWzZw4vEd",
+  "name": "Commissar",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Passive Effect: Creatures under the user's command gain +50% Power to their damaging attacks, +25% EHR, 10% Damage Reduction and immunity to @Trait[push-x], while under the effects of @Affliction[fear].</p>",
+    "traits": [
+      "taskmaster"
+    ],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.intimidate.mod}",
+          60
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "taskmaster"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 40,
+        "y": 109,
+        "connected": [
+          "beastmaster",
+          "unreasonable",
+          "minor-buff-28",
+          "assert-dominance",
+          "conscription",
+          "job-done-right",
+          "war-drums"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "wmX0ocGG3aiRXbpf",
+  "img": "icons/equipment/head/hat-furred-white.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/conscription.json
+++ b/packs/core-perks/conscription.json
@@ -1,0 +1,144 @@
+{
+  "folder": "6XbjR9qPWzZw4vEd",
+  "name": "Conscription",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Conscription",
+        "slug": "conscription",
+        "description": "<p>Target: A hostile creature with the @Affliction[fear] affliction.</p><p><br>Effect: You inflict the target with @UUID[Compendium.ptr2e.core-effects-new.ActiveEffect.tks8Fa9ZmwYOSr4Z]{Puppet 1}.</p>",
+        "traits": [
+          "taskmaster"
+        ],
+        "type": "generic",
+        "img": "icons/sundries/flags/banner-symbol-eye-purple.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "range": {
+          "target": "creature",
+          "distance": 5,
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Target: A hostile creature with the @Affliction[fear] affliction.</p><p><br>Effect: You inflict the target with @UUID[Compendium.ptr2e.core-effects-new.ActiveEffect.tks8Fa9ZmwYOSr4Z]{Puppet 1}.</p>",
+    "traits": [
+      "taskmaster"
+    ],
+    "prerequisites": [
+      "item:perk:commissar",
+      "item:perk:show-of-force"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "taskmaster"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 44,
+        "y": 108,
+        "connected": [
+          "commissar",
+          "assert-dominance",
+          "minor-buff-7",
+          "the-quality-of-quantity"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "12l6wQTwYdBs0m0g",
+  "img": "icons/sundries/flags/banner-symbol-eye-purple.webp",
+  "effects": [
+    {
+      "name": "Conscription",
+      "type": "passive",
+      "_id": "w8joRBnXStBF4QlQ",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.tks8Fa9ZmwYOSr4Z",
+            "phase": "initial",
+            "predicate": [
+              "target:effect:fear"
+            ],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 1
+              }
+            ],
+            "dontMerge": false,
+            "key": "conscription-generic",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778078196775,
+        "modifiedTime": 1778078196775,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/defer-destiny.json
+++ b/packs/core-perks/defer-destiny.json
@@ -1,0 +1,74 @@
+{
+  "folder": "KcpEanpX82Cu6Dqh",
+  "name": "Defer Destiny",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Defer Destiny",
+        "slug": "defer-destiny",
+        "description": "<p>Effect: The user delays the targeted Summon's initiative by 30%.</p>",
+        "traits": [],
+        "type": "generic",
+        "img": "icons/magic/time/hourglass-tilted-gray.webp",
+        "cost": {
+          "activation": "simple",
+          "powerPoints": 3
+        },
+        "range": {
+          "target": "object",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Effect: The user delays the targeted Summon's initiative by 30%.</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.spiritual.mod}",
+          30
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "mental",
+      "approach": "power",
+      "archetype": "sage"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 136,
+        "y": 114,
+        "connected": [
+          "minor-buff-30",
+          "hasten-conjuration",
+          "exorcism"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "fDLPpKtxkptVjjxb",
+  "img": "icons/magic/time/hourglass-tilted-gray.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/demoralize.json
+++ b/packs/core-perks/demoralize.json
@@ -1,0 +1,132 @@
+{
+  "folder": "jLhPGZvYVjjs7D54",
+  "name": "Demoralize",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Effect: Your @Trait[social] Status attacks inflict @Tick[-1]  and @Tick[-1 pp] on their targets.</p>",
+    "traits": [
+      "agitator"
+    ],
+    "prerequisites": [
+      "trait:agitator"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "agitator"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 169,
+        "y": 138,
+        "connected": [
+          "agitator",
+          "hesitation",
+          "inconceivable"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "2NkL1uyFovyfi50f",
+  "img": "icons/skills/social/thumbs-down.webp",
+  "effects": [
+    {
+      "name": "Demoralize",
+      "type": "passive",
+      "_id": "sTT0nAQ9y6DTazwh",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+            "phase": "initial",
+            "predicate": [
+              "item:trait:social"
+            ],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "status-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.LHUTMAC0nCJWDRFt",
+            "phase": "initial",
+            "predicate": [
+              "item:trait:social"
+            ],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "status-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778077892924,
+        "modifiedTime": 1778077892924,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/equivalent-exchange.json
+++ b/packs/core-perks/equivalent-exchange.json
@@ -1,0 +1,77 @@
+{
+  "folder": "c29hnIAtXgwB7FeY",
+  "name": "Equivalent Exchange",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Equivalent Exchange",
+        "slug": "equivalent-exchange",
+        "description": "<p>The user may choose to consume an amount of their own Shields in order to restore an equal amount of HP.</p>",
+        "traits": [
+          "tank"
+        ],
+        "type": "generic",
+        "img": "icons/skills/social/trading-justice-scale-gold.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "self",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>The user may choose to consume an amount of their own Shields in order to restore an equal amount of HP.</p>",
+    "traits": [
+      "tank"
+    ],
+    "prerequisites": [
+      "item:perk:improved-shielding"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "tank"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 83,
+        "y": 107,
+        "hidden": false,
+        "type": "normal",
+        "connected": [
+          "improved-shielding",
+          "minor-buff-43"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ]
+  },
+  "_id": "srvoq0G5Olx6UUSF",
+  "img": "icons/skills/social/trading-justice-scale-gold.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/exorcism.json
+++ b/packs/core-perks/exorcism.json
@@ -18,7 +18,7 @@
       {
         "name": "Exorcism",
         "slug": "exorcism",
-        "description": "<p>Exorcism allows the user to terminate the target summon.</p>",
+        "description": "<p>Exorcism allows the user to end the target summon.</p>",
         "traits": [
           "sage",
           "summon"
@@ -55,7 +55,7 @@
         }
       }
     ],
-    "description": "<p>The user may use the @UUID[Item.eeIllJocCQpNQjQq.Actions.exorcism] and @UUID[Item.eeIllJocCQpNQjQq.Actions.exorcism-mass] actions.</p>",
+    "description": "<p>The user may use the Exorcism and Mass Exorcism actions.</p>",
     "traits": [
       "sage",
       "summon"

--- a/packs/core-perks/exorcism.json
+++ b/packs/core-perks/exorcism.json
@@ -18,7 +18,7 @@
       {
         "name": "Exorcism",
         "slug": "exorcism",
-        "description": "<p>Exorcism allows the user to end the target summon.</p>",
+        "description": "<p>Effect: The target Summon expires.</p>",
         "traits": [
           "sage",
           "summon"
@@ -37,7 +37,7 @@
       {
         "name": "Exorcism (Mass)",
         "slug": "exorcism-mass",
-        "description": "<p>Mass Exorcism reduces the duration of all summons on the field by 1.</p><p>Note: This will not function until Summons V2 is implemented.</p>",
+        "description": "<p>Effect: All active Summons have their duration reduced by 1.</p><p>Note: This will not function until Summons V2 is implemented.</p>",
         "traits": [
           "sage",
           "summon"

--- a/packs/core-perks/exorcism.json
+++ b/packs/core-perks/exorcism.json
@@ -1,0 +1,100 @@
+{
+  "folder": "KcpEanpX82Cu6Dqh",
+  "name": "Exorcism",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Exorcism",
+        "slug": "exorcism",
+        "description": "<p>Exorcism allows the user to terminate the target summon.</p>",
+        "traits": [
+          "sage",
+          "summon"
+        ],
+        "type": "generic",
+        "img": "icons/magic/holy/chalice-glowing-gold-water.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      },
+      {
+        "name": "Exorcism (Mass)",
+        "slug": "exorcism-mass",
+        "description": "<p>Mass Exorcism reduces the duration of all summons on the field by 1.</p><p>Note: This will not function until Summons V2 is implemented.</p>",
+        "traits": [
+          "sage",
+          "summon"
+        ],
+        "type": "generic",
+        "img": "icons/magic/holy/chalice-glowing-gold-water.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 6
+        },
+        "variant": "exorcism",
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>The user may use the @UUID[Item.eeIllJocCQpNQjQq.Actions.exorcism] and @UUID[Item.eeIllJocCQpNQjQq.Actions.exorcism-mass] actions.</p>",
+    "traits": [
+      "sage",
+      "summon"
+    ],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.thaumaturgy.mod}",
+          65
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "mental",
+      "approach": "power",
+      "archetype": "sage"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 130,
+        "y": 112,
+        "connected": [
+          "minor-buff-30",
+          "defer-destiny",
+          "screen-setter"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "eeIllJocCQpNQjQq",
+  "img": "icons/magic/holy/chalice-glowing-gold-water.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/exorcist-style.json
+++ b/packs/core-perks/exorcist-style.json
@@ -1,0 +1,54 @@
+{
+  "folder": "F4b52L00KrAtdPu5",
+  "name": "Exorcist Style",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Effect: The affected @Trait[psychic]-type creature's @Trait[psychic] attacks gain @Trait[ignore-type-immunity].</p><p><br>@Trait[psychic] attacks made while under the influence of this Style inflict @Tick[-1] HP on the user.</p>",
+    "traits": [
+      "style",
+      "command",
+      "psychic"
+    ],
+    "prerequisites": [
+      "item:perk:type-specialist"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "mental",
+      "approach": "power",
+      "archetype": "psychic"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 196,
+        "y": 98,
+        "connected": [
+          "type-specialist"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "MDl1e5zZHCO7eFJU",
+  "img": "icons/magic/perception/shadow-stealth-eyes-purple.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/exorcist-style.json
+++ b/packs/core-perks/exorcist-style.json
@@ -15,7 +15,7 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Effect: The affected @Trait[psychic]-type creature's @Trait[psychic] attacks gain @Trait[ignore-type-immunity].</p><p><br>@Trait[psychic] attacks made while under the influence of this Style inflict @Tick[-1] HP on the user.</p>",
+    "description": "<p>Effect: The affected @Trait[psychic]-type creature's @Trait[psychic] Attacks gain @Trait[ignore-type-immunity] and cause the creature to lose @Tick[-1].</p>",
     "traits": [
       "style",
       "command",

--- a/packs/core-perks/hive-needle.json
+++ b/packs/core-perks/hive-needle.json
@@ -1,0 +1,131 @@
+{
+  "folder": "o5iIUG4Bj40M86yi",
+  "name": "Hive Needle",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>You may add the @Trait[bug] typing to your @Trait[weapon] attacks, in addition to their normal typing.</p>",
+    "traits": [
+      "bug",
+      "weapon"
+    ],
+    "prerequisites": [
+      "trait:bug",
+      "trait:wielder"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "bug"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 93,
+        "y": 23,
+        "connected": [
+          "minor-buff-24",
+          "all-seasonal",
+          "ocular-evolution"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "CtIDRBJKnEtrAFB9",
+  "img": "icons/weapons/polearms/spear-simple-hooked.webp",
+  "effects": [
+    {
+      "name": "Hive Needle",
+      "type": "passive",
+      "_id": "XN54WN38rbKBfGNc",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "hive-needle",
+            "predicate": [],
+            "domain": "all",
+            "label": "Hive Needle",
+            "toggleable": true,
+            "count": false,
+            "state": true,
+            "alwaysActive": false,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "alter-attack",
+            "key": "weapon-trait-attack",
+            "value": "bug",
+            "predicate": [
+              "hive-needle"
+            ],
+            "property": "type",
+            "definition": [],
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778078261464,
+        "modifiedTime": 1778078261464,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/idol.json
+++ b/packs/core-perks/idol.json
@@ -15,7 +15,7 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>You gain the @UUID[Compendium.ptr2e.core-abilities.Item.B11xHNehbKeFoCs2]{Cute Charm} ability as a tutored ability.</p>",
+    "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.Item.B11xHNehbKeFoCs2]{Cute Charm} as a Tutored Ability.</p>",
     "traits": [],
     "prerequisites": [
       "item:perk:beauty"

--- a/packs/core-perks/idol.json
+++ b/packs/core-perks/idol.json
@@ -1,0 +1,121 @@
+{
+  "folder": "jLhPGZvYVjjs7D54",
+  "name": "Idol",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>You gain the @UUID[Compendium.ptr2e.core-abilities.Item.B11xHNehbKeFoCs2]{Cute Charm} ability as a tutored ability.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:beauty"
+    ],
+    "autoUnlock": [
+      "item:ability:cute-charm"
+    ],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "resilience",
+      "archetype": "agitator"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 168,
+        "y": 151,
+        "connected": [
+          "beauty",
+          "break-up-song",
+          "not-the-face"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "TqNd3QBCjF0bbfrt",
+  "img": "systems/ptr2e/img/perk-icons/Socialite.svg",
+  "effects": [
+    {
+      "name": "Idol",
+      "type": "passive",
+      "_id": "f4M6UDDGraJ5gl3W",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.B11xHNehbKeFoCs2",
+            "phase": "initial",
+            "predicate": [
+              "item:perk:idol"
+            ],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778077911789,
+        "modifiedTime": 1778077911789,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/inconceivable.json
+++ b/packs/core-perks/inconceivable.json
@@ -15,7 +15,7 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Effect: Your @Trait[social] moves have a 30% chance to inflict -1 Evasion Stage.</p>",
+    "description": "<p>Effect: The user's @Trait[social] Attacks have a 30% chance to inflict -1 EVA Stage for 5 Activations on hit.</p>",
     "traits": [
       "agitator"
     ],

--- a/packs/core-perks/inconceivable.json
+++ b/packs/core-perks/inconceivable.json
@@ -1,0 +1,115 @@
+{
+  "folder": "jLhPGZvYVjjs7D54",
+  "name": "Inconceivable",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Effect: Your @Trait[social] moves have a 30% chance to inflict -1 Evasion Stage.</p>",
+    "traits": [
+      "agitator"
+    ],
+    "prerequisites": [
+      "item:perk:demoralize"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "finesse",
+      "archetype": "agitator"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 175,
+        "y": 140,
+        "connected": [
+          "demoralize",
+          "agitator",
+          "minor-buff-1",
+          "one-of-the-classic-blunders"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "OdRqXF48KUYYvxe8",
+  "img": "icons/svg/blind.svg",
+  "effects": [
+    {
+      "name": "Inconceivable",
+      "type": "passive",
+      "_id": "4dnZCa9uBMiJDmUA",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.hIE6W3Y5E9CyHiTy",
+            "phase": "initial",
+            "predicate": [],
+            "key": "social-trait-attack",
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778077917316,
+        "modifiedTime": 1778077917316,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/insidious-style.json
+++ b/packs/core-perks/insidious-style.json
@@ -1,0 +1,81 @@
+{
+  "folder": "JZrGRskscJOkkPWA",
+  "name": "Insidious Style",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Insidious Style",
+        "slug": "insidious-style",
+        "description": "<p>Effect: Grants the affected creature 30% EHR, but they also suffer @Affliction[delay 20].</p>",
+        "traits": [
+          "command",
+          "style"
+        ],
+        "type": "generic",
+        "img": "icons/skills/toxins/poison-bottle-corked-fire-green.webp",
+        "cost": {
+          "activation": "simple",
+          "powerPoints": 2
+        },
+        "range": {
+          "target": "ally",
+          "distance": 20,
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Effect: Grants the affected creature 30% EHR, but they also suffer @Affliction[delay 20].</p>",
+    "traits": [
+      "command",
+      "style"
+    ],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.leadership.mod}",
+          25
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 1,
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "support"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 122,
+        "y": 123,
+        "connected": [
+          "type-style",
+          "rapid-fire-style",
+          "minor-buff-48"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "jdbskUc5XoD3vvlj",
+  "img": "icons/skills/toxins/poison-bottle-corked-fire-green.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/insidious-style.json
+++ b/packs/core-perks/insidious-style.json
@@ -18,7 +18,7 @@
       {
         "name": "Insidious Style",
         "slug": "insidious-style",
-        "description": "<p>Effect: Grants the affected creature 30% EHR, but they also suffer @Affliction[delay 20].</p>",
+         "description": "<p>Effect: Grants the affected creature 30% EHR, and has its Initiative delayed by 20% after its Activation.</p>",
         "traits": [
           "command",
           "style"

--- a/packs/core-perks/job-done-right.json
+++ b/packs/core-perks/job-done-right.json
@@ -15,7 +15,7 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.Item.OsJJxiRsE1WcZtV2]{Supreme Overlord} as a tutored ability.</p>",
+    "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.Item.OsJJxiRsE1WcZtV2]{Supreme Overlord} as a Tutored Ability.</p>",
     "traits": [
       "taskmaster"
     ],

--- a/packs/core-perks/job-done-right.json
+++ b/packs/core-perks/job-done-right.json
@@ -1,0 +1,121 @@
+{
+  "folder": "6XbjR9qPWzZw4vEd",
+  "name": "Job Done Right",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Effect: The user gains @UUID[Compendium.ptr2e.core-abilities.Item.OsJJxiRsE1WcZtV2]{Supreme Overlord} as a tutored ability.</p>",
+    "traits": [
+      "taskmaster"
+    ],
+    "prerequisites": [
+      "item:perk:commissar"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "taskmaster"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 46,
+        "y": 114,
+        "connected": [
+          "commissar",
+          "harsh-motivator",
+          "lethal-restraint"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "L9x0zcP1Qg9JY7bK",
+  "img": "icons/creatures/unholy/demons-horned-glowing-pink.webp",
+  "effects": [
+    {
+      "name": "Job Done Right",
+      "type": "passive",
+      "_id": "ATyuhRj2Lp0zQ5DG",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-abilities.Item.OsJJxiRsE1WcZtV2",
+            "phase": "initial",
+            "predicate": [
+              "item:perk:job-done-right"
+            ],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778078214205,
+        "modifiedTime": 1778078214205,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/micromanagement.json
+++ b/packs/core-perks/micromanagement.json
@@ -1,0 +1,54 @@
+{
+  "folder": "PAZ8zWUPw7Azm5V6",
+  "name": "Micromanagement",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>You may use Metamove: Target Split when using non-attack [Command] actions like Styles.</p>",
+    "traits": [
+      "tactician"
+    ],
+    "prerequisites": [
+      "item:perk:metamove-target-split"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "support"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 25,
+        "y": 55,
+        "connected": [
+          "tactician",
+          "mobilize",
+          "your-targets-right-here"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "xoVnT45zrOKbwXNG",
+  "img": "systems/ptr2e/img/perk-icons/Orders_Training.svg",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/micromanagement.json
+++ b/packs/core-perks/micromanagement.json
@@ -15,7 +15,7 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>You may use Metamove: Target Split when using non-attack [Command] actions like Styles.</p>",
+    "description": "<p>Effect: The user may apply Metamove: Target Split to their @Trait[command] Generic Actions.</p>",,
     "traits": [
       "tactician"
     ],

--- a/packs/core-perks/micromanagement.json
+++ b/packs/core-perks/micromanagement.json
@@ -15,7 +15,7 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Effect: The user may apply Metamove: Target Split to their @Trait[command] Generic Actions.</p>",,
+    "description": "<p>Effect: The user may apply Metamove: Target Split to their @Trait[command] Generic Actions.</p>",
     "traits": [
       "tactician"
     ],

--- a/packs/core-perks/mindbreak.json
+++ b/packs/core-perks/mindbreak.json
@@ -1,0 +1,57 @@
+{
+  "folder": "F4b52L00KrAtdPu5",
+  "name": "Mindbreak",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Effect: You inflict the Mindbroken state on the target. Whenever they would gain a @Trait[stage-change] effect, they suffer @Tick[-1] and @Tick[-1 pp].</p><p>Mindbroken can be cured by using a Soothe Bell.</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.psychic.mod}",
+          60
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "mental",
+      "approach": "power",
+      "archetype": "psychic"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 132,
+        "y": 122,
+        "connected": [
+          "master-mindscanner",
+          "wild-surge",
+          "hasten-conjuration"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "YhytfJUtxw9BUQeb",
+  "img": "icons/magic/control/fear-fright-white.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/mourning-blade.json
+++ b/packs/core-perks/mourning-blade.json
@@ -1,0 +1,138 @@
+{
+  "folder": "a1w2zpzavg6qtJFn",
+  "name": "Mourning Blade",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Mourning Blade",
+        "slug": "mourning-blade",
+        "description": "<p>Effect: The user establishes a Mourning Blade Clock with 6 Spans. Each time the user inflicts a hostile target with an affliction, tick the Mourning Blade clock by 1.</p><p>When the Mourning Blade clock is full, the user may unleash the Mourning Blade attack.</p>",
+        "traits": [
+          "sharp",
+          "pierce"
+        ],
+        "type": "attack",
+        "img": "icons/skills/melee/strike-blade-scimitar-green-purple.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 5
+        },
+        "range": {
+          "target": "cone",
+          "distance": 5,
+          "unit": "m"
+        },
+        "types": [
+          "electric"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 180,
+        "accuracy": 100
+      }
+    ],
+    "description": "<p>Effect: The user establishes a Mourning Blade Clock with 6 Spans. Each time the user inflicts a hostile target with an affliction, tick the Mourning Blade clock by 1.</p><p>When the Mourning Blade clock is full, the user may unleash the Mourning Blade attack. Activating the clock results in the emptying of the clock.</p><p>The Mourning Blade clock resets at the end of every combat.</p>",
+    "traits": [],
+    "prerequisites": [],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "affliction"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 144,
+        "y": 66,
+        "connected": [
+          "sadism",
+          "suspicious-minds",
+          "logicians-wisdom"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "1HFMztrB9CHfItny",
+  "img": "icons/skills/melee/strike-blade-scimitar-green-purple.webp",
+  "effects": [
+    {
+      "name": "Mourning Blade",
+      "type": "passive",
+      "_id": "B1Vl0I7xRvh6Yehy",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "create-clock",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [],
+            "key": "ski6UBjdlfm7BCaC",
+            "max": 9,
+            "private": false,
+            "label": "Mourning Blade",
+            "color": "#ffff00",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778077579906,
+        "modifiedTime": 1778077579906,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/mourning-blade.json
+++ b/packs/core-perks/mourning-blade.json
@@ -44,7 +44,7 @@
         "accuracy": 100
       }
     ],
-    "description": "<p>Effect: The user establishes a Mourning Blade Clock with 6 Spans. Each time the user inflicts a hostile target with an affliction, tick the Mourning Blade clock by 1.</p><p>When the Mourning Blade clock is full, the user may unleash the Mourning Blade attack. Activating the clock results in the emptying of the clock.</p><p>The Mourning Blade clock resets at the end of every combat.</p>",
+    "description": "<p>Effect: The user maintains a Mourning Blade Clock, with a Size of 6 Spans. When the user inflicts a creature with a @Trait[major-affliction] or @Trait[minor-affliction], the Clock is incremented by +1.</p><p>When the Mourning Blade clock is full, the user may use Mourning Blade.</p><p>The Mourning Blade Clock is emptied when the user resolves Mourning Blade and at the end of combat.</p>",
     "traits": [],
     "prerequisites": [],
     "autoUnlock": [],

--- a/packs/core-perks/one-of-the-classic-blunders.json
+++ b/packs/core-perks/one-of-the-classic-blunders.json
@@ -18,15 +18,15 @@
       {
         "name": "One of the Classic Blunders",
         "slug": "one-of-the-classic-blunders",
-        "description": "<p>Trigger: An enemy misses you with an attack.</p><p>Effect: You may use a [Social] status move against the target who missed you. This attack is considered a Free Action @Trait[interrupt].</p>",
+        "description": "<p>Trigger: An Attack misses the user.</p><p>Effect: The user uses a @Trait[social] Status-Category Attack as a Free Action against the triggering creature.</p>",
         "traits": [
-          "agitator"
+          "interrupt"
         ],
         "type": "generic",
         "img": "systems/ptr2e/img/item-icons/sunglasses.webp",
         "cost": {
           "activation": "free",
-          "powerPoints": 3
+          "powerPoints": 2
         },
         "range": {
           "target": "self",
@@ -34,7 +34,7 @@
         }
       }
     ],
-    "description": "<p>Trigger: An enemy misses you with an attack.</p><p>Effect: You may use a [Social] status move against the target who missed you. This attack is considered a Free Action @Trait[interrupt].</p>",
+    "description": "<p>Effect: When an Attack misses the user, they may spend @PP[-2] as a Free Action @Trait[interrupt] to use a @Trait[social] Status-Category Attack as a Free Action against the source of the Attack.</p>",
     "traits": [
       "agitator"
     ],

--- a/packs/core-perks/one-of-the-classic-blunders.json
+++ b/packs/core-perks/one-of-the-classic-blunders.json
@@ -1,0 +1,73 @@
+{
+  "folder": "jLhPGZvYVjjs7D54",
+  "name": "One of the Classic Blunders",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "One of the Classic Blunders",
+        "slug": "one-of-the-classic-blunders",
+        "description": "<p>Trigger: An enemy misses you with an attack.</p><p>Effect: You may use a [Social] status move against the target who missed you. This attack is considered a Free Action @Trait[interrupt].</p>",
+        "traits": [
+          "agitator"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/item-icons/sunglasses.webp",
+        "cost": {
+          "activation": "free",
+          "powerPoints": 3
+        },
+        "range": {
+          "target": "self",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Trigger: An enemy misses you with an attack.</p><p>Effect: You may use a [Social] status move against the target who missed you. This attack is considered a Free Action @Trait[interrupt].</p>",
+    "traits": [
+      "agitator"
+    ],
+    "prerequisites": [
+      "trait:agitator"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "resilience",
+      "archetype": "agitator"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 172,
+        "y": 147,
+        "connected": [
+          "condemn",
+          "agitator",
+          "inconceivable"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "WGzVbhlOGNloKCJT",
+  "img": "systems/ptr2e/img/item-icons/sunglasses.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/overwatch.json
+++ b/packs/core-perks/overwatch.json
@@ -16,7 +16,7 @@
     },
     "actions": [
       {
-        "name": "Overwatch Action",
+        "name": "Overwatch",
         "slug": "overwatch",
         "description": "<p>Set a fixed 30 degree Overwatch cone with a range equal to the range increment of your chosen ranged weapon attack. Until your next activation, make a free action @Trait[interrupt] attack using your ranged weapon against anyone who moves through the overwatch area.</p>",
         "traits": [],

--- a/packs/core-perks/overwatch.json
+++ b/packs/core-perks/overwatch.json
@@ -1,0 +1,69 @@
+{
+  "folder": "VCEaYPpKcCqDx7yx",
+  "name": "Overwatch",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Overwatch Action",
+        "slug": "overwatch",
+        "description": "<p>Set a fixed 30 degree Overwatch cone with a range equal to the range increment of your chosen ranged weapon attack. Until your next activation, make a free action @Trait[interrupt] attack using your ranged weapon against anyone who moves through the overwatch area.</p>",
+        "traits": [],
+        "type": "generic",
+        "img": "icons/weapons/guns/rifle-sniper-tripod.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "range": {
+          "target": "cone",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Set a fixed 30 degree Overwatch cone with a range equal to the range increment of your chosen ranged weapon attack. Until your next activation, make a free action @Trait[interrupt] attack using your ranged weapon against anyone who moves through the overwatch area.</p>",
+    "traits": [],
+    "prerequisites": [
+      "trait:wielder"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "weapon"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 193,
+        "y": 69,
+        "connected": [
+          "harry",
+          "down-the-sights",
+          "defense-in-depth"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "qiLw7r7NbrcK8Upg",
+  "img": "icons/weapons/guns/rifle-sniper-tripod.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/pack-hunger.json
+++ b/packs/core-perks/pack-hunger.json
@@ -1,0 +1,109 @@
+{
+  "folder": "UZGN1glVNXLieg48",
+  "name": "Pack Hunger",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Passive: When the user applies @Affliction[marked] to an enemy, that enemy suffers from @Affliction[hindered] and @Affliction[unlucky] while marked.</p>",
+    "traits": [],
+    "prerequisites": [
+      "trait:pack-leader"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "pack-mon"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 143,
+        "y": 177,
+        "connected": [
+          "packmarked",
+          "wound-spring",
+          "dance-partner",
+          "skysplitter",
+          "vampire-field"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "5iIegRjf8eh42ITA",
+  "img": "icons/creatures/abilities/wolf-howl-moon-purple.webp",
+  "effects": [
+    {
+      "name": "Pack Hunger",
+      "type": "passive",
+      "_id": "KosgG0STFKnDAc3B",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "",
+            "value": 0,
+            "method": 2,
+            "phase": "initial",
+            "predicate": [],
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778077806872,
+        "modifiedTime": 1778077806872,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/pokerface.json
+++ b/packs/core-perks/pokerface.json
@@ -1,0 +1,53 @@
+{
+  "folder": "E5JYWji5073kTXhD",
+  "name": "Pokerface",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Effect: When the user plays a card from their Metronome Hand, the resulting move gains +20% Power if it is a damaging move, or @Affliction[advance 10] if it is a status move.</p>",
+    "traits": [
+      "gambler"
+    ],
+    "prerequisites": [
+      "item:move:metronome"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "gambler"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 93,
+        "y": 192,
+        "connected": [
+          "ace-up-my-sleeve",
+          "mulligan"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "DaXBhh4qES9IYGAr",
+  "img": "icons/sundries/gaming/playing-cards-grey.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/pokerface.json
+++ b/packs/core-perks/pokerface.json
@@ -15,7 +15,7 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Effect: When the user plays a card from their Metronome Hand, the resulting move gains +20% Power if it is a damaging move, or @Affliction[advance 10] if it is a status move.</p>",
+    "description": "<p>Effect: When the played from the user's Metronome Hand, Physical- and Special-Category Attacks have +20% Power and Status-Category Attacks cause the user to gain @Affliction[advance 10].</p>",
     "traits": [
       "gambler"
     ],

--- a/packs/core-perks/ranger-cadet.json
+++ b/packs/core-perks/ranger-cadet.json
@@ -1,0 +1,114 @@
+{
+  "name": "Ranger Cadet",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>You gain access to the @Trait[ranger] perk web.</p>",
+    "traits": [
+      "ranger"
+    ],
+    "prerequisites": [
+      "trait:humanoid"
+    ],
+    "autoUnlock": [
+      "trait:ranger"
+    ],
+    "design": {
+      "arena": "social",
+      "approach": "resilience",
+      "archetype": "ranger"
+    },
+    "webs": [],
+    "traitWebs": [
+      "ranger"
+    ],
+    "nodes": [
+      {
+        "x": 15,
+        "y": 15,
+        "hidden": false,
+        "type": "root",
+        "connected": [
+          "bondmate"
+        ],
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
+        "tier": null
+      }
+    ]
+  },
+  "_id": "yuWsy4KLWa9Px1PB",
+  "img": "systems/ptr2e/img/perk-icons/Trainer.svg",
+  "effects": [
+    {
+      "name": "Ranger Cadet",
+      "type": "passive",
+      "_id": "5QWTd4uIIXukUazc",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "value": "ranger",
+            "phase": "initial",
+            "predicate": [],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778075738867,
+        "modifiedTime": 1778075738867,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/right-hand-mon.json
+++ b/packs/core-perks/right-hand-mon.json
@@ -1,0 +1,137 @@
+{
+  "folder": "PAZ8zWUPw7Azm5V6",
+  "name": "Right Hand Mon",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Right Hand Mon",
+        "slug": "right-hand-mon",
+        "description": "<p>Trigger: The user's Muse clock is emptied.</p><p>Effect: The user may, as a @Trait[interrupt] action, advance an ally's next activation by 100%.</p>",
+        "traits": [],
+        "type": "generic",
+        "img": "icons/svg/tower.svg",
+        "cost": {
+          "activation": "free",
+          "powerPoints": 5
+        },
+        "range": {
+          "target": "creature",
+          "distance": 5,
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Trigger: The user's Muse clock is emptied.</p><p>Effect: The user may, as a @Trait[interrupt] action, advance an ally's next activation by 100%.</p>",
+    "traits": [],
+    "prerequisites": [
+      "item:perk:tactician",
+      "item:perk:muse"
+    ],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "tactician"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 145,
+        "y": 166,
+        "connected": [
+          "dance-partner",
+          "muse",
+          "minor-buff-15"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "0lN4f4vi2j5UGx72",
+  "img": "icons/svg/tower.svg",
+  "effects": [
+    {
+      "name": "Right Hand Mon",
+      "type": "passive",
+      "_id": "3CU8NSlGr2XhGfLe",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advancecondition",
+            "phase": "initial",
+            "predicate": [],
+            "key": "right-hand-mon-generic",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 100
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778078004025,
+        "modifiedTime": 1778078004025,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/right-hand-mon.json
+++ b/packs/core-perks/right-hand-mon.json
@@ -18,7 +18,7 @@
       {
         "name": "Right Hand Mon",
         "slug": "right-hand-mon",
-        "description": "<p>Trigger: The user's Muse clock is emptied.</p><p>Effect: The user may, as a @Trait[interrupt] action, advance an ally's next activation by 100%.</p>",
+        "description": "<p>Trigger: The user's Muse clock is emptied.</p><p>Effect: The target creature gains @Affliction[advance 100].</p>",
         "traits": [],
         "type": "generic",
         "img": "icons/svg/tower.svg",
@@ -27,13 +27,13 @@
           "powerPoints": 5
         },
         "range": {
-          "target": "creature",
+          "target": "ally",
           "distance": 5,
           "unit": "m"
         }
       }
     ],
-    "description": "<p>Trigger: The user's Muse clock is emptied.</p><p>Effect: The user may, as a @Trait[interrupt] action, advance an ally's next activation by 100%.</p>",
+    "description": "<p>Effect: When the user empties their Muse Clock, they may spend @PP[-5] as a Free Action @Trait[interrupt] to grant an Ally within 5m @Affliction[advance 100].</p>",
     "traits": [],
     "prerequisites": [
       "item:perk:tactician",

--- a/packs/core-perks/seers-sacrifice.json
+++ b/packs/core-perks/seers-sacrifice.json
@@ -1,0 +1,120 @@
+{
+  "folder": "F4b52L00KrAtdPu5",
+  "name": "Seer's Sacrifice",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>Connection: @UUID[Compendium.ptr2e.core-moves.Item.GFHmsvlYP7sgp7em]{Ally Switch}</p><p><br>Effect: The user is able to use Ally Switch as a Free Action @Trait[interrupt].</p>",
+    "traits": [
+      "psychic"
+    ],
+    "prerequisites": [
+      "trait:psychic"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "psychic"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 147,
+        "y": 148,
+        "connected": [
+          "fractalised-contingency",
+          "minor-buff-2"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "kXUCBGC1twd0BH47",
+  "img": "icons/skills/movement/portal-silhouette-pink.webp",
+  "effects": [
+    {
+      "name": "Seer's Sacrifice",
+      "type": "passive",
+      "_id": "OAD0wZY6HbRvrclm",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-moves.Item.GFHmsvlYP7sgp7em",
+            "phase": "initial",
+            "predicate": [
+              "item:perk:seers-sacrifice"
+            ],
+            "alterations": [],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "allowDuplicate": false,
+            "reevaluateOnUpdate": true,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "inMemoryOnly": false,
+            "track": false,
+            "replaceSelf": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778078286606,
+        "modifiedTime": 1778078286606,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/show-of-force.json
+++ b/packs/core-perks/show-of-force.json
@@ -1,0 +1,146 @@
+{
+  "folder": "6XbjR9qPWzZw4vEd",
+  "name": "Show of Force",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Show of Force",
+        "slug": "show-of-force",
+        "description": "<p>Effect: The user may declare a Show of Force, inflicting @Affliction[fear 5] on creatures within a 3m Emanation. This is considered a @Trait[social] attack.</p>",
+        "traits": [
+          "taskmaster"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/perk-icons/Taskmaster.svg",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "range": {
+          "target": "emanation",
+          "distance": 3,
+          "unit": "m"
+        },
+        "types": [
+          "dark"
+        ],
+        "category": "status",
+        "predicate": [],
+        "accuracy": 100
+      }
+    ],
+    "description": "<p>Effect: The user may declare a Show of Force, inflicting @Affliction[fear 5] on creatures within a 3m Emanation. This is considered a @Trait[social] Status attack.</p>",
+    "traits": [
+      "taskmaster",
+      "social"
+    ],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.intimidate.mod}",
+          55
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "taskmaster"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 31,
+        "y": 114,
+        "connected": [
+          "driven",
+          "masters-whip",
+          "minor-buff-11"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "ZRRpx7WpVOg8XuJF",
+  "img": "systems/ptr2e/img/perk-icons/Taskmaster.svg",
+  "effects": [
+    {
+      "name": "Show of Force",
+      "type": "passive",
+      "_id": "UH5vr0aZJAnhV7Sf",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.fearcondition000",
+            "phase": "initial",
+            "predicate": [],
+            "key": "show-of-force-attack",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778078228690,
+        "modifiedTime": 1778078228690,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/show-of-force.json
+++ b/packs/core-perks/show-of-force.json
@@ -18,9 +18,10 @@
       {
         "name": "Show of Force",
         "slug": "show-of-force",
-        "description": "<p>Effect: The user may declare a Show of Force, inflicting @Affliction[fear 5] on creatures within a 3m Emanation. This is considered a @Trait[social] attack.</p>",
+        "description": "<p>Effect: All valid targets gain @Affliction[fear 5].</p>",
         "traits": [
-          "taskmaster"
+          "social",
+          "drill"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/perk-icons/Taskmaster.svg",

--- a/packs/core-perks/siren-song.json
+++ b/packs/core-perks/siren-song.json
@@ -18,7 +18,7 @@
       {
         "name": "Siren Song",
         "slug": "siren-song",
-        "description": "<p>Effect: The user gains the Siren Song attack, allowing them a 50% to inflict enemies with @UUID[Compendium.ptr2e.core-effects.Item.tks8Fa9ZmwYOSr4Z]{Puppet 1}.</p>",
+        "description": "<p>Effect: On hit, the target has a 50% to gain @UUID[Compendium.ptr2e.core-effects.Item.tks8Fa9ZmwYOSr4Z]{Puppet 1}.</p>",
         "traits": [
           "sonic",
           "social"
@@ -43,7 +43,7 @@
         "accuracy": 100
       }
     ],
-    "description": "<p>Effect: The user gains the Siren Song attack, allowing them a 50% to inflict enemies with @UUID[Compendium.ptr2e.core-effects.Item.tks8Fa9ZmwYOSr4Z]{Puppet 1}.</p>",
+    "description": "<p>Effect: The user gains the Attack Siren Song.</p>",
     "traits": [],
     "prerequisites": [
       {

--- a/packs/core-perks/siren-song.json
+++ b/packs/core-perks/siren-song.json
@@ -1,0 +1,144 @@
+{
+  "folder": "lzLExT1c5IqNcbnB",
+  "name": "Siren Song",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Siren Song",
+        "slug": "siren-song",
+        "description": "<p>Effect: The user gains the Siren Song attack, allowing them a 50% to inflict enemies with @UUID[Compendium.ptr2e.core-effects.Item.tks8Fa9ZmwYOSr4Z]{Puppet 1}.</p>",
+        "traits": [
+          "sonic",
+          "social"
+        ],
+        "type": "attack",
+        "img": "icons/magic/control/hypnosis-mesmerism-swirl.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 4
+        },
+        "range": {
+          "target": "creature",
+          "distance": 5,
+          "unit": "m"
+        },
+        "types": [
+          "normal"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": [],
+        "accuracy": 100
+      }
+    ],
+    "description": "<p>Effect: The user gains the Siren Song attack, allowing them a 50% to inflict enemies with @UUID[Compendium.ptr2e.core-effects.Item.tks8Fa9ZmwYOSr4Z]{Puppet 1}.</p>",
+    "traits": [],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.singing.mod}",
+          60
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "musician"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 179,
+        "y": 167,
+        "connected": [
+          "cover-artist",
+          "guerilla-radio"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "HKpdD0gKEEIjQyN1",
+  "img": "icons/magic/control/hypnosis-mesmerism-swirl.webp",
+  "effects": [
+    {
+      "name": "Siren Song",
+      "type": "passive",
+      "_id": "kp5s9J85hcyiYU5P",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.tks8Fa9ZmwYOSr4Z",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 50,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "siren-song-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778077957154,
+        "modifiedTime": 1778077957154,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/skysplitter.json
+++ b/packs/core-perks/skysplitter.json
@@ -18,7 +18,7 @@
       {
         "name": "Skysplitter (Vulnerable)",
         "slug": "skysplitter-vulnerable",
-        "description": "<p>Effect: The user maintains a Skysplitter clock of 12 spans. Each time the user or a member of their pack attacks an enemy target, they may tick the Skysplitter clock.</p><p>Once the Skysplitter clock is full, the user may, as a complex action, empty it to inflict @UUID[Compendium.ptr2e.core-effects.Item.o814z13dfeo0AqBW]{Vulnerable (Flying)} to a chosen target followed immediately by the Skysplitter Strike attack. After using Skysplitter Strike, or at the end of a given combat, the Skysplitter Clock resets to empty.</p><p>Skysplitter Strike uses Speed as the attacking stat.</p>",
+        "description": "<p>Effect: The target gains @UUID[Compendium.ptr2e.core-effects.Item.o814z13dfeo0AqBW]{Vulnerable (Flying)}.</p>",
         "traits": [],
         "type": "generic",
         "img": "icons/skills/melee/sword-winged-holy-orange.webp",
@@ -35,10 +35,11 @@
       {
         "name": "Skysplitter Strike",
         "slug": "skysplitter-strike",
-        "description": "<p>Effect: The user maintains a Skysplitter clock of 12 spans. Each time the user or a member of their pack attacks an enemy target, they may tick the Skysplitter clock.</p><p>Once the Skysplitter clock is full, the user may, as a complex action, empty it to inflict @UUID[Compendium.ptr2e.core-effects.Item.o814z13dfeo0AqBW]{Vulnerable (Flying)} to a chosen target followed immediately by the Skysplitter Strike attack. After using Skysplitter Strike, or at the end of a given combat, the Skysplitter Clock resets to empty.</p><p>Skysplitter Strike uses Speed as the attacking stat.</p>",
+        "description": "<p>Trigger: The user resolved Skysplitter (Vulnerable).</p>",
         "traits": [
           "sharp",
           "pierce",
+          "interrupt",
           "contact"
         ],
         "type": "attack",

--- a/packs/core-perks/skysplitter.json
+++ b/packs/core-perks/skysplitter.json
@@ -1,0 +1,174 @@
+{
+  "folder": "UZGN1glVNXLieg48",
+  "name": "Skysplitter",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Skysplitter (Vulnerable)",
+        "slug": "skysplitter-vulnerable",
+        "description": "<p>Effect: The user maintains a Skysplitter clock of 12 spans. Each time the user or a member of their pack attacks an enemy target, they may tick the Skysplitter clock.</p><p>Once the Skysplitter clock is full, the user may, as a complex action, empty it to inflict @UUID[Compendium.ptr2e.core-effects.Item.o814z13dfeo0AqBW]{Vulnerable (Flying)} to a chosen target followed immediately by the Skysplitter Strike attack. After using Skysplitter Strike, or at the end of a given combat, the Skysplitter Clock resets to empty.</p><p>Skysplitter Strike uses Speed as the attacking stat.</p>",
+        "traits": [],
+        "type": "generic",
+        "img": "icons/skills/melee/sword-winged-holy-orange.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 2
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        }
+      },
+      {
+        "name": "Skysplitter Strike",
+        "slug": "skysplitter-strike",
+        "description": "<p>Effect: The user maintains a Skysplitter clock of 12 spans. Each time the user or a member of their pack attacks an enemy target, they may tick the Skysplitter clock.</p><p>Once the Skysplitter clock is full, the user may, as a complex action, empty it to inflict @UUID[Compendium.ptr2e.core-effects.Item.o814z13dfeo0AqBW]{Vulnerable (Flying)} to a chosen target followed immediately by the Skysplitter Strike attack. After using Skysplitter Strike, or at the end of a given combat, the Skysplitter Clock resets to empty.</p><p>Skysplitter Strike uses Speed as the attacking stat.</p>",
+        "traits": [
+          "sharp",
+          "pierce",
+          "contact"
+        ],
+        "type": "attack",
+        "img": "icons/skills/melee/sword-winged-holy-orange.webp",
+        "cost": {
+          "activation": "free",
+          "powerPoints": 5
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "flying"
+        ],
+        "category": "physical",
+        "free": true,
+        "offensiveStat": "spe",
+        "predicate": [],
+        "power": 160,
+        "accuracy": 100
+      }
+    ],
+    "description": "<p>Effect: The user maintains a Skysplitter clock of 12 spans. Each time the user or a member of their pack attacks an enemy target, they may tick the Skysplitter clock.</p><p>Once the Skysplitter clock is full, the user may, as a complex action, empty it to inflict @UUID[Compendium.ptr2e.core-effects.Item.o814z13dfeo0AqBW]{Vulnerable (Flying)} to a chosen target followed immediately by the Skysplitter Strike attack. After using Skysplitter Strike, or at the end of a given combat, the Skysplitter Clock resets to empty.</p><p>Skysplitter Strike uses Speed as the attacking stat.</p>",
+    "traits": [
+      "pack-mon"
+    ],
+    "prerequisites": [
+      "trait:pack-leader"
+    ],
+    "autoUnlock": [],
+    "cost": 5,
+    "design": {
+      "arena": "physical",
+      "approach": "power",
+      "archetype": "pack-mon"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 150,
+        "y": 184,
+        "connected": [
+          "synchronised-takedown",
+          "pack-hunger"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "kuYUv0iERAPEK9Hq",
+  "img": "icons/skills/melee/sword-winged-holy-orange.webp",
+  "effects": [
+    {
+      "name": "Skysplitter",
+      "type": "passive",
+      "_id": "jJQOmPhw1AR0xg1W",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.o814z13dfeo0AqBW",
+            "phase": "initial",
+            "predicate": [],
+            "key": "skysplitter-vulnerable-generic",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "create-clock",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [],
+            "key": "QQaLblSfTpjpswvY",
+            "max": 12,
+            "private": false,
+            "label": "Skysplitter",
+            "color": "#008000",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778077814807,
+        "modifiedTime": 1778077814807,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/standard-issue.json
+++ b/packs/core-perks/standard-issue.json
@@ -1,0 +1,130 @@
+{
+  "folder": "LPbbEDkprZMje251",
+  "name": "Standard Issue",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>You may add the @Trait[normal] typing to your @Trait[weapon] attacks, in addition to their normal typing.</p>",
+    "traits": [
+      "normal",
+      "weapon"
+    ],
+    "prerequisites": [
+      "trait:normal",
+      "trait:wielder"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "physical",
+      "approach": "finesse",
+      "archetype": "normal"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 148,
+        "y": 91,
+        "connected": [
+          "generalizer",
+          "plain-irritating"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "WYH8V4NQOBoKTqXi",
+  "img": "icons/weapons/guns/pistol-large-steel.webp",
+  "effects": [
+    {
+      "name": "Standard Issue",
+      "type": "passive",
+      "_id": "QspP6yjpGT6zh6At",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "standard-issue",
+            "predicate": [],
+            "domain": "all",
+            "label": "Standard Issue",
+            "toggleable": true,
+            "count": false,
+            "state": true,
+            "alwaysActive": false,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "alter-attack",
+            "key": "weapon-trait-attack",
+            "value": "normal",
+            "predicate": [
+              "standard-issue"
+            ],
+            "property": "type",
+            "definition": [],
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778078305774,
+        "modifiedTime": 1778078305774,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/the-quality-of-quantity.json
+++ b/packs/core-perks/the-quality-of-quantity.json
@@ -1,0 +1,177 @@
+{
+  "folder": "6XbjR9qPWzZw4vEd",
+  "name": "The Quality of Quantity",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "The Quality of Quantity",
+        "slug": "the-quality-of-quantity",
+        "description": "<p>Trigger: An allied creature becomes @Affliction[fainted].</p><p>Effect: You may advance 1 commanded creature with the @Affliction[fear] affliction by 100% and grant them @Affliction[argute] and @Affliction[boosted].</p>",
+        "traits": [
+          "taskmaster",
+          "command"
+        ],
+        "type": "generic",
+        "img": "icons/environment/people/infantry-army.webp",
+        "cost": {
+          "activation": "free",
+          "powerPoints": 5
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Trigger: An allied creature becomes @Affliction[fainted].</p><p>Effect: You may advance 1 commanded creature with the @Affliction[fear] affliction by 100% and grant them @Affliction[argute] and @Affliction[boosted].</p>",
+    "traits": [
+      "taskmaster",
+      "command"
+    ],
+    "prerequisites": [
+      "item:perk:commissar"
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "taskmaster"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 44,
+        "y": 103,
+        "connected": [
+          "conscription",
+          "assert-dominance",
+          "minor-buff-41",
+          "war-drums"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "9qH4CQPuqeE2ZZa2",
+  "img": "icons/environment/people/infantry-army.webp",
+  "effects": [
+    {
+      "name": "The Quality of Quantity",
+      "type": "passive",
+      "_id": "ah42yain3Px184Rm",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.argutecondition0",
+            "phase": "initial",
+            "predicate": [
+              "target:effect:fear"
+            ],
+            "alterations": [],
+            "key": "the-quality-of-quantity-generic",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.boostedcondition",
+            "phase": "initial",
+            "predicate": [
+              "target:effect:fear"
+            ],
+            "alterations": [],
+            "key": "the-quality-of-quantity-generic",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advancecondition",
+            "phase": "initial",
+            "predicate": [
+              "target:effect:fear"
+            ],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 100
+              }
+            ],
+            "key": "the-quality-of-quantity-generic",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778078456872,
+        "modifiedTime": 1778078456872,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/the-quality-of-quantity.json
+++ b/packs/core-perks/the-quality-of-quantity.json
@@ -21,6 +21,8 @@
         "description": "<p>Trigger: An allied creature becomes @Affliction[fainted].</p><p>Effect: You may advance 1 commanded creature with the @Affliction[fear] affliction by 100% and grant them @Affliction[argute] and @Affliction[boosted].</p>",
         "traits": [
           "taskmaster",
+          "interrupt",
+          "flinch-25",
           "command"
         ],
         "type": "generic",
@@ -30,7 +32,7 @@
           "powerPoints": 5
         },
         "range": {
-          "target": "creature",
+          "target": "ally",
           "distance": 10,
           "unit": "m"
         }

--- a/packs/core-perks/twist.json
+++ b/packs/core-perks/twist.json
@@ -1,0 +1,74 @@
+{
+  "folder": "E5JYWji5073kTXhD",
+  "name": "Twist",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Twist",
+        "slug": "twist",
+        "description": "<p>Effect: On the same turn that the user has used @UUID[Compendium.ptr2e.core-gear.Item.PZFyt0DGaa8C6SCy]{Metronome}, the user may discard up to 3 Metronome Cards, and draw again for an equal number of cards.</p>",
+        "traits": [
+          "gambler"
+        ],
+        "type": "generic",
+        "img": "icons/sundries/gaming/game-playing-cards-deck.webp",
+        "cost": {
+          "activation": "free",
+          "powerPoints": 2
+        },
+        "range": {
+          "target": "self",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Effect: On the same turn that the user has used @UUID[Compendium.ptr2e.core-gear.Item.PZFyt0DGaa8C6SCy]{Metronome}, the user may discard up to 3 Metronome Cards, and draw again for an equal number of cards.</p>",
+    "traits": [
+      "gambler"
+    ],
+    "prerequisites": [
+      "item:move:metronome"
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "gambler"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 96,
+        "y": 188,
+        "connected": [
+          "the-devil-does-bargain",
+          "ace-up-my-sleeve",
+          "minor-buff-65",
+          "card-captor-1"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "23tGrqFsV5A8DBAi",
+  "img": "icons/sundries/gaming/game-playing-cards-deck.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/twist.json
+++ b/packs/core-perks/twist.json
@@ -18,10 +18,7 @@
       {
         "name": "Twist",
         "slug": "twist",
-        "description": "<p>Effect: On the same turn that the user has used @UUID[Compendium.ptr2e.core-gear.Item.PZFyt0DGaa8C6SCy]{Metronome}, the user may discard up to 3 Metronome Cards, and draw again for an equal number of cards.</p>",
-        "traits": [
-          "gambler"
-        ],
+        "description": "<p>Effect: If the user has used @UUID[Compendium.ptr2e.core-gear.Item.PZFyt0DGaa8C6SCy]{Metronome} this Activation, they may discard up to 3 Metronome Cards and draw again for an equal number of cards.</p>",
         "type": "generic",
         "img": "icons/sundries/gaming/game-playing-cards-deck.webp",
         "cost": {
@@ -34,7 +31,7 @@
         }
       }
     ],
-    "description": "<p>Effect: On the same turn that the user has used @UUID[Compendium.ptr2e.core-gear.Item.PZFyt0DGaa8C6SCy]{Metronome}, the user may discard up to 3 Metronome Cards, and draw again for an equal number of cards.</p>",
+    "description": "<p>Effect: If the user has used @UUID[Compendium.ptr2e.core-gear.Item.PZFyt0DGaa8C6SCy]{Metronome} this Activation, they may discard up to 3 Metronome Cards and draw again for an equal number of cards.</p>",
     "traits": [
       "gambler"
     ],

--- a/packs/core-perks/unown-song-bewitching-melody.json
+++ b/packs/core-perks/unown-song-bewitching-melody.json
@@ -1,0 +1,81 @@
+{
+  "folder": "KcpEanpX82Cu6Dqh",
+  "name": "Unown Song: Bewitching Melody",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Unown Song: Bewitching Melody",
+        "slug": "unown-song-bewitching-melody",
+        "description": "<p>Effect: Summons Unown to perform a Bewitching Melody.</p><p>Bewitching Melody lasts for 3 rounds, and while it is active, grants all allied creatures 30% EHR.</p>",
+        "traits": [
+          "sage",
+          "summon"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "summon": "Compendium.ptr2e.core-summons.UwUWMxacI00nX6aW",
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Effect: Summons Unown to perform a Bewitching Melody.</p><p>Bewitching Melody lasts for 3 rounds, and while it is active, grants all allied creatures 30% EHR.</p>",
+    "traits": [
+      "sage",
+      "summon"
+    ],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.thaumaturgy.mod}",
+          45
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "mental",
+      "approach": "power",
+      "archetype": "sage"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 147,
+        "y": 118,
+        "connected": [
+          "hasten-conjuration",
+          "unown-song-sanctuary-ward",
+          "neurolize"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "rkKf1W6HQazczQQl",
+  "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/unown-song-fugue.json
+++ b/packs/core-perks/unown-song-fugue.json
@@ -1,0 +1,100 @@
+{
+  "folder": "KcpEanpX82Cu6Dqh",
+  "name": "Unown Song: Fugue",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Unown Song: Fugue",
+        "slug": "unown-song-fugue",
+        "description": "<p>This perk summons an Unown Choir to perform the Unown Song: Fugue.</p><p>Effect: While this summon is active, no other summons can be created. Summons with the @Trait[legendary] trait are not subject to this restriction.</p>",
+        "traits": [
+          "sage",
+          "summon"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 6
+        },
+        "summon": "Compendium.ptr2e.core-summons.9nlG6rQxSuggQOcp",
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      },
+      {
+        "name": "Fugue Cooldown",
+        "slug": "unown-song-fugue-cooldown",
+        "description": "<p>This perk summons an Unown Choir to perform the Unown Song: Fugue.</p><p>Only 1 Fugue summon may exist at any given time. This Summon has 150AV and lasts for 3 Activations.</p><p>Effect: While this summon is active, no other summons can be created. Summons with the @Trait[legendary] traits are not subject to this restriction.</p><p>After the Fugue summon expires, the user must summon the Fugue Cooldown Summon. This last for 2 Activations and has AV100. While the Fugue Cooldown Summon is active, the Fugue summon may not be re-summoned.</p>",
+        "traits": [
+          "sage",
+          "summon"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+        "cost": {
+          "activation": "free"
+        },
+        "summon": "Compendium.ptr2e.core-summons.Item.HuBU8nD7KMTpShwj",
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>This perk summons an Unown Choir to perform the Unown Song: Fugue.</p><p>Only 1 Fugue summon may exist at any given time. This Summon has 150AV and lasts for 3 Activations.</p><p>Effect: While this summon is active, no other summons can be created. Summons with the @Trait[legendary] traits are not subject to this restriction.</p><p>After the Fugue summon expires, the user must summon the Fugue Cooldown Summon. This last for 2 Activations and has AV100. While the Fugue Cooldown Summon is active, the Fugue summon may not be re-summoned.</p>",
+    "traits": [
+      "sage",
+      "summon"
+    ],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.thaumaturgy.mod}",
+          60
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "sage"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 146,
+        "y": 111,
+        "connected": [
+          "unown-song-sanctuary-ward",
+          "screen-setter",
+          "unown-song-symphonic-healing"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "Jd3KdybuKfwlv2px",
+  "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/unown-song-symphonic-healing.json
+++ b/packs/core-perks/unown-song-symphonic-healing.json
@@ -1,0 +1,83 @@
+{
+  "folder": "KcpEanpX82Cu6Dqh",
+  "name": "Unown Song: Symphonic Healing",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Unown Song: Symphonic Healing",
+        "slug": "unown-song-symphonic-healing",
+        "description": "<p>Effect: The user can summon a choir of Unown to perform Symphonic Healing. This summon lasts for 3 activations, with an AV of 100.</p><p>On the summon's activation, it heals all allies on the field for @Tick[4].</p>",
+        "traits": [
+          "sage",
+          "summon",
+          "healing"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 5
+        },
+        "summon": "Compendium.ptr2e.core-summons.6e62CRYLP8gt9WeY",
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Effect: The user can summon a choir of Unown to perform Symphonic Healing. This summon lasts for 5 activations, with an AV of 100.</p><p>On the summon's activation, it heals all allies on the field for @Tick[4].</p>",
+    "traits": [
+      "sage",
+      "summon",
+      "healing"
+    ],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.thaumaturgy.mod}",
+          45
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 3,
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "sage"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 153,
+        "y": 111,
+        "connected": [
+          "unown-song-fugue",
+          "type-embodiment-type",
+          "long-range-psychoportation"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "jnMbQC4cEhxVrEw6",
+  "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/vampire-field.json
+++ b/packs/core-perks/vampire-field.json
@@ -1,0 +1,76 @@
+{
+  "folder": "UZGN1glVNXLieg48",
+  "name": "Vampire Field",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Vampire Field",
+        "slug": "vampire-field",
+        "description": "<p>Effect: The user summons a Vampire Field, giving all allied attacks the @Trait[drain-1-10] trait.</p><p>This summon lasts for 3 rounds.</p>",
+        "traits": [
+          "healer",
+          "summon"
+        ],
+        "type": "generic",
+        "img": "icons/creatures/abilities/fang-tooth-blood-red.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "summon": "Compendium.ptr2e.core-summons.Item.ZoHWcYyAXl3Nw98Y",
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Effect: The user summons a Vampire Field, giving all allied attacks the @Trait[drain-1-10] trait.</p><p>This summon has an AV of 150 and lasts for 3 activations.</p>",
+    "traits": [
+      "healer",
+      "summon"
+    ],
+    "prerequisites": [
+      "trait:pack-leader"
+    ],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "physical",
+      "approach": "resilience",
+      "archetype": "pack-mon"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 142,
+        "y": 181,
+        "connected": [
+          "pack-hunger",
+          "pile-on",
+          "metamove-empower"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "2VzEwPMzgNmQlAmI",
+  "img": "icons/creatures/abilities/fang-tooth-blood-red.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-perks/war-drums.json
+++ b/packs/core-perks/war-drums.json
@@ -18,7 +18,7 @@
       {
         "name": "War Drums",
         "slug": "war-drums",
-        "description": "<p>Effect: Creates a War Drums summon with AV88 lasting 3 activations. On the summon's activation, it advance the actions of allied creatures suffering from the @Affliction[fear] affliction by 20%.</p>",
+        "description": "<p>Effect: The user set a War Drums Summon (AV 88), lasting 3 Activations. On the Summon's activation, allied creatures that have @Affliction[fear] gain @Affliction[advance 20].</p>",
         "traits": [
           "taskmaster",
           "summon"
@@ -35,7 +35,7 @@
         }
       }
     ],
-    "description": "<p>Effect: Creates a War Drums summon with AV88 lasting 3 activations. On the summon's activation, it advance the actions of allied creatures suffering from the @Affliction[fear] affliction by 20%.</p>",
+    "description": "<p>Effect: The user set a War Drums Summon (AV 88), lasting 3 Activations. On the Summon's activation, allied creatures that have @Affliction[fear] gain @Affliction[advance 20].</p>",
     "traits": [
       "taskmaster",
       "summon"

--- a/packs/core-perks/war-drums.json
+++ b/packs/core-perks/war-drums.json
@@ -1,0 +1,75 @@
+{
+  "folder": "6XbjR9qPWzZw4vEd",
+  "name": "War Drums",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "War Drums",
+        "slug": "war-drums",
+        "description": "<p>Effect: Creates a War Drums summon with AV88 lasting 3 activations. On the summon's activation, it advance the actions of allied creatures suffering from the @Affliction[fear] affliction by 20%.</p>",
+        "traits": [
+          "taskmaster",
+          "summon"
+        ],
+        "type": "generic",
+        "img": "icons/tools/instruments/drum-snare-red.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 5
+        },
+        "range": {
+          "target": "field",
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Effect: Creates a War Drums summon with AV88 lasting 3 activations. On the summon's activation, it advance the actions of allied creatures suffering from the @Affliction[fear] affliction by 20%.</p>",
+    "traits": [
+      "taskmaster",
+      "summon"
+    ],
+    "prerequisites": [
+      "item:perk:commissar"
+    ],
+    "autoUnlock": [],
+    "cost": 4,
+    "design": {
+      "arena": "social",
+      "approach": "power",
+      "archetype": "taskmaster"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 38,
+        "y": 101,
+        "connected": [
+          "commissar",
+          "the-quality-of-quantity",
+          "forensic-accountant"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "Dx8QtwhmAVm4U25t",
+  "img": "icons/tools/instruments/drum-snare-red.webp",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-summons/bewitching-melody.json
+++ b/packs/core-summons/bewitching-melody.json
@@ -1,0 +1,88 @@
+{
+  "name": "Bewitching Melody",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "summon"
+    ],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "_id": "UwUWMxacI00nX6aW",
+  "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+  "effects": [
+    {
+      "name": "Bewitching Melody",
+      "type": "summon",
+      "_id": "FeJnzrT5AOB65OBH",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.modifiers.effectHitRate",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage",
+        "targetType": "all",
+        "targetUuid": null,
+        "predicate": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778072998710,
+        "modifiedTime": 1778072998710,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-summons/bondmate-summon.json
+++ b/packs/core-summons/bondmate-summon.json
@@ -1,0 +1,122 @@
+{
+  "name": "Bondmate (Summon)",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "summon",
+      "ranger"
+    ],
+    "actions": [
+      {
+        "name": "Bondmate",
+        "slug": "bondmate",
+        "traits": [
+          "tank",
+          "summon",
+          "ranger"
+        ],
+        "type": "summon",
+        "img": "icons/magic/defensive/armor-green-hex.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "dragon"
+        ],
+        "category": "status",
+        "predicate": [],
+        "targetType": "target",
+        "damageType": "power",
+        "attackStat": "owner"
+      }
+    ],
+    "baseAV": 90,
+    "duration": 3
+  },
+  "_id": "4LTYjzwsQde6lytE",
+  "img": "icons/magic/defensive/armor-green-hex.webp",
+  "effects": [
+    {
+      "name": "Bondmate",
+      "type": "passive",
+      "_id": "H9tcWCnn88zd83cp",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.k1FukpHKnZGqjSNc",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "key": "bondmate-summon",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778073003077,
+        "modifiedTime": 1778073003077,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-summons/fugue-cooldown.json
+++ b/packs/core-summons/fugue-cooldown.json
@@ -1,0 +1,25 @@
+{
+  "name": "Fugue Cooldown",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [],
+    "baseAV": 100,
+    "duration": 2
+  },
+  "_id": "HuBU8nD7KMTpShwj",
+  "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-summons/fugue.json
+++ b/packs/core-summons/fugue.json
@@ -1,0 +1,25 @@
+{
+  "name": "Fugue",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "_id": "9nlG6rQxSuggQOcp",
+  "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+  "effects": [],
+  "flags": {}
+}

--- a/packs/core-summons/symphonic-healing.json
+++ b/packs/core-summons/symphonic-healing.json
@@ -1,0 +1,115 @@
+{
+  "name": "Symphonic Healing",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "Symphonic Healing",
+        "slug": "symphonic-healing",
+        "traits": [],
+        "type": "summon",
+        "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "psychic"
+        ],
+        "category": "status",
+        "predicate": [],
+        "targetType": "ally",
+        "damageType": "power",
+        "attackStat": "owner"
+      }
+    ],
+    "baseAV": 100,
+    "duration": 3
+  },
+  "_id": "6e62CRYLP8gt9WeY",
+  "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+  "effects": [
+    {
+      "name": "Symphonic Healing",
+      "type": "passive",
+      "_id": "1URNJjHGo2GfwMix",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects.Item.4DlXFTVooz07YcDm",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "key": "symphonic-healing-summon",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778073042608,
+        "modifiedTime": 1778073042608,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-summons/vampire-field-summon.json
+++ b/packs/core-summons/vampire-field-summon.json
@@ -1,0 +1,90 @@
+{
+  "name": "Vampire Field (Summon)",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "summon"
+    ],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "_id": "ZoHWcYyAXl3Nw98Y",
+  "img": "icons/creatures/abilities/fang-tooth-blood-red.webp",
+  "effects": [
+    {
+      "name": "Vampire Field",
+      "type": "summon",
+      "_id": "qqoxKADvIaMMdyzs",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "key": "attack",
+            "value": "drain-1-10",
+            "predicate": [],
+            "property": "traits",
+            "definition": [],
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage",
+        "targetType": "ally",
+        "targetUuid": null,
+        "predicate": []
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778073055063,
+        "modifiedTime": 1778073055063,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-summons/war-drums-summon.json
+++ b/packs/core-summons/war-drums-summon.json
@@ -1,0 +1,117 @@
+{
+  "name": "War Drums (Summon)",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "actions": [
+      {
+        "name": "War Drums",
+        "slug": "war-drums",
+        "traits": [],
+        "type": "summon",
+        "img": "icons/tools/instruments/drum-snare-red.webp",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 10,
+          "unit": "m"
+        },
+        "types": [
+          "shadow"
+        ],
+        "category": "status",
+        "predicate": [],
+        "targetType": "ally",
+        "damageType": "power",
+        "attackStat": "owner"
+      }
+    ],
+    "baseAV": 88,
+    "duration": 3
+  },
+  "_id": "XlDXxNiSlATtu3xk",
+  "img": "icons/tools/instruments/drum-snare-red.webp",
+  "effects": [
+    {
+      "name": "War Drums",
+      "type": "passive",
+      "_id": "rDrH7KPyuCKhbRr5",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advancecondition",
+            "phase": "initial",
+            "predicate": [
+              "target:effect:fear"
+            ],
+            "key": "war-drums-summon",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 20
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778073060353,
+        "modifiedTime": 1778073060353,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}


### PR DESCRIPTION
Significantly expands the Taskmaster and Sage archetypes, reinforces the Social/Agitator archetype, pack mon/pack leader archetype, gambler archetype, and a handful of miscellaneous additions.
- Update Summon: Bewitching Melody
- Update Summon: Bondmate (Summon)
- Update Summon: Fugue
- Update Summon: Fugue Cooldown
- Update Summon: Symphonic Healing
- Update Summon: Vampire Field (Summon)
- Update Summon: War Drums (Summon)
- Update Perk: Ranger Cadet
- Update Perk: Bondmate
- Update Perk: Mourning Blade
- Update Perk: Ace Up My Sleeve
- Update Perk: Pokerface
- Update Perk: Twist
- Update Perk: Pack Hunger
- Update Perk: Skysplitter
- Update Perk: Vampire Field
- Update Perk: Defer Destiny
- Update Perk: Exorcism
- Update Perk: Unown Song: Bewitching Melody
- Update Perk: Unown Song: Fugue
- Update Perk: Unown Song: Symphonic Healing
- Update Perk: Demoralize
- Update Perk: Idol
- Update Perk: Inconceivable
- Update Perk: One of the Classic Blunders
- Update Perk: Siren Song
- Update Perk: Insidious Style
- Update Perk: Right Hand Mon
- Update Perk: Building Momentum
- Update Perk: Micromanagement
- Update Perk: Bait
- Update Perk: Equivalent Exchange
- Update Perk: Assert Dominance
- Update Perk: Commissar
- Update Perk: Conscription
- Update Perk: Job Done Right
- Update Perk: Show of Force
- Update Perk: War Drums
- Update Perk: Hive Needle
- Update Perk: Mindbreak
- Update Perk: Seer's Sacrifice
- Update Perk: Standard Issue
- Update Perk: Exorcist Style
- Update Perk: Overwatch
- Update Perk: The Quality of Quantity