### PR TITLE
Foundry Data Sync - Remaining Weapons Grade/Rarity Pass (except PMD Throwables)

### DIFF
--- a/packs/core-gear/highland-thistle.json
+++ b/packs/core-gear/highland-thistle.json
@@ -1,0 +1,322 @@
+{
+  "folder": "fwBg1GB1fMcgPklo",
+  "name": "Highland Thistle",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.11,
+      "previous": {
+        "schema": 0.109,
+        "foundry": "12.331",
+        "system": "0.10.0-alpha.5.1"
+      }
+    },
+    "traits": [
+      "weapon",
+      "grass",
+      "fantasy",
+      "blade",
+      "fling",
+      "1-handed",
+      "switch-grip"
+    ],
+    "actions": [
+      {
+        "name": "Thistle Swing",
+        "slug": "thistle-swing",
+        "traits": [
+          "weapon",
+          "sharp",
+          "contact",
+          "adaptable",
+          "double-strike",
+          "priority-10"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 1
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 45,
+        "accuracy": 100
+      },
+      {
+        "name": "Thistle Thrust",
+        "slug": "thistle-thrust",
+        "traits": [
+          "weapon",
+          "contact",
+          "adaptable",
+          "crit-1",
+          "grapple",
+          "pass-1"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 2
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "predicate": [],
+        "power": 90,
+        "accuracy": 95,
+        "free": true
+      }
+    ],
+    "description": "<p>Highland Thistle is a magical sword crafted by Wood Elves in times of old. While a mastercrafted sword in its own right, it also boosts the wearer's own capabilities and grants them some special powers to boot!</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "handsHeld": 1,
+      "slot": "held"
+    },
+    "grade": "B",
+    "fling": {
+      "type": "grass",
+      "power": 95,
+      "accuracy": 90,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 3,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "unique",
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    },
+    "slug": "highland-thistle",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "ammoType": []
+  },
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "Highland Thistle",
+      "type": "passive",
+      "_id": "8DawitkSuILm96oa",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "key": "thistle-swing-attack-damage-flat",
+            "value": "12+ceil(@actor.system.advancement.level/9)",
+            "predicate": [],
+            "label": "Swing",
+            "phase": "initial",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "thistle-thrust-attack-damage-flat",
+            "value": "20+ceil(@actor.system.advancement.level/8)",
+            "predicate": [],
+            "label": "Thrust",
+            "phase": "initial",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "fling-highland-thistle-attack-damage-flat",
+            "value": 19,
+            "predicate": [],
+            "label": "Highland Thistle (Fling)",
+            "phase": "initial",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [],
+            "hp": null,
+            "atk": 15,
+            "def": null,
+            "spa": null,
+            "spd": null,
+            "spe": 10,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-moves.Item.AO8ABcakgLIp4Fuz",
+            "phase": "initial",
+            "predicate": [],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.actions.0.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "replaceSelf": true,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false
+          },
+          {
+            "type": "grant-item",
+            "value": "Compendium.ptr2e.core-moves.Item.D0WZXNV3LxJsHpnp",
+            "phase": "initial",
+            "predicate": [],
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.actions.1.free",
+                "value": "true"
+              }
+            ],
+            "onDeleteActions": {
+              "grantee": "detach",
+              "granter": "cascade"
+            },
+            "replaceSelf": true,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "reevaluateOnUpdate": false,
+            "inMemoryOnly": false,
+            "allowDuplicate": true,
+            "track": false
+          },
+          {
+            "type": "flat-modifier",
+            "value": "8+ceil(@actor.system.advancement.level/6)",
+            "phase": "initial",
+            "predicate": [],
+            "label": "Highland Thistle Enhancement",
+            "key": "leaf-blade-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "value": "24+ceil(@actor.system.advancement.level/4)",
+            "phase": "initial",
+            "predicate": [],
+            "key": "solar-blade-resolution-attack-damage",
+            "label": "Highland Thistle Enhancement",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "weapon",
+            "phase": "initial",
+            "predicate": [],
+            "property": "traits",
+            "definition": [],
+            "key": "leaf-blade-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "weapon",
+            "phase": "initial",
+            "predicate": [],
+            "key": "solar-blade-resolution-attack",
+            "property": "traits",
+            "definition": [],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "units": "turns",
+        "value": null,
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "_stats": {
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.2MoMKszqC3PlxHxN.ActiveEffect.yxvzqvjaJw3Mm08g",
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778681018927,
+        "modifiedTime": 1778681917918,
+        "lastModifiedBy": "dgye2I5sN06rQmNS"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
+    }
+  ],
+  "_id": "bUNUTCwtpWtLID6P"
+}

--- a/packs/core-gear/nunchaku.json
+++ b/packs/core-gear/nunchaku.json
@@ -1,0 +1,422 @@
+{
+  "name": "Nunchaku",
+  "type": "weapon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "slug": "nunchaku",
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
+      "notes": ""
+    },
+    "traits": [
+      "weapon",
+      "fling",
+      "blunt",
+      "bludgeon",
+      "1-handed",
+      "switch-grip",
+      "ninja",
+      "martial",
+      "conventional",
+      "modern",
+      "early-modern",
+      "medieval",
+      "fantasy"
+    ],
+    "actions": [
+      {
+        "name": "Nunchaku Strike",
+        "slug": "nunchaku-strike",
+        "description": "<p>Effect: On hit, the target has a 25% chance of gaining @Affliction[delay 15].</p>",
+        "traits": [
+          "weapon",
+          "contact",
+          "priority-20",
+          "grapple",
+          "crash-1-5"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex"
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 55,
+        "accuracy": 70
+      },
+      {
+        "name": "Nunchaku Bash",
+        "slug": "nunchaku-bash",
+        "description": "<p>Effect: On hit, the target has a 15% chance of gaining @Affliction[confused 3] and a 10% chance of gaining @Affliction[delay 10].</p>",
+        "traits": [
+          "weapon",
+          "contact",
+          "double-strike",
+          "crash-1-4"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex"
+        },
+        "variant": "nunchaku-strike",
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 30,
+        "accuracy": 60
+      },
+      {
+        "name": "Nunchaku Flurry",
+        "slug": "nunchaku-flurry",
+        "description": "<p>Effect: On hit, the target gains @Affliction[delay 30] and has a 20% chance of gaining a further @Affliction[delay 20] and -1 SPD Stage for 5 Activations.</p>",
+        "traits": [
+          "weapon",
+          "contact",
+          "5-strike",
+          "flinch-10",
+          "crash-1-3"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "variant": "nunchaku-strike",
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 27,
+        "accuracy": 50
+      },
+      {
+        "name": "Nunchaku Lock",
+        "slug": "nunchaku-lock",
+        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[hindered 3]. The user may freely use @UUID[Compendium.ptr2e.core-moves.Item.disarmPuV6qPq9mN] or @UUID[Compendium.ptr2e.core-moves.nZIEKK2aQE5Y53Q4] on the target.</p>",
+        "traits": [
+          "weapon",
+          "contact",
+          "flinch-15",
+          "crash-1-6"
+        ],
+        "type": "attack",
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "variant": "nunchaku-strike",
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "free": true,
+        "predicate": [],
+        "power": 45,
+        "accuracy": 55
+      }
+    ],
+    "description": "<p>The nunchaku is a traditional martial arts weapon consisting of two sticks connected to each other at their ends by a short metal chain or a rope. It is intended to be used as a training weapon, since practicing with it enables the development of quick hand movements and improves posture. Many martial arts use these weapons for locking and striking.</p>",
+    "crafting": {
+      "skill": "",
+      "spans": null,
+      "materials": []
+    },
+    "equipped": {
+      "carryType": "stowed",
+      "slot": "held",
+      "handsHeld": 1
+    },
+    "grade": "E",
+    "fling": {
+      "type": "untyped",
+      "power": 70,
+      "accuracy": 85,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 4,
+        "unit": "m"
+      }
+    },
+    "quantity": 1,
+    "rarity": "uncommon",
+    "ammoType": [],
+    "identification": {
+      "misidentified": null,
+      "status": "identified",
+      "unidentified": {
+        "name": "Unidentified Item",
+        "img": "systems/ptu/css/images/icons/gear_icon.png",
+        "description": "<p>Unidentified Item</p>"
+      }
+    }
+  },
+  "_id": "PDUxZaAyfWlUosRu",
+  "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+  "effects": [
+    {
+      "name": "Nunchaku",
+      "type": "passive",
+      "_id": "Woms3v7e9WyzmMZG",
+      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "value": 5,
+            "phase": "initial",
+            "predicate": [],
+            "key": "nunchaku-strike-attack-damage-flat",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "nunchaku-bash-attack-damage-flat",
+            "value": 2,
+            "phase": "initial",
+            "predicate": [],
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "nunchaku-flurry-attack-damage-flat",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [],
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "value": 3,
+            "phase": "initial",
+            "predicate": [],
+            "key": "nunchaku-lock-attack-damage-flat",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 25,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": -15
+              }
+            ],
+            "dontMerge": false,
+            "key": "nunchaku-strike-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.confusedconditio",
+            "phase": "initial",
+            "predicate": [],
+            "key": "nunchaku-bash-attack",
+            "chance": 15,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 10,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "nunchaku-bash-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": -30
+              }
+            ],
+            "dontMerge": true,
+            "key": "nunchaku-flurry-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": -20
+              }
+            ],
+            "dontMerge": true,
+            "key": "nunchaku-flurry-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.HLAV9dhz632Rfp1K",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "nunchaku-flurry-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.hinderedconditio",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 50,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "key": "nunchaku-lock-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "flat-modifier",
+            "value": 4,
+            "phase": "initial",
+            "predicate": [],
+            "key": "fling-nunchaku-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778679097938,
+        "modifiedTime": 1778679097938,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "folder": "V4skAU6G3OH5fXaf",
+  "flags": {}
+}

--- a/packs/core-gear/silphco-defender-sidearm.json
+++ b/packs/core-gear/silphco-defender-sidearm.json
@@ -20,33 +20,33 @@
       {
         "name": "Defender Shot",
         "slug": "defender-shot",
-        "description": "<p>The SilphCo Defender is a mass-produced sidearm, not known for it's power but certainly for it's reliability.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "traits": [
           "weapon",
-          "ray"
+          "ray",
+          "flinch-10"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "range": {
-          "target": "enemy",
-          "distance": 10,
+          "target": "creature",
+          "distance": 9,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "types": [
           "untyped"
         ],
         "category": "special",
-        "power": 60,
-        "accuracy": 100,
+        "power": 70,
+        "accuracy": 92,
         "free": true,
         "predicate": []
       }
     ],
-    "description": "<p>The SilphCo Defender is a mass-produced sidearm, not known for it's power but certainly for it's reliability.</p>",
+    "description": "<p>The SilphCo Defender is a mass-produced laser sidearm, not particularly known for its output or precision, but is easy to repair and rugged.</p>",
     "crafting": {
       "skill": "Electronics",
       "spans": 8,
@@ -64,7 +64,7 @@
       "type": "untyped",
       "power": 45,
       "accuracy": 90,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 3,
@@ -82,9 +82,6 @@
         "description": "<p>Unidentified Item</p>"
       }
     },
-    "weaponType": "Handgun (Laser)",
-    "weaponPp": 15,
-    "weaponRange": "15",
     "slug": "silphco-defender-sidearm",
     "publication": {
       "source": "PTR 2e Core",
@@ -107,11 +104,12 @@
           {
             "type": "flat-modifier",
             "key": "defender-shot-attack-damage",
-            "value": 5,
+            "value": 9,
             "predicate": [],
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           }
         ],
         "slug": null,
@@ -125,7 +123,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -137,13 +137,17 @@
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.fhfuptGmpadYy37I.ActiveEffect.QO0MYb3X5EGQF0Iv",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "1.5.0.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1758158102085,
-        "modifiedTime": 1767461586862,
-        "lastModifiedBy": "5ImYyhOS2D6D7ypO"
-      }
+        "modifiedTime": 1778622842370,
+        "lastModifiedBy": "dgye2I5sN06rQmNS"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "PhrQtZzEwKPjfmK2",

--- a/packs/core-gear/silphco-laslock-rifle.json
+++ b/packs/core-gear/silphco-laslock-rifle.json
@@ -11,42 +11,43 @@
       "laser",
       "energy-weapon",
       "sci-fi",
-      "charge-pool-18",
       "reload-3",
-      "2-handed"
+      "2-handed",
+      "charge-pool-7"
     ],
     "actions": [
       {
         "name": "Laslock Beam",
         "slug": "laslock-beam",
-        "description": "<p>The SilphCo Laslock is a single-shot rifle that trades out on the convenience of the Defender for a higher power output and thus longer effective range.</p>",
+        "description": "<p>Ammo Use: 1</p>",
         "traits": [
           "weapon",
           "ray",
-          "flinch-25"
+          "flinch-30",
+          "crit-1",
+          "crash-1-6"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "range": {
           "target": "creature",
-          "distance": 25,
+          "distance": 26,
           "unit": "m"
         },
         "cost": {
-          "activation": "complex",
-          "powerPoints": 1
+          "activation": "complex"
         },
         "types": [
           "untyped"
         ],
         "category": "special",
-        "power": 80,
-        "accuracy": 95,
+        "power": 110,
+        "accuracy": 84,
         "free": true,
         "predicate": []
       }
     ],
-    "description": "<p>The SilphCo Laslock is a single-shot rifle that trades out on the convenience of the Defender for a higher power output and thus longer effective range.</p>",
+    "description": "<p>The SilphCo Laslock Rifle is more temperamental and prone to backfires than the Defender, but outputs a really powerful beam at surprising ranges.</p>",
     "crafting": {
       "skill": "Electronics",
       "spans": 8,
@@ -64,7 +65,7 @@
       "type": "untyped",
       "power": 80,
       "accuracy": 80,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 2,
@@ -82,9 +83,6 @@
         "description": "<p>Unidentified Item</p>"
       }
     },
-    "weaponType": "Rifle (Energy)",
-    "weaponPp": 8,
-    "weaponRange": "25",
     "slug": "silphco-laslock-rifle",
     "publication": {
       "source": "PTR 2e Core",
@@ -107,11 +105,12 @@
           {
             "type": "flat-modifier",
             "key": "laslock-beam-attack-damage",
-            "value": 30,
+            "value": 39,
             "predicate": [],
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           }
         ],
         "slug": null,
@@ -125,7 +124,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -137,13 +138,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "1.5.0.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1758158061278,
-        "modifiedTime": 1767461598425,
-        "lastModifiedBy": "5ImYyhOS2D6D7ypO"
-      }
+        "modifiedTime": 1778623288419,
+        "lastModifiedBy": "dgye2I5sN06rQmNS"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "GPebepuiQbZSuf35",

--- a/packs/core-gear/spadroon.json
+++ b/packs/core-gear/spadroon.json
@@ -56,7 +56,7 @@
         "free": true,
         "predicate": [],
         "power": 40,
-        "accuracy": 100
+        "accuracy": 95
       },
       {
         "name": "Spadroon Thrust",
@@ -103,7 +103,7 @@
       "type": "steel",
       "power": 80,
       "accuracy": 90,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 3,
@@ -111,7 +111,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -120,7 +120,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "B",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -139,7 +141,8 @@
             "label": "Spadroon",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -149,7 +152,8 @@
             "label": "Spadroon Thrust",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "basic",
@@ -158,7 +162,8 @@
             "predicate": [],
             "label": "Spadroon (Fling)",
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -172,7 +177,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -184,13 +191,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "VeARUVttJ2hHxFn7"
 }

--- a/packs/core-gear/taser-club.json
+++ b/packs/core-gear/taser-club.json
@@ -18,68 +18,70 @@
       "sci-fi",
       "modern",
       "weapon",
-      "bludgeon",
-      "electric",
-      "contact"
+      "bludgeon"
     ],
     "actions": [
       {
-        "name": "Volt Jolt",
-        "slug": "volt-jolt",
-        "description": "<p>This attack can cause sporadic muscle twitches. It has a 30% chance to inflict @Affliction[tased 5]</p>",
+        "name": "Taser Club Strike",
+        "slug": "taser-club-strike",
+        "description": "<p>Effect: On hit, the target has a 60% chance to gain @Affliction[paralysis 4] and @Affliction[tased 2], and a 30% chance to gain @Affliction[fear 4].</p>",
         "traits": [
           "weapon",
-          "electric",
-          "contact"
+          "contact",
+          "hammer",
+          "flinch-15"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
-        "range": {
-          "target": "enemy",
-          "distance": 1,
-          "unit": "m"
-        },
         "cost": {
           "activation": "complex",
           "powerPoints": 2
+        },
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
         },
         "types": [
           "electric"
         ],
         "category": "physical",
-        "power": 80,
-        "accuracy": 90,
         "free": true,
-        "predicate": []
+        "predicate": [],
+        "power": 80,
+        "accuracy": 93
       },
       {
-        "name": "Capture Prod",
-        "slug": "capture-prod",
-        "description": "<p>The Capture Prod attack has a 30% chance to inflict Paralysis, and cannot reduce the target's HP below 1.</p>",
+        "name": "Taser Club Bash",
+        "slug": "taser-club-strikenqtwp-b8s-qquqk-cvl",
+        "description": "<p>Effect: On hit, the target has a 40% chance to gain @Affliction[paralysis 3] and @Affliction[tased 1], and a 20% chance to gain @Affliction[fear 3].</p>",
         "traits": [
           "weapon",
-          "electric",
-          "contact"
+          "contact",
+          "hammer",
+          "flinch-10",
+          "double-strike"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
-        "range": {
-          "target": "enemy",
-          "distance": 1,
-          "unit": "m"
-        },
         "cost": {
           "activation": "complex",
-          "powerPoints": 2
+          "powerPoints": 1
+        },
+        "variant": "taser-club-strike",
+        "range": {
+          "target": "creature",
+          "distance": 1,
+          "unit": "m"
         },
         "types": [
           "electric"
         ],
         "category": "physical",
-        "power": 100,
-        "accuracy": 80,
         "free": true,
-        "predicate": []
+        "predicate": [],
+        "power": 30,
+        "accuracy": 88
       }
     ],
     "description": "<p>Taser Clubs tend to be used for violent but nonlethal suppression by law enforcement units.</p>",
@@ -98,7 +100,12 @@
       "type": "electric",
       "power": null,
       "accuracy": 100,
-      "hide": false
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 10,
+        "unit": "m"
+      }
     },
     "quantity": 1,
     "rarity": "uncommon",
@@ -110,10 +117,205 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "slug": "taser-club",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
-  "effects": [],
-  "flags": {},
+  "effects": [
+    {
+      "name": "Taser Club",
+      "type": "passive",
+      "_id": "aUbsR9wOffFonosM",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "value": 10,
+            "phase": "initial",
+            "predicate": [],
+            "key": "taser-club-strike-attack-damage",
+            "label": "Club Strike",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "taser-club-bash-attack-damage",
+            "value": 4,
+            "phase": "initial",
+            "predicate": [],
+            "label": "Club Bash",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.paralysisconditi",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 60,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 4
+              }
+            ],
+            "dontMerge": false,
+            "key": "taser-club-strike-attack",
+            "label": "Taser Club (Paralysis)",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.paralysisconditi",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 40,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "key": "taser-club-bash",
+            "label": "Taser Club (Paralysis)",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.tasedcondition00",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 60,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 2
+              }
+            ],
+            "dontMerge": false,
+            "key": "taser-club-strike-attack",
+            "label": "Taser Club (Tased)",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.tasedcondition00",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 40,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 1
+              }
+            ],
+            "dontMerge": false,
+            "key": "taser-club-bash-attack",
+            "label": "Taser Club (Tased)",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.fearcondition000",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 4
+              }
+            ],
+            "dontMerge": false,
+            "key": "taser-club-strike-attack",
+            "label": "Taser Club (Fear)",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.fearcondition000",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "key": "taser-club-bash-attack",
+            "label": "Taser Club (Fear)",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778624725963,
+        "modifiedTime": 1778625368658,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
   "_id": "LSbokvEI2j3nTdO1"
 }

--- a/packs/core-gear/taser.json
+++ b/packs/core-gear/taser.json
@@ -54,18 +54,16 @@
       {
         "name": "Taser Pulse",
         "slug": "taser-pulse",
-        "description": "<p>Trigger: The target has this item's Taser Barbs embedded in them.</p><p>Effect: The target gains @Affliction[paralysis 2] and @Affliction[tased 2], and has a 20% chance to lose -1 ATK, SPATK, and/or EVA Stage.</p>",
+        "description": "<p>Trigger: The target has this item's Taser Barbs embedded in them.</p><p>Effect: The target gains @Affliction[paralysis 2] and @Affliction[tased 2], and has a 20% chance to lose -1 ATK, SPATK, and/or EVA Stage for 5 Activations and gain @Affliction[fear 5].</p><p>Ammo Use: 1</p>",
         "traits": [
           "weapon",
           "pulse",
-          "flinch-10",
-          "impel"
+          "flinch-10"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
         "cost": {
-          "activation": "simple",
-          "powerPoints": 1
+          "activation": "simple"
         },
         "variant": "taser-barb",
         "range": {
@@ -95,7 +93,7 @@
       "type": "untyped",
       "power": null,
       "accuracy": 100,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 10,
@@ -103,7 +101,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -112,7 +110,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "C",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -133,15 +133,16 @@
             "affects": "target",
             "alterations": [
               {
+                "method": 5,
                 "property": "duration.turns",
-                "value": 2,
-                "method": 5
+                "value": 2
               }
             ],
             "dontMerge": false,
             "label": "Taser (Para)",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -153,15 +154,16 @@
             "affects": "target",
             "alterations": [
               {
+                "method": 5,
                 "property": "duration.turns",
-                "value": 2,
-                "method": 5
+                "value": 2
               }
             ],
             "dontMerge": false,
             "label": "Taser (Tased)",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -174,8 +176,9 @@
             "alterations": [],
             "dontMerge": false,
             "label": "Taser (ATK)",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -188,8 +191,9 @@
             "alterations": [],
             "dontMerge": false,
             "label": "Taser (SPATK)",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -202,8 +206,24 @@
             "alterations": [],
             "dontMerge": false,
             "label": "Taser (EVA)",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "taser-pulse-attack",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.fearcondition000",
+            "predicate": [],
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "label": "Taser (Fear)",
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -217,7 +237,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -229,13 +251,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
-        "lastModifiedBy": null
-      }
+        "systemVersion": "1.7.5.beta",
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "createdTime": 1778624395704,
+        "modifiedTime": 1778624509606
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "ZMsKEVb8ZafBwjAE"
 }

--- a/packs/core-gear/tomahawk.json
+++ b/packs/core-gear/tomahawk.json
@@ -113,7 +113,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -122,7 +122,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "D",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -140,7 +142,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -149,7 +152,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -162,7 +166,8 @@
             "alterations": [],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -181,7 +186,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -191,7 +197,8 @@
             "label": "Fling Crit",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -201,7 +208,8 @@
             "label": "Fling Flat",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -220,7 +228,8 @@
             ],
             "dontMerge": true,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -234,7 +243,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -246,13 +257,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "T21hHoncQ807HlTn"
 }

--- a/packs/core-gear/wand-of-barking.json
+++ b/packs/core-gear/wand-of-barking.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -55,7 +55,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-gem-teal.webp",
   "effects": [
@@ -94,7 +95,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -108,7 +110,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -120,14 +124,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "nr6DOkgiSSlgCb1E"

--- a/packs/core-gear/wand-of-buzzing.json
+++ b/packs/core-gear/wand-of-buzzing.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -55,7 +55,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-totem.webp",
   "effects": [
@@ -94,7 +95,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -108,7 +110,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -120,14 +124,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "fgj9BJwPoUm2nkN3"

--- a/packs/core-gear/wand-of-dazzling.json
+++ b/packs/core-gear/wand-of-dazzling.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -55,7 +55,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-star-white.webp",
   "effects": [
@@ -94,7 +95,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -108,7 +110,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -120,14 +124,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "P1ZvKUxpXgJ11uDV"

--- a/packs/core-gear/wand-of-embers.json
+++ b/packs/core-gear/wand-of-embers.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -58,7 +58,8 @@
       ],
       "notes": ""
     },
-    "slug": "wand-of-embers"
+    "slug": "wand-of-embers",
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-carved-fire.webp",
   "effects": [
@@ -97,7 +98,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -111,7 +113,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -123,14 +127,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "tNwiOY8BIRI4lXyw"

--- a/packs/core-gear/wand-of-minds.json
+++ b/packs/core-gear/wand-of-minds.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -55,7 +55,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-simple-eye.webp",
   "effects": [
@@ -94,7 +95,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -108,7 +110,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -120,14 +124,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "bOAfXlj34xx41HJh"

--- a/packs/core-gear/wand-of-mirrors.json
+++ b/packs/core-gear/wand-of-mirrors.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -55,7 +55,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-carved-stone-shard.webp",
   "effects": [
@@ -94,7 +95,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -108,7 +110,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -120,14 +124,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "bkp1jRCIRz4Pw2G3"

--- a/packs/core-gear/wand-of-quartz.json
+++ b/packs/core-gear/wand-of-quartz.json
@@ -42,7 +42,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -59,7 +59,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-gem-red.webp",
   "effects": [
@@ -98,7 +99,8 @@
             "allowDuplicate": true,
             "track": false,
             "replaceSelf": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -112,7 +114,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -124,12 +128,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "lastModifiedBy": "XNKN3zSF1KgrBp5u",
-        "modifiedTime": 1755850836126
-      }
+        "modifiedTime": 1755850836126,
+        "createdTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "_id": "nihsKoS7sY6gJIyJ"

--- a/packs/core-gear/wand-of-sands.json
+++ b/packs/core-gear/wand-of-sands.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -55,7 +55,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-skull-forked.webp",
   "effects": [
@@ -99,7 +100,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -113,7 +115,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -125,14 +129,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "QmwIRbsyw3Lih27N"

--- a/packs/core-gear/wand-of-snowballs.json
+++ b/packs/core-gear/wand-of-snowballs.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -55,7 +55,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-gem-blue.webp",
   "effects": [
@@ -94,7 +95,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -108,7 +110,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -120,14 +124,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "nzaci96Iht4Mh2P7"

--- a/packs/core-gear/wand-of-sprouts.json
+++ b/packs/core-gear/wand-of-sprouts.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -55,7 +55,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-crook-yellow.webp",
   "effects": [
@@ -99,7 +100,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -113,7 +115,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -125,14 +129,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "c8MVtToR9sfwagv2"

--- a/packs/core-gear/wand-of-toxins.json
+++ b/packs/core-gear/wand-of-toxins.json
@@ -42,7 +42,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -59,7 +59,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-gem-violet.webp",
   "effects": [
@@ -103,7 +104,8 @@
             "allowDuplicate": true,
             "track": false,
             "replaceSelf": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -117,7 +119,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -129,12 +133,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "lastModifiedBy": "XNKN3zSF1KgrBp5u",
-        "modifiedTime": 1755850672487
-      }
+        "modifiedTime": 1755850672487,
+        "createdTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "_id": "BD8kP4HEY5UdCDVK"

--- a/packs/core-gear/wand-of-umbra.json
+++ b/packs/core-gear/wand-of-umbra.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -55,7 +55,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-gem-purple.webp",
   "effects": [
@@ -94,7 +95,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -108,7 +110,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -120,14 +124,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "Aylv8pQ7kIoSm43o"

--- a/packs/core-gear/wand-of-wet.json
+++ b/packs/core-gear/wand-of-wet.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -55,7 +55,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-gem-blue.webp",
   "effects": [
@@ -94,7 +95,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -108,7 +110,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -120,14 +124,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "Wmj6FfXipcJ15OVa"

--- a/packs/core-gear/wand-of-zap.json
+++ b/packs/core-gear/wand-of-zap.json
@@ -38,7 +38,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -55,7 +55,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "ammoType": []
   },
   "img": "icons/weapons/wands/wand-skull-feathers.webp",
   "effects": [
@@ -94,7 +95,8 @@
               "grantee": "detach",
               "granter": "cascade"
             },
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -108,7 +110,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -120,14 +124,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.0.0.beta-ready.2",
         "createdTime": null,
         "modifiedTime": null,
         "lastModifiedBy": null,
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "_id": "x80jKAigGR0RdKFs"

--- a/packs/core-gear/war-club.json
+++ b/packs/core-gear/war-club.json
@@ -9,8 +9,10 @@
     },
     "slug": "war-club",
     "publication": {
-      "source": "",
-      "authors": [],
+      "source": "PTR 2e Core",
+      "authors": [
+        "PTR 2e Team"
+      ],
       "notes": ""
     },
     "traits": [
@@ -72,7 +74,7 @@
       "type": "untyped",
       "power": 90,
       "accuracy": 80,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 2,
@@ -80,7 +82,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -89,7 +91,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "D",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -108,7 +112,8 @@
             "label": "War Club",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -127,7 +132,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -141,7 +147,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -153,13 +161,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
-        "lastModifiedBy": null
-      }
+        "lastModifiedBy": null,
+        "createdTime": null,
+        "modifiedTime": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "PTU8yGUWH8HwSQU0"
 }

--- a/packs/core-gear/whip.json
+++ b/packs/core-gear/whip.json
@@ -29,15 +29,14 @@
       {
         "name": "Whip Strike",
         "slug": "whip-strike",
-        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[delay 30]. On a Critical Hit, the target gains @Affliction[bleed 5].</p>",
+        "description": "<p>Effect: On hit, the target has a 30% chance of gaining @Affliction[delay 30] and @Affliction[fear 2]. On a Critical Hit, the target gains @Affliction[bleed 5] and @Affliction[fear 3].</p>",
         "traits": [
           "weapon",
           "adaptable",
           "contact",
           "missile",
           "crit-1",
-          "flinch-10",
-          "impel"
+          "flinch-10"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -61,15 +60,14 @@
       {
         "name": "Whip Lash",
         "slug": "whip-lash",
-        "description": "<p>Effect: On hit, the target gains @Affliction[delay 30] and has a 30% chance of gaining @Affliction[bleed 5] and a further @Affliction[delay 30]. On a Critical Hit, the target loses -1 random Stat Stage for 5 Activations, and has a 30% chance of gaining @Affliction[splinter 5].</p>",
+        "description": "<p>Effect: On hit, the target gains @Affliction[delay 20] and @Affliction[fear 1], and has a 30% chance of gaining @Affliction[bleed 5] and a further @Affliction[delay 30] and @Affliction[fear 2]. On a Critical Hit, the target gains @Affliction[fear 3] and has a 30% chance of gaining @Affliction[splinter 5].</p>",
         "traits": [
           "weapon",
           "adaptable",
           "contact",
           "missile",
           "crit-1",
-          "flinch-30",
-          "impel"
+          "flinch-25"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -94,14 +92,13 @@
       {
         "name": "Whip Bind",
         "slug": "whip-bind",
-        "description": "<p>Effect: On hit, the target is @Affliction[bound], and the user automatically succeeds with a @Affliction[grapple] against the target. The target is @Affliction[hindered] and has -1 default ACC while @Affliction[bound], and can only be cured of @Affliction[bound] as a Free Action while this item is not Held or the target escapes the Grapple.</p>",
+        "description": "<p>Effect: On hit, the target is @Affliction[grapple] and @Affliction[bound]. The target is @Affliction[hindered] while @Affliction[bound], and can be cured of @Affliction[bound] as a Free Action @Trait[interrupt] while this item is not Held by the user, or if the target escapes the Grapple.</p>",
         "traits": [
           "weapon",
           "adaptable",
           "contact",
           "missile",
-          "flinch-10",
-          "impel"
+          "flinch-20"
         ],
         "type": "attack",
         "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -146,7 +143,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "common",
+    "rarity": "rare",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -155,7 +152,9 @@
         "img": "systems/ptu/css/images/icons/gear_icon.png",
         "description": "<p>Unidentified Item</p>"
       }
-    }
+    },
+    "grade": "D",
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -172,9 +171,10 @@
             "value": 3,
             "predicate": [],
             "label": "Whip",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "roll-effect",
@@ -186,15 +186,37 @@
             "affects": "target",
             "alterations": [
               {
+                "method": 5,
                 "property": "system.amount",
-                "value": -20,
-                "method": 5
+                "value": -20
               }
             ],
             "dontMerge": false,
             "label": "Delay",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.fearcondition000",
+            "phase": "initial",
+            "predicate": [],
+            "label": "Fear",
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 2
+              }
+            ],
+            "dontMerge": false,
+            "key": "whip-strike-attack",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -207,8 +229,30 @@
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.fearcondition000",
+            "phase": "initial",
+            "predicate": [],
+            "label": "Fear",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "key": "whip-strike-attack-crit",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "flat-modifier",
@@ -216,9 +260,10 @@
             "value": 5,
             "predicate": [],
             "label": "Lash",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "roll-effect",
@@ -230,15 +275,37 @@
             "affects": "target",
             "alterations": [
               {
+                "method": 5,
                 "property": "system.amount",
-                "value": -30,
-                "method": 5
+                "value": -20
               }
             ],
             "dontMerge": false,
             "label": "Auto Delay",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.fearcondition000",
+            "phase": "initial",
+            "predicate": [],
+            "label": "Auto Fear",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 1
+              }
+            ],
+            "dontMerge": true,
+            "key": "whip-lash-attack",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -250,15 +317,16 @@
             "affects": "target",
             "alterations": [
               {
+                "method": 5,
                 "property": "system.amount",
-                "value": -30,
-                "method": 5
+                "value": -30
               }
             ],
             "dontMerge": false,
             "label": "Delay",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -270,13 +338,35 @@
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
-            "label": "Lash Bleed",
-            "ignored": false,
-            "method": 2
+            "label": "Bleed",
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
-            "key": "whip-lash-crit",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.fearcondition000",
+            "phase": "initial",
+            "predicate": [],
+            "label": "Fear",
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 2
+              }
+            ],
+            "dontMerge": false,
+            "key": "whip-lash-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "whip-lash-attack-crit",
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.splinterconditio",
             "predicate": [],
             "chance": 30,
@@ -285,8 +375,30 @@
             "alterations": [],
             "dontMerge": false,
             "label": "Lash Splinter",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.fearcondition000",
+            "phase": "initial",
+            "predicate": [],
+            "label": "Fear",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": true,
+            "key": "whip-lash-attack-crit",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -299,8 +411,9 @@
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -313,8 +426,9 @@
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -328,7 +442,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -340,13 +456,18 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
-        "lastModifiedBy": null
-      }
+        "systemVersion": "1.7.5.beta",
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "createdTime": 1778679579227,
+        "modifiedTime": 1778680345979
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
-  "flags": {},
   "_id": "WmEtmDZ28GjmyFNW"
 }

--- a/packs/core-gear/xernean-longbow.json
+++ b/packs/core-gear/xernean-longbow.json
@@ -8,9 +8,13 @@
     },
     "traits": [
       "weapon",
-      "bow",
+      "fairy",
+      "charge-pool-12",
+      "reload-2",
       "fantasy",
-      "fairy"
+      "2-handed",
+      "projectile",
+      "arcane"
     ],
     "actions": [
       {
@@ -70,9 +74,74 @@
         "defensiveStat": "spd",
         "predicate": [],
         "free": true
+      },
+      {
+        "name": "Xernean Longbow Shot",
+        "slug": "xernean-shot",
+        "traits": [
+          "weapon",
+          "missile",
+          "adaptable",
+          "readied",
+          "flinch-10"
+        ],
+        "type": "attack",
+        "range": {
+          "target": "creature",
+          "distance": 45,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "power": 150,
+        "accuracy": 85,
+        "free": true,
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "predicate": [],
+        "description": "<p>Ammo Use: 1</p>"
+      },
+      {
+        "name": "Xernean Light Arrow",
+        "slug": "xernean-light-arrow",
+        "traits": [
+          "weapon",
+          "missile",
+          "ray",
+          "arcane",
+          "readied",
+          "flinch-35"
+        ],
+        "type": "attack",
+        "range": {
+          "target": "creature",
+          "distance": 45,
+          "unit": "m"
+        },
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "physical",
+        "power": 195,
+        "accuracy": 90,
+        "free": true,
+        "img": "systems/ptr2e/img/icons/weapon_icon.webp",
+        "predicate": [],
+        "description": "<p>Effect: On hit, the target loses @Tick[-3 shield].</p><p>Ammo Use: 1</p>",
+        "variant": "xernean-shot",
+        "offensiveStat": "spa",
+        "defensiveStat": "spd"
       }
     ],
-    "description": "<p>A bow crafted from the shedding of the Horns of Xerneas. It has a faint pearl sheen that becomes a soft glow in the light of the moon.</p>",
+    "description": "<p>A longbow crafted from the sheddings of the Xerneas's antlers. It has a faint pearl sheen that becomes a soft glow in the light of the moon. The longbow possesses numerous magical properties, and enchants the arrows it fires.</p>",
     "crafting": {
       "skill": "",
       "spans": null,
@@ -80,18 +149,23 @@
     },
     "equipped": {
       "carryType": "equipped",
-      "handsHeld": null,
+      "handsHeld": 2,
       "slot": "held"
     },
     "grade": "A",
     "fling": {
       "type": "fairy",
       "power": 60,
-      "accuracy": 100,
-      "hide": false
+      "accuracy": 80,
+      "hide": true,
+      "range": {
+        "target": "creature",
+        "distance": 3,
+        "unit": "m"
+      }
     },
     "quantity": 1,
-    "rarity": "rare",
+    "rarity": "unique",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -106,38 +180,166 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
-    }
+      ],
+      "notes": ""
+    },
+    "ammoType": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
     {
       "name": "Xernean Longbow",
       "type": "passive",
-      "_id": "TqpfXm3BqL5WpcUW",
+      "_id": "QJMubwOeMMbZ38LO",
       "img": "systems/ptr2e/img/icons/effect_icon.webp",
       "system": {
         "changes": [
           {
-            "type": "basic",
-            "key": "system.attributes.atk.value",
-            "value": 25,
+            "type": "stats-alteration",
+            "value": 0,
+            "phase": "initial",
             "predicate": [],
-            "priority": null,
+            "hp": null,
+            "atk": 10,
+            "def": 5,
+            "spa": 10,
+            "spd": 5,
+            "spe": null,
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "flat-modifier",
+            "key": "xernean-shot-attack-damage-flat",
+            "value": "23+ceil(@actor.system.advancement.level/10)",
+            "predicate": [],
+            "label": "Xernean Longbow Shot",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "method": 2
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.auJlcV40ua09ITga",
+            "phase": "initial",
+            "predicate": [],
+            "key": "xernean-shot-attack",
+            "affects": "self",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 15
+              }
+            ],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "flat-modifier",
+            "value": "31+ceil(@actor.system.advancement.level/5)",
+            "phase": "initial",
+            "predicate": [],
+            "label": "Light Arrow",
+            "key": "xernean-light-arrow-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.auJlcV40ua09ITga",
+            "phase": "initial",
+            "predicate": [],
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 40
+              }
+            ],
+            "key": "xernean-light-arrow-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "stage-modifier",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "target:trait:dark"
+            ],
+            "key": "xernean-light-arrow-attack-effectiveness-stage",
+            "label": "Light Arrow (Evil-Slaying)",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "stage-modifier",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "target:trait:dragon"
+            ],
+            "key": "xernean-light-arrow-attack-effectiveness-stage",
+            "label": "Light Arrow (Wyrm-Slaying)",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "stage-modifier",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "target:trait:fighting"
+            ],
+            "key": "xernean-light-arrow-attack-effectiveness-stage",
+            "label": "Light Arrow (Hero-Slaying)",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.k1FukpHKnZGqjSNc",
+            "phase": "initial",
+            "predicate": [],
+            "key": "xernean-light-arrow-attack",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": -3
+              }
+            ],
+            "dontMerge": true,
+            "label": "Light Arrow (Barrier-Rending)",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
         "stacks": 0
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -145,17 +347,21 @@
       "transfer": true,
       "statuses": [],
       "sort": 0,
-      "flags": {},
       "_stats": {
-        "compendiumSource": null,
+        "compendiumSource": "Compendium.ptr2e.core-gear.Item.kcONNhYYQmn2dEKX.ActiveEffect.6wnrC0ZO9DLyoep9",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "exportSource": null,
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.5",
-        "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
-      }
+        "systemVersion": "1.7.5.beta",
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "modifiedTime": 1778683856721,
+        "createdTime": 1778682480219
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "Tn65RZTafVbxqEXT",

--- a/packs/core-gear/zweihander.json
+++ b/packs/core-gear/zweihander.json
@@ -175,12 +175,12 @@
       "handsHeld": 2,
       "slot": "held"
     },
-    "grade": "D",
+    "grade": "B",
     "fling": {
       "type": "untyped",
       "power": 100,
       "accuracy": 65,
-      "hide": false,
+      "hide": true,
       "range": {
         "target": "creature",
         "distance": 2,
@@ -188,7 +188,7 @@
       }
     },
     "quantity": 1,
-    "rarity": "rare",
+    "rarity": "uncommon",
     "identification": {
       "misidentified": null,
       "status": "identified",
@@ -205,7 +205,8 @@
       ],
       "notes": ""
     },
-    "description": "<p>The zweihander is a large two-handed sword and is considered the final stage in the trend of making very large swords, offering many of the benefits of polearms in the process.</p>"
+    "description": "<p>The zweihander is a large two-handed sword and is considered the final stage in the trend of making very large swords, offering many of the benefits of polearms in the process.</p>",
+    "ammoType": []
   },
   "_id": "MXMKNrLaYJsoTetc",
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
@@ -225,7 +226,8 @@
             "label": "Zweihander",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -235,7 +237,8 @@
             "label": "Thrust",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -245,7 +248,8 @@
             "label": "Cleave",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -255,7 +259,8 @@
             "label": "Half-Swing",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -265,7 +270,8 @@
             "label": "Half-Thrust",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "flat-modifier",
@@ -275,7 +281,8 @@
             "label": "Zweihander (Fling)",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -294,7 +301,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -308,7 +316,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -320,13 +330,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.3.beta",
         "createdTime": 1757549013437,
         "modifiedTime": 1757549551240,
         "lastModifiedBy": "UTlFSVhgfIUeTsoW"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }


### PR DESCRIPTION
Also adds new weapon: Nunchaku.
- Update Weapon: Nunchaku
- Update Weapon: SilphCo Defender Sidearm
- Update Weapon: SilphCo Laslock Rifle
- Update Weapon: Spadroon
- Update Weapon: Taser
- Update Weapon: Taser Club
- Update Weapon: Tomahawk
- Update Weapon: War Club
- Update Weapon: Whip
- Update Weapon: Zweihander
- Update Weapon: Highland Thistle
- Update Weapon: Xernean Longbow
- Update Weapon: Wand of Zap
- Update Weapon: Wand of Wet
- Update Weapon: Wand of Umbra
- Update Weapon: Wand of Toxins
- Update Weapon: Wand of Sprouts
- Update Weapon: Wand of Snowballs
- Update Weapon: Wand of Sands
- Update Weapon: Wand of Quartz
- Update Weapon: Wand of Mirrors
- Update Weapon: Wand of Minds
- Update Weapon: Wand of Embers
- Update Weapon: Wand of Dazzling
- Update Weapon: Wand of Buzzing
- Update Weapon: Wand of Barking