### PR TITLE
Foundry Data Sync - Focused Fire Rework

### DIFF
--- a/packs/core-perks/focused-fire-1.json
+++ b/packs/core-perks/focused-fire-1.json
@@ -14,7 +14,7 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Passive Effect: When making an @Trait[x-strike] roll to determine number of hits, your number of guaranteed hits increases by 1 per tier of this perk.<br /><br />For example; 1+d4 hits becomes 2+d3 hits, which can later upgrade to 3+d2 hits.<br /><br />This perk is disabled when the creature with it has the @UUID[Compendium.ptr2e.core-abilities.m3NkhaFegGTH5ZuK]{Skill Link} ability slotted.</p>",
+    "description": "<p>Effect: The user’s @Trait[x-strike] Attacks have +10% Accuracy and EHR, and +1 default CRIT, and afflict the user with @Affliction[delay 8].</p>",
     "traits": [],
     "prerequisites": [],
     "autoUnlock": [],
@@ -102,7 +102,7 @@
       }
     ],
     "slug": "focused-fire-1",
-    "originSlug": null
+    "traitWebs": []
   },
   "img": "icons/equipment/head/goggles-leather-grey.webp",
   "effects": [
@@ -114,13 +114,66 @@
       "system": {
         "changes": [
           {
-            "type": "flat-modifier",
-            "key": "strike-trait-attack-hits-flat",
-            "value": 1,
-            "predicate": [],
+            "type": "percentile-modifier",
+            "value": 10,
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "item:perk:focused-fire-4"
+              }
+            ],
+            "label": "Focused Fire (Acc)",
+            "key": "strike-trait-attack-accuracy",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
+          },
+          {
+            "type": "stage-modifier",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [],
+            "key": "strike-trait-attack-crit",
+            "label": "Focused Fire (Crit)",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.auJlcV40ua09ITga",
+            "phase": "initial",
+            "predicate": [],
+            "affects": "self",
+            "alterations": [],
+            "key": "strike-trait-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "item:perk:focused-fire-2"
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 8
+              }
+            ],
+            "dontMerge": false,
+            "key": "strike-trait-attack",
+            "label": "Focused Fire Delay",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -134,17 +187,33 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
-      "description": "<p>Passive Effect: When making an @Trait[x-strike] roll to determine number of hits, your number of guaranteed hits increases by 1 per tier of this perk.<br /><br />For example; 1+d4 hits becomes 2+d3 hits, which can later upgrade to 3+d2 hits.<br /><br />This perk is disabled when the creature with it has the @UUID[Compendium.ptr2e.core-abilities.m3NkhaFegGTH5ZuK]{Skill Link} ability slotted.</p>",
+      "description": "",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
       "statuses": [],
-      "sort": 0
+      "sort": 0,
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778189287847,
+        "modifiedTime": 1778189549193,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "zrVtKATNxzLNxTUX",
-  "flags": {},
   "_id": "FcY3illt965ovD2J"
 }

--- a/packs/core-perks/focused-fire-2.json
+++ b/packs/core-perks/focused-fire-2.json
@@ -14,11 +14,11 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Passive Effect: When making an @Trait[x-strike] roll to determine number of hits, your number of guaranteed hits increases by 1 per tier of this perk.<br /><br />For example; 1+d4 hits becomes 2+d3 hits, which can later upgrade to 3+d2 hits.<br /><br />This perk is disabled when the creature with it has the @UUID[Compendium.ptr2e.core-abilities.m3NkhaFegGTH5ZuK]{Skill Link} ability slotted.</p>",
+    "description": "<p>Effect: The user’s @Trait[x-strike] Attacks deal +10% more damage, +1 minimum hits, and afflict the user with @Affliction[delay 12].</p>",
     "traits": [],
     "prerequisites": [],
     "autoUnlock": [],
-    "cost": 2,
+    "cost": 3,
     "design": {
       "arena": "physical",
       "approach": "finesse",
@@ -41,17 +41,14 @@
         },
         "config": {
           "texture": "icons/equipment/head/goggles-leather-grey.webp",
-          "alpha": null,
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "tint": null,
-          "scale": null
+          "tint": null
         }
       }
     ],
     "slug": "focused-fire-2",
-    "originSlug": null
+    "traitWebs": []
   },
   "img": "icons/equipment/head/goggles-leather-grey.webp",
   "effects": [
@@ -63,13 +60,59 @@
       "system": {
         "changes": [
           {
+            "type": "percentile-modifier",
+            "value": 10,
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "item:perk:focused-fire-4"
+              }
+            ],
+            "label": "Focused Fire (Dam)",
+            "key": "strike-trait-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
             "type": "flat-modifier",
             "key": "strike-trait-attack-hits-flat",
             "value": 1,
-            "predicate": [],
+            "predicate": [
+              {
+                "not": "item:perk:focused-fire-3"
+              }
+            ],
+            "phase": "initial",
+            "label": "Focused Fire (Hits)",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "item:perk:focused-fire-3"
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 12
+              }
+            ],
+            "dontMerge": false,
+            "key": "strike-trait-attack",
+            "label": "Focused Fire Delay",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -83,17 +126,33 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
-      "description": "<p>Passive Effect: When making an @Trait[x-strike] roll to determine number of hits, your number of guaranteed hits increases by 1 per tier of this perk.<br /><br />For example; 1+d4 hits becomes 2+d3 hits, which can later upgrade to 3+d2 hits.<br /><br />This perk is disabled when the creature with it has the @UUID[Compendium.ptr2e.core-abilities.m3NkhaFegGTH5ZuK]{Skill Link} ability slotted.</p>",
+      "description": "",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
       "statuses": [],
-      "sort": 0
+      "sort": 0,
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778189595793,
+        "modifiedTime": 1778189726182,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "zrVtKATNxzLNxTUX",
-  "flags": {},
   "_id": "PltJPYwzC2OhEOya"
 }

--- a/packs/core-perks/focused-fire-3.json
+++ b/packs/core-perks/focused-fire-3.json
@@ -14,11 +14,11 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Passive Effect: When making an @Trait[x-strike] roll to determine number of hits, your number of guaranteed hits increases by 1 per tier of this perk.<br /><br />For example; 1+d4 hits becomes 2+d3 hits, which can later upgrade to 3+d2 hits.<br /><br />This perk is disabled when the creature with it has the @UUID[Compendium.ptr2e.core-abilities.m3NkhaFegGTH5ZuK]{Skill Link} ability slotted.</p>",
+    "description": "<p>Effect: The user’s @Trait[x-strike] Attacks have +20% EHR, +1 minimum hits, and afflict the user with @Affliction[delay 16].</p>",
     "traits": [],
     "prerequisites": [],
     "autoUnlock": [],
-    "cost": 2,
+    "cost": 3,
     "design": {
       "arena": "physical",
       "approach": "finesse",
@@ -41,17 +41,14 @@
         },
         "config": {
           "texture": "icons/equipment/head/goggles-leather-grey.webp",
-          "alpha": null,
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "tint": null,
-          "scale": null
+          "tint": null
         }
       }
     ],
     "slug": "focused-fire-3",
-    "originSlug": null
+    "traitWebs": []
   },
   "img": "icons/equipment/head/goggles-leather-grey.webp",
   "effects": [
@@ -65,11 +62,55 @@
           {
             "type": "flat-modifier",
             "key": "strike-trait-attack-hits-flat",
-            "value": 1,
+            "value": 2,
+            "phase": "initial",
             "predicate": [],
+            "label": "Focused Fire (Hits)",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.auJlcV40ua09ITga",
+            "phase": "initial",
+            "predicate": [],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 20
+              }
+            ],
+            "affects": "self",
+            "key": "strike-trait-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "item:perk:focused-fire-4"
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 16
+              }
+            ],
+            "dontMerge": false,
+            "key": "strike-trait-attack",
+            "label": "Focused Fire Delay",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -83,17 +124,33 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
-      "description": "<p>Passive Effect: When making an @Trait[x-strike] roll to determine number of hits, your number of guaranteed hits increases by 1 per tier of this perk.<br /><br />For example; 1+d4 hits becomes 2+d3 hits, which can later upgrade to 3+d2 hits.<br /><br />This perk is disabled when the creature with it has the @UUID[Compendium.ptr2e.core-abilities.m3NkhaFegGTH5ZuK]{Skill Link} ability slotted.</p>",
+      "description": "",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
       "statuses": [],
-      "sort": 0
+      "sort": 0,
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778189811665,
+        "modifiedTime": 1778190237624,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "zrVtKATNxzLNxTUX",
-  "flags": {},
   "_id": "rbz2kCOwvjnITZbY"
 }

--- a/packs/core-perks/focused-fire-4.json
+++ b/packs/core-perks/focused-fire-4.json
@@ -14,11 +14,11 @@
       "notes": ""
     },
     "actions": [],
-    "description": "<p>Passive Effect: When making an @Trait[x-strike] roll to determine number of hits, your number of guaranteed hits increases by 1 per tier of this perk.<br /><br />For example; 1+d4 hits becomes 2+d3 hits, which can later upgrade to 3+d2 hits.<br /><br />This perk is disabled when the creature with it has the @UUID[Compendium.ptr2e.core-abilities.m3NkhaFegGTH5ZuK]{Skill Link} ability slotted.</p>",
+    "description": "<p>Effect: The user’s @Trait[x-strike] Attacks deal +20% damage, have +10% Accuracy and +5% Base Effect Chance, and afflict the user with @Affliction[delay 20].</p>",
     "traits": [],
     "prerequisites": [],
     "autoUnlock": [],
-    "cost": 2,
+    "cost": 4,
     "design": {
       "arena": "physical",
       "approach": "finesse",
@@ -41,17 +41,14 @@
         },
         "config": {
           "texture": "icons/equipment/head/goggles-leather-grey.webp",
-          "alpha": null,
           "backgroundColor": null,
           "borderColor": null,
-          "borderWidth": null,
-          "tint": null,
-          "scale": null
+          "tint": null
         }
       }
     ],
     "slug": "focused-fire-4",
-    "originSlug": null
+    "traitWebs": []
   },
   "img": "icons/equipment/head/goggles-leather-grey.webp",
   "effects": [
@@ -63,13 +60,58 @@
       "system": {
         "changes": [
           {
-            "type": "flat-modifier",
-            "key": "strike-trait-attack-hits-flat",
-            "value": 1,
+            "type": "percentile-modifier",
+            "key": "strike-trait-attack-damage",
+            "value": 30,
             "predicate": [],
+            "phase": "initial",
+            "label": "Focused Fire (Dam)",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 20,
+            "phase": "initial",
+            "predicate": [],
+            "label": "Focused Fire (Acc)",
+            "key": "strike-trait-attack-accuracy",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.dVXsQ55hDouadYkE",
+            "phase": "initial",
+            "predicate": [],
+            "key": "strike-trait-attack",
+            "affects": "self",
+            "alterations": [],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 20
+              }
+            ],
+            "dontMerge": false,
+            "key": "strike-trait-attack",
+            "label": "Focused Fire Delay",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -83,17 +125,33 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
-      "description": "<p>Passive Effect: When making an @Trait[x-strike] roll to determine number of hits, your number of guaranteed hits increases by 1 per tier of this perk.<br /><br />For example; 1+d4 hits becomes 2+d3 hits, which can later upgrade to 3+d2 hits.<br /><br />This perk is disabled when the creature with it has the @UUID[Compendium.ptr2e.core-abilities.m3NkhaFegGTH5ZuK]{Skill Link} ability slotted.</p>",
+      "description": "",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
       "statuses": [],
-      "sort": 0
+      "sort": 0,
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778190046031,
+        "modifiedTime": 1778190272625,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "zrVtKATNxzLNxTUX",
-  "flags": {},
   "_id": "mLzdq1QTiLDGXe9Z"
 }


### PR DESCRIPTION
The Perk just being four instances of "+1 minimum hits" isn't a particularly enthralling design, so these are a bit more substantial and far less powerful.
- Update Perk: Focused Fire 1
- Update Perk: Focused Fire 2
- Update Perk: Focused Fire 3
- Update Perk: Focused Fire 4