### PR TITLE
Foundry Data Sync - Update Delay Abilities with new UUID

### DIFF
--- a/packs/core-abilities/feedback.json
+++ b/packs/core-abilities/feedback.json
@@ -67,7 +67,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -86,7 +87,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -100,7 +102,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -112,13 +116,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1757875098876,
         "modifiedTime": 1757875272511,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-abilities/loud-bang.json
+++ b/packs/core-abilities/loud-bang.json
@@ -16,7 +16,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user's Sonic Attacks have a 30% to chance to cause target(s) to be @Affliction[delay 20] and lose -1 EVA Stage for 5 Activations.</p>",
         "img": "icons/svg/explosion.svg"
@@ -64,7 +65,9 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false
           },
           {
             "type": "roll-effect",
@@ -76,19 +79,25 @@
             "alterations": [],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -101,13 +110,16 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.3.3.beta",
         "createdTime": 1748204873108,
         "modifiedTime": 1748204977323,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/stench.json
+++ b/packs/core-abilities/stench.json
@@ -15,7 +15,8 @@
         },
         "range": {
           "target": "creature",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Trigger: The user hits target(s) with a Physical or Special-Category attack.</p><p>Effect: All valid target(s) has a 10% chance to be @Affliction[delay 40].</p>",
         "img": "icons/svg/explosion.svg"
@@ -32,7 +33,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "mNww18uHVxa0yoaz",
@@ -60,19 +62,26 @@
             ],
             "priority": null,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -84,13 +93,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.5.3.0",
         "createdTime": 1738250046138,
         "modifiedTime": 1738250095556,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
-      }
+        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }


### PR DESCRIPTION
Instances of the Delay effect were not properly linking from the compendium. Updating to use the most up-to-date UUID.
- Update Ability: Feedback
- Update Ability: Loud Bang
- Update Ability: Stench