### PR TITLE
Foundry Data Sync - Bulk Ability Touch Up

### DIFF
--- a/packs/core-abilities/abyssal-claw.json
+++ b/packs/core-abilities/abyssal-claw.json
@@ -16,7 +16,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user's damaging Dark-Type attacks that would deal Resisted damage instead deal neutral damage.</p>",
         "img": "icons/svg/explosion.svg"
@@ -35,9 +36,69 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "0iXEYSi51p8NOksg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Abyssal Claw",
+      "type": "passive",
+      "_id": "r9B8M1QkEmUXW5kM",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "effectiveness:resisted"
+            ],
+            "key": "dark-attack-effectiveness-stage",
+            "label": "Abyssal Claw",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778665249302,
+        "modifiedTime": 1778665377149,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/aerodynamic.json
+++ b/packs/core-abilities/aerodynamic.json
@@ -20,10 +20,11 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Trigger: The user is hit by a Flying-Type and/or [Wind] attack.</p><p>Effect: The user takes no damage from the attack and is unaffected by the attack's effects. The user gains +1 SPD Stage for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/svg/flying_icon.svg"
       },
       {
         "traits": [
@@ -53,9 +54,146 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "E4v9kg43PkxWINRi",
-  "effects": []
+  "effects": [
+    {
+      "name": "Aerodynamic",
+      "type": "passive",
+      "_id": "2i6dB1dA193wgBd4",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "add-trait",
+            "value": "flying",
+            "phase": "initial",
+            "predicate": [
+              "effect:summon:windy-weather"
+            ],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.attributes.spe.stage",
+            "value": 1,
+            "predicate": [
+              "effect:summon:windy-weather"
+            ],
+            "priority": null,
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.flight.value",
+            "value": 3,
+            "phase": "initial",
+            "predicate": [
+              "effect:summon:windy-weather"
+            ],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "value": -10000,
+            "phase": "initial",
+            "predicate": [],
+            "key": "flying-attack-damage-percentile",
+            "label": "Flying DR",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-note",
+            "value": "Hit by Flying? {actor|link} can use Aerodynamic",
+            "phase": "initial",
+            "predicate": [],
+            "key": "flying-attack",
+            "visibility": null,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-note",
+            "value": "Hit by Wind? {actor|link} can use Aerodynamic",
+            "phase": "initial",
+            "predicate": [],
+            "key": "wind-trait-attack",
+            "visibility": null,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.XeiSuS3APUcN0MLM",
+            "phase": "initial",
+            "predicate": [],
+            "key": "aerodynamic-generic",
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "value": -100000,
+            "phase": "initial",
+            "predicate": [],
+            "key": "wind-trait-attack-damage-percentile",
+            "label": "Wind DR",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778665490747,
+        "modifiedTime": 1778666553479,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/amplifier.json
+++ b/packs/core-abilities/amplifier.json
@@ -16,16 +16,15 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user's [Sonic] attacks have 30% more Power and have their Range increased by 50%.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Effect: The user's [Sonic] attacks have 30% more Power and have their Range increased by 50%.</p>",
-    "traits": [
-      "partial-automation"
-    ],
+    "traits": [],
     "slug": "amplifier",
     "_migration": {
       "version": null,
@@ -35,13 +34,14 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "8GEZyBul46p9V0Fn",
   "effects": [
     {
-      "name": "Amplifier (Partial)",
+      "name": "Amplifier",
       "type": "passive",
       "_id": "CX3EyE55W72ME7gi",
       "img": "icons/magic/sonic/projectile-sound-rings-wave.webp",
@@ -54,21 +54,37 @@
             "predicate": [],
             "label": "Amplifier Power",
             "priority": null,
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
+          },
+          {
+            "type": "alter-attack",
+            "value": 1.5,
+            "phase": "initial",
+            "predicate": [],
+            "property": "range",
+            "definition": [],
+            "method": 1,
+            "key": "sonic-trait-attack",
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -80,13 +96,17 @@
       "_stats": {
         "compendiumSource": "Actor.zshgfm9Ey2yqW8eS.Item.vdWAkG4TbIs3apAy.ActiveEffect.l6pjnn54jiTqHOwt",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.4.1.0",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1721934790549,
-        "modifiedTime": 1732924055746,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+        "modifiedTime": 1778665958772,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/anger-shell.json
+++ b/packs/core-abilities/anger-shell.json
@@ -18,13 +18,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: An attack is resolved against the user and the user meets the [Desperation 1/2] Condition.</p><p>Effect: The user gains +1 ATK, SPATK, and SPD Stages and loses -1 DEF and SPDEF Stages for 5 Activations.</p>",
+        "description": "<p>Trigger: The user enters the @Trait[desperation-1-2] state.</p><p>Effect: The user gains +1 ATK, SPATK, and SPD Stages and loses -1 DEF and SPDEF Stages for 5 Activations.</p>",
         "img": "icons/commodities/biological/shell-turtle-grey.webp"
       }
     ],
-    "description": "<p>Trigger: The user drops below 50% HP due to damage from a Physical- or Special-Category Attack.</p><p>Effect: The user gains +1 ATK, SPATK, and SPD Stages and loses -1 DEF and SPDEF Stages for 5 Activations.</p>",
+    "description": "<p>Trigger: The user enters the @Trait[desperation-1-2] state.</p><p>Effect: The user gains +1 ATK, SPATK, and SPD Stages and loses -1 DEF and SPDEF Stages for 5 Activations.</p>",
     "traits": [
       "desperation-1-2"
     ],
@@ -60,8 +61,9 @@
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -73,8 +75,9 @@
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -86,8 +89,9 @@
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -99,8 +103,9 @@
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -112,8 +117,19 @@
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-note",
+            "value": "{actor|link} can use {item|link}.",
+            "phase": "initial",
+            "predicate": [],
+            "key": "desperation-1-2",
+            "visibility": null,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -127,7 +143,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -140,13 +158,16 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.1.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1753709454653,
-        "modifiedTime": 1753710413472,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1778666141355,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/antivenom.json
+++ b/packs/core-abilities/antivenom.json
@@ -11,10 +11,9 @@
         ],
         "name": "Antivenom",
         "slug": "antivenom",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
           "trigger": "<p>The user is hit by a Poison-Type attack.</p>"
         },
         "range": {
@@ -22,7 +21,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user is hit by a Poison-Type attack.</p><p>Effect: The user takes no damage from the triggering attack, and the triggering attack's effects are not applied. Then the user's ATK Stage is raised by +1 for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/magic/life/cross-embers-glow-yellow-purple.webp"
       }
     ],
     "description": "<p>Trigger: The user is hit by a Poison-Type attack.</p><p>Effect: The user takes no damage from the triggering attack, and the triggering attack's effects are not applied. Then the user's ATK Stage is raised by +1 for 5 Activations.</p>",
@@ -38,9 +37,81 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "yxyhfm7SV6MjnhqQ",
-  "effects": []
+  "effects": [
+    {
+      "name": "Antivenom",
+      "type": "passive",
+      "_id": "zmHWpu4DfiAWSI0m",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "value": -100000,
+            "phase": "initial",
+            "predicate": [],
+            "key": "poison-attack-damage-percentile",
+            "label": "Antivenom",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.ZGwaMlzUwkSuCPyH",
+            "phase": "initial",
+            "predicate": [],
+            "key": "poison-attack",
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778666234079,
+        "modifiedTime": 1778666648781,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/benevolence.json
+++ b/packs/core-abilities/benevolence.json
@@ -21,11 +21,11 @@
           "distance": 10,
           "unit": "m"
         },
-        "description": "<p>Effect: The target heals two Ticks of HP at the end of their Activations, for the next 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The target gains @Affliction[regen 5] (Upgraded to 2 Ticks).</p>",
+        "img": "icons/magic/life/cross-area-circle-green-white.webp"
       }
     ],
-    "description": "<p>Effect: The target heals two Ticks of HP at the end of their Activations, for the next 5 Activations.</p>",
+    "description": "<p>Effect: The target gains @Affliction[regen 5] (Upgraded to 2 Ticks).</p>",
     "traits": [
       "healing",
       "aura"
@@ -69,7 +69,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -83,7 +84,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -96,13 +99,16 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.1.beta",
         "createdTime": 1753714386137,
         "modifiedTime": 1753714433186,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/bone-zone.json
+++ b/packs/core-abilities/bone-zone.json
@@ -17,11 +17,11 @@
           "unit": "m",
           "distance": 10
         },
-        "description": "<p>Effect: The user's [Bone] attacks are resisted one step less, and deal neutral damage to creatures normally immune.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user's [Bone] attacks gain +1 Effectiveness Stage and the @Trait[ignore-type-immunity] trait.</p>",
+        "img": "icons/commodities/bones/bone-simple-white-pink.webp"
       }
     ],
-    "description": "<p>Effect: The user's [Bone] attacks are resisted one step less, and deal neutral damage to creatures normally immune.</p>",
+    "description": "<p>Effect: The user's [Bone] attacks gain +1 Effectiveness Stage and the @Trait[ignore-type-immunity] trait.</p>",
     "traits": [],
     "slug": "bone-zone",
     "_migration": {
@@ -52,7 +52,8 @@
             "predicate": [],
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "alter-attack",
@@ -63,7 +64,8 @@
             "property": "traits",
             "definition": [],
             "priority": null,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -77,7 +79,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -89,13 +93,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
         "createdTime": 1765238292887,
         "modifiedTime": 1765238353476,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-abilities/capoeira.json
+++ b/packs/core-abilities/capoeira.json
@@ -14,16 +14,15 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user's [Kick] Attacks also have [Dance], and the user's [Dance] Attacks have their Power increased by 30%.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Effect: The user's [Kick] Attacks also have [Dance], and the user's [Dance] Attacks have their Power increased by 30%.</p>",
-    "traits": [
-      "partial-automation"
-    ],
+    "traits": [],
     "slug": "capoeira",
     "_migration": {
       "version": null,
@@ -33,7 +32,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "ziFVuKuam7P7iQIP",
@@ -52,21 +52,37 @@
             "predicate": [],
             "label": "Capoeira",
             "priority": null,
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "dance",
+            "phase": "initial",
+            "predicate": [],
+            "property": "traits",
+            "definition": [],
+            "key": "kick-trait-attack",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -78,13 +94,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.2.0.3",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1722258477245,
-        "modifiedTime": 1722258506869,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+        "modifiedTime": 1778667741045,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/capoeira.json
+++ b/packs/core-abilities/capoeira.json
@@ -21,7 +21,7 @@
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Effect: The user's [Kick] Attacks also have [Dance], and the user's [Dance] Attacks have their Power increased by 30%.</p>",
+    "description": "<p>Effect: The user's @Trait[kick] Attacks also have @Trait[dance], and the user's @Trait[dance] Attacks have their Power increased by 30%.</p>",
     "traits": [],
     "slug": "capoeira",
     "_migration": {

--- a/packs/core-abilities/cascade.json
+++ b/packs/core-abilities/cascade.json
@@ -14,13 +14,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Effect: The user's [X-Strike] attacks gain +30% Power.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user's @Trait[x-strike] & @Trait[double-strike] attacks gain +30% Power.</p>",
+        "img": "icons/skills/melee/strikes-sword-triple-gray.webp"
       }
     ],
-    "description": "<p>Effect: The user's [X-Strike] attacks gain +30% Power.</p>",
+    "description": "<p>Effect: The user's @Trait[x-strike] & @Trait[double-strike] attacks gain +30% Power.</p>",
     "traits": [],
     "slug": "cascade",
     "_migration": {
@@ -31,9 +32,76 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "1LD7gNdEIVRuzhDz",
-  "effects": []
+  "effects": [
+    {
+      "name": "Cascade",
+      "type": "passive",
+      "_id": "LZ6oePEPBuZoTnx1",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "x-strike-trait-attack-power",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "percentile-modifier",
+            "key": "double-strike-trait-attack-power",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778667802652,
+        "modifiedTime": 1778667842361,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/caustic-heat.json
+++ b/packs/core-abilities/caustic-heat.json
@@ -10,10 +10,9 @@
         ],
         "name": "Caustic Heat",
         "slug": "caustic-heat",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
           "trigger": "<p>The user applies either @Affliction[burn] or @Affliction[poison].</p>"
         },
         "range": {
@@ -22,7 +21,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user applies either @Affliction[burn] or @Affliction[poison].</p><p>Effect: The user applies both @Affliction[burn] and @Affliction[poison] for an equal number of Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/creatures/abilities/dragon-breath-purple.webp"
       }
     ],
     "description": "<p>Trigger: The user applies either @Affliction[burn] or @Affliction[poison].</p><p>Effect: The user applies both @Affliction[burn] and @Affliction[poison] for an equal number of Activations.</p>",
@@ -36,9 +35,84 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "XyQjHFI7YWwYvw5G",
-  "effects": []
+  "effects": [
+    {
+      "name": "Caustic Heat",
+      "type": "passive",
+      "_id": "AuYxD1C8Xvqm4erT",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.poisoncondition0",
+            "phase": "initial",
+            "predicate": [],
+            "key": "burn-applied",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.burncondition000",
+            "phase": "initial",
+            "predicate": [],
+            "key": "poison-applied",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778667935062,
+        "modifiedTime": 1778668006706,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/celestial-blessing.json
+++ b/packs/core-abilities/celestial-blessing.json
@@ -16,7 +16,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: While affected by Misty Terrain is active, user gains two Ticks of HP at the end of each of their Activations.</p>",
         "img": "icons/svg/explosion.svg"
@@ -51,9 +52,61 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "vENE76PY6PxQxMVX",
-  "effects": []
+  "effects": [
+    {
+      "name": "Celestial Blessing",
+      "type": "affliction",
+      "_id": "drUhAeDqaWf4tAH1",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/8",
+        "type": "healing",
+        "predicate": [
+          "effect:summon:misty-terrain"
+        ]
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778668102594,
+        "modifiedTime": 1778668128601,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/cheek-pouch.json
+++ b/packs/core-abilities/cheek-pouch.json
@@ -6,8 +6,7 @@
     "actions": [],
     "description": "<p>Effect: Whenever the user consumes a @Trait[food] item, they recover @Tick[5] in addition to the @Trait[food] item's effect.</p><p>Passive: The user possesses an additional @Trait[belt], which can only be filled by a @Trait[food] item.<br><br>Connection: Stuff Cheeks.</p>",
     "traits": [
-      "healing",
-      "partial-automation"
+      "healing"
     ],
     "slug": "cheek-pouch",
     "_migration": {
@@ -33,7 +32,6 @@
         "changes": [
           {
             "type": "grant-item",
-            "key": "",
             "value": "Compendium.ptr2e.core-moves.Item.QJjxOISEcfO0vgmP",
             "predicate": [
               "ability:cheek-pouch:active"
@@ -41,9 +39,9 @@
             "allowDuplicate": false,
             "alterations": [
               {
+                "method": 5,
                 "property": "system.actions.0.free",
-                "value": "true",
-                "method": 5
+                "value": "true"
               }
             ],
             "priority": null,
@@ -52,11 +50,42 @@
               "granter": "cascade"
             },
             "reevaluateOnUpdate": true,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
             "inMemoryOnly": false,
             "track": false,
-            "replaceSelf": false,
-            "method": 2
+            "replaceSelf": false
+          },
+          {
+            "type": "basic",
+            "key": "system.inventory.belt.max",
+            "value": 2,
+            "phase": "initial",
+            "predicate": [],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 5
+              }
+            ],
+            "dontMerge": false,
+            "key": "food-trait-generic",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -70,7 +99,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -82,14 +113,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.2.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1739566976681,
-        "modifiedTime": 1754317052231,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1778668310167,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/coil-up.json
+++ b/packs/core-abilities/coil-up.json
@@ -13,7 +13,6 @@
         "type": "generic",
         "cost": {
           "activation": "free",
-          "powerPoints": 0,
           "trigger": "<p>The user enters combat.</p>"
         },
         "range": {
@@ -53,16 +52,15 @@
         "changes": [
           {
             "type": "grant-item",
-            "key": "",
             "value": "Compendium.ptr2e.core-moves.Item.7r57DxIctmNSW2oV",
             "predicate": [
               "ability:coil-up:active"
             ],
             "alterations": [
               {
+                "method": 5,
                 "property": "system.actions.0.free",
-                "value": "true",
-                "method": 5
+                "value": "true"
               }
             ],
             "priority": null,
@@ -72,11 +70,23 @@
               "granter": "cascade"
             },
             "reevaluateOnUpdate": true,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
             "inMemoryOnly": false,
             "track": false,
-            "replaceSelf": false,
-            "method": 2
+            "replaceSelf": false
+          },
+          {
+            "type": "roll-note",
+            "value": "{actor|link} enters combat and may spend {item|actions.contents.0.cost.powerPoints} PP to use {item|link}!",
+            "phase": "initial",
+            "predicate": [],
+            "visibility": null,
+            "key": "combat-enter",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -90,7 +100,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -102,14 +114,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.2.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737395090460,
-        "modifiedTime": 1754317311793,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1778668507477,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/cold-rebound.json
+++ b/packs/core-abilities/cold-rebound.json
@@ -55,16 +55,15 @@
         "changes": [
           {
             "type": "grant-item",
-            "key": "",
             "value": "Compendium.ptr2e.core-moves.Item.YoLEpica6f4PLgWO",
             "predicate": [
               "ability:cold-rebound:active"
             ],
             "alterations": [
               {
+                "method": 5,
                 "property": "system.actions.0.free",
-                "value": "true",
-                "method": 5
+                "value": "true"
               }
             ],
             "priority": null,
@@ -74,11 +73,23 @@
               "granter": "cascade"
             },
             "allowDuplicate": false,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
             "inMemoryOnly": false,
             "track": false,
-            "replaceSelf": false,
-            "method": 2
+            "replaceSelf": false
+          },
+          {
+            "type": "roll-note",
+            "value": "Hit by a Contact Move? {actor|link} can use {item|link}.",
+            "phase": "initial",
+            "predicate": [],
+            "key": "contact-trait-attack",
+            "visibility": null,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -92,7 +103,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -104,14 +117,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.2.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737395182970,
-        "modifiedTime": 1754317340889,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1778668599705,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/coldflame.json
+++ b/packs/core-abilities/coldflame.json
@@ -8,10 +8,9 @@
         "traits": [],
         "name": "Coldflame",
         "slug": "coldflame",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
           "trigger": "<p>The user applies either @Affliction[burn] or @Affliction[frostbite].</p>"
         },
         "range": {
@@ -20,7 +19,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user applies either @Affliction[burn] or @Affliction[frostbite].</p><p>Effect: The user applies both @Affliction[burn] and @Affliction[frostbite] for an equal number of Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/magic/fire/projectile-fireball-smoke-strong-teal.webp"
       }
     ],
     "description": "<p>Trigger: The user applies either @Affliction[burn] or @Affliction[frostbite].</p><p>Effect: The user applies both @Affliction[burn] and @Affliction[frostbite] for an equal number of Activations.</p>",
@@ -34,9 +33,84 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "fmuCUbeLJbHsVIMM",
-  "effects": []
+  "effects": [
+    {
+      "name": "Coldflame",
+      "type": "passive",
+      "_id": "FEN9eshUwEbYoR9Y",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.frostbiteconditi",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "burn-applied",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.burncondition000",
+            "phase": "initial",
+            "predicate": [],
+            "key": "frostbite-applied",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778669406056,
+        "modifiedTime": 1778669464744,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/competitive.json
+++ b/packs/core-abilities/competitive.json
@@ -8,15 +8,15 @@
         "traits": [],
         "name": "Competitive",
         "slug": "competitive",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
           "trigger": "<p>A negative [Stage Change] effect from another creature is applied to the user.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Trigger: A negative [Stage Change] effect from another creature is applied to the user.</p><p>Effect: The user's SPATK Stage increases by +2 for 5 Activations.</p>",
         "img": "systems/ptr2e/img/icons/special_icon.png"
@@ -48,17 +48,17 @@
         "changes": [
           {
             "type": "roll-effect",
-            "key": "competetive-generic",
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.1TqcwIUNl32wJCAZ",
+            "phase": "initial",
             "predicate": [],
             "chance": 100,
-            "affects": "self",
-            "priority": null,
             "isFixedChance": false,
+            "affects": "defensive",
             "alterations": [],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "key": "negative-stage-change-trait-applied",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -72,7 +72,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -84,14 +86,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.1.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737564323163,
-        "modifiedTime": 1753828075507,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1778669694707,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/content.json
+++ b/packs/core-abilities/content.json
@@ -46,29 +46,26 @@
   "effects": [
     {
       "name": "Content",
-      "type": "passive",
+      "type": "affliction",
       "_id": "bT8l1ApbMaLFjCHA",
       "img": "systems/ptr2e/img/icons/effect_icon.webp",
       "system": {
         "changes": [
           {
-            "type": "roll-effect",
-            "key": "content-generic",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+            "type": "roll-option",
+            "value": "content:ability",
+            "phase": "initial",
             "predicate": [],
-            "chance": 100,
-            "isFixedChance": true,
-            "affects": "target",
-            "alterations": [
-              {
-                "property": "system.changes.0.value",
-                "value": 2,
-                "method": 5
-              }
-            ],
-            "dontMerge": false,
+            "domain": "all",
+            "toggleable": true,
+            "count": false,
+            "label": "Content Ability",
+            "state": true,
+            "alwaysActive": false,
+            "key": "",
+            "method": 2,
             "ignored": false,
-            "method": 2
+            "suboptions": []
           }
         ],
         "slug": null,
@@ -77,12 +74,20 @@
         "removeOnRecall": false,
         "removeAfterAttacking": false,
         "removeAfterAttacked": false,
-        "stacks": 0
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/8",
+        "type": "healing",
+        "predicate": [
+          "content:ability"
+        ]
       },
       "disabled": false,
       "duration": {
-        "units": "turns",
-        "value": null
+        "units": "seconds",
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -95,13 +100,16 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.1.beta",
-        "createdTime": 1753828119021,
-        "modifiedTime": 1753828469660,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778669991098,
+        "modifiedTime": 1778670015688,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/corrosion.json
+++ b/packs/core-abilities/corrosion.json
@@ -14,13 +14,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Effect: The user's Status-Category Attacks that apply the @Affliction[poison] and @Affliction[blight] Affliction can now affect Steel- and Poison-Type creatures. The user's non Poison-Type attacks that apply @Affliction[poison] and @Affliction[blight] can apply these Afflictions to Steel and Poison-Typed creatures.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user's @Trait[poison]-type attacks gain the @Trait[ignore-type-immunity] & @Trait[ignore-immunity] traits.</p>",
+        "img": "systems/ptr2e/img/svg/poison_icon.svg"
       }
     ],
-    "description": "<p>Effect: The user's Status-Category Attacks that apply the @Affliction[poison] and @Affliction[blight] Affliction can now affect Steel- and Poison-Type creatures. The user's non Poison-Type attacks that apply @Affliction[poison] and @Affliction[blight] can apply these Afflictions to Steel and Poison-Typed creatures.</p>",
+    "description": "<p>Effect: The user's @Trait[poison]-type attacks gain the @Trait[ignore-type-immunity] & @Trait[ignore-immunity] traits.</p>",
     "traits": [],
     "slug": "corrosion",
     "_migration": {
@@ -31,9 +32,78 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "4Y4R1qdYtLbm3tE6",
-  "effects": []
+  "effects": [
+    {
+      "name": "Corrosion",
+      "type": "passive",
+      "_id": "TKL0vSREbgALLP6O",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "ignore-type-immunity",
+            "phase": "initial",
+            "predicate": [],
+            "key": "poison-attack",
+            "property": "traits",
+            "definition": [],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "ignore-immunity",
+            "phase": "initial",
+            "predicate": [],
+            "key": "poison-attack",
+            "property": "traits",
+            "definition": [],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778670103710,
+        "modifiedTime": 1778670173290,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/costar.json
+++ b/packs/core-abilities/costar.json
@@ -24,7 +24,9 @@
       }
     ],
     "description": "<p>Trigger: The user enters battle or is switched-in.</p><p>Effect: The user copies all [Stage Change] effects the target has.</p>",
-    "traits": [],
+    "traits": [
+      "partial-automation"
+    ],
     "slug": "costar",
     "_migration": {
       "version": null,
@@ -34,9 +36,66 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "Li9d7BVtjKrm2ske",
-  "effects": []
+  "effects": [
+    {
+      "name": "Costar",
+      "type": "passive",
+      "_id": "XHGIjZBWEvXHOxDo",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-note",
+            "value": "{actor|link} enters combat and may spend {item|actions.contents.0.cost.powerPoints} PP to use {item|link}!",
+            "phase": "initial",
+            "predicate": [],
+            "key": "combat-enter",
+            "visibility": null,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778670284366,
+        "modifiedTime": 1778670313677,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/cotton-down.json
+++ b/packs/core-abilities/cotton-down.json
@@ -14,7 +14,6 @@
         "type": "generic",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
           "trigger": "<p>The user is hit by an attack.</p>"
         },
         "range": {
@@ -26,7 +25,7 @@
         "img": "systems/ptr2e/img/icons/status_icon.png"
       }
     ],
-    "description": "<p>Trigger: The user is hit by an attack. </p><p>Effect: The triggering creature, and all other creatures within range, lose -1 SPD Stage for 5 Activations.</p>",
+    "description": "<p>Trigger: The user is hit by an attack.</p><p>Effect: The triggering creature, and all other creatures within range, lose -1 SPD Stage for 5 Activations.</p>",
     "traits": [
       "defensive",
       "powder"
@@ -63,8 +62,19 @@
             "affects": "target",
             "alterations": [],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-note",
+            "value": "Hit by a @Trait[contact] attack? {actor|link} may be able to use {item|link}.",
+            "phase": "initial",
+            "predicate": [],
+            "key": "contact-trait-attack",
+            "visibility": null,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -78,7 +88,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -91,13 +103,16 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.1.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1753828899782,
-        "modifiedTime": 1753828923433,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1778684393068,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/deep-freeze.json
+++ b/packs/core-abilities/deep-freeze.json
@@ -11,19 +11,18 @@
         ],
         "name": "Deep Freeze",
         "slug": "deep-freeze",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 3,
           "trigger": "<p>The user is hit with a [Contact] attack.</p>"
         },
         "range": {
           "target": "creature",
-          "distance": 10,
+          "distance": 1,
           "unit": "m"
         },
         "description": "<p>Trigger: The user is hit with a [Contact] attack.</p><p>Effect: The attacking creature has a 10% chance of gaining @Affliction[frozen 2].</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/conditions/frozen.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit with a [Contact] attack.</p><p>Effect: The attacking creature has a 20% chance of gaining @Affliction[frozen 2].</p>",
@@ -39,7 +38,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "IF6BAzszAVDQivLO",
@@ -56,23 +56,31 @@
             "key": "contact-trait-attack",
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.frozencondition0",
             "predicate": [],
-            "chance": 30,
+            "chance": 20,
             "affects": "origin",
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": true,
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -84,13 +92,17 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-abilities.Item.5LF7Z8sWyuD05AFR.ActiveEffect.bsfoEvgKXZ4f0tSH",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.2.4.2",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1728599764055,
-        "modifiedTime": 1728635871606,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
-      }
+        "modifiedTime": 1778684639202,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/defiant.json
+++ b/packs/core-abilities/defiant.json
@@ -10,7 +10,7 @@
         ],
         "name": "Defiant",
         "slug": "defiant",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
           "trigger": "<p>A negative [Stage Change] effect from another creature is applied to the user.</p>"
@@ -54,12 +54,13 @@
             "value": "{actor|link}'s {item|link} may be able to activate as they just had an effect applied!",
             "predicate": [],
             "visibility": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
-            "key": "defiant-generic",
+            "key": "negative-stage-change-received",
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.g1Gt9mJWimAqrqZ0",
             "predicate": [],
             "chance": 100,
@@ -67,8 +68,9 @@
             "affects": "self",
             "alterations": [],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -82,7 +84,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -94,13 +98,17 @@
         "compendiumSource": "Compendium.ptr2e.core-abilities.Item.zkPwckV2p2C4AjFp.ActiveEffect.AtxTtATg56OHCBz7",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1746198074555,
-        "modifiedTime": 1765277977272,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1778684772914,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-abilities/discretion.json
+++ b/packs/core-abilities/discretion.json
@@ -18,7 +18,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Trigger: The user misses with an attack.</p><p>Effect: The user does not spend PP on the missed attack, and gains +2 ACC Stages for 5 Activations.</p>",
         "img": "icons/svg/explosion.svg"
@@ -35,9 +36,70 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "VM76lMqpqLmOyVpu",
-  "effects": []
+  "effects": [
+    {
+      "name": "Discretion",
+      "type": "passive",
+      "_id": "FeaIqnLfYbeZQedi",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.Smwu5LWbBYgjUmPc",
+            "phase": "initial",
+            "predicate": [],
+            "alterations": [],
+            "key": "discretion-generic",
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "self",
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778684988467,
+        "modifiedTime": 1778685017762,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/dry-skin.json
+++ b/packs/core-abilities/dry-skin.json
@@ -19,19 +19,17 @@
         },
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 10
+          "unit": "m"
         },
         "description": "<p>Effect: The user recovers 4 Ticks of HP when hit by a Water-Type attack, and recovers a tick of HP at the end of their turn in Rainy Weather. The user takes 25% more damage from Fire-Type attacks, and loses a Tick of HP at the end of their turn in Sunny Weather.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/magic/air/weather-clouds-sunlight.webp"
       }
     ],
     "description": "<p>Effect: The user recovers 4 Ticks of HP when hit by a Water-Type attack, and recovers a tick of HP at the end of their turn in Rainy Weather. The user takes 25% more damage from Fire-Type attacks, and loses a Tick of HP at the end of their turn in Sunny Weather.</p>",
     "traits": [
       "healing",
       "defensive",
-      "environ",
-      "partial-automation"
+      "environ"
     ],
     "slug": "dry-skin",
     "_migration": {
@@ -72,7 +70,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "ephemeral-modifier",
@@ -82,7 +81,8 @@
             "label": "Dry Skin",
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -96,7 +96,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -108,12 +110,116 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
         "createdTime": 1765240592996,
         "modifiedTime": 1765240652037,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
+    },
+    {
+      "name": "Rain Regen",
+      "type": "affliction",
+      "_id": "LXaRrGfzEhNGD7zc",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/16",
+        "type": "healing",
+        "predicate": [
+          "effect:summon:rainy-weather"
+        ]
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778685165800,
+        "modifiedTime": 1778685179604,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    },
+    {
+      "name": "Sun Tick",
+      "type": "affliction",
+      "_id": "qZL9FRZFOhFmXBHR",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/16",
+        "type": "damage",
+        "predicate": [
+          "effect:summon:sunny-weather"
+        ]
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778685196316,
+        "modifiedTime": 1778685218066,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
       }
     }
   ]

--- a/packs/core-abilities/earth-eater.json
+++ b/packs/core-abilities/earth-eater.json
@@ -12,10 +12,9 @@
         ],
         "name": "Earth Eater",
         "slug": "earth-eater",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 4,
           "trigger": "<p>The user is hit by a Ground-Type attack.</p>"
         },
         "range": {
@@ -23,7 +22,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user is hit by a Ground-Type attack.</p><p>Effect: The user ignores the damage and effects of the triggering attack and recovers 4 Ticks of HP.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/svg/ground_icon.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a Ground-Type attack.</p><p>Effect: The user ignores the damage and effects of the triggering attack and recovers 4 Ticks of HP.</p>",
@@ -40,9 +39,86 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "CwD0qR63pFkatLwC",
-  "effects": []
+  "effects": [
+    {
+      "name": "Earth Eater",
+      "type": "passive",
+      "_id": "AhVj8WaVqNih5wQH",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "value": -1000000,
+            "phase": "initial",
+            "predicate": [],
+            "key": "ground-attack-damage-percentile",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+            "phase": "initial",
+            "predicate": [],
+            "key": "ground-attack",
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 4
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778686074829,
+        "modifiedTime": 1778687015833,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/effect-spore.json
+++ b/packs/core-abilities/effect-spore.json
@@ -12,10 +12,9 @@
         ],
         "name": "Effect Spore",
         "slug": "effect-spore",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 3,
           "trigger": "<p>The user is hit by a [Contact] attack.</p>"
         },
         "range": {
@@ -23,8 +22,8 @@
           "distance": 1,
           "unit": "m"
         },
-        "description": "<p>Trigger: The user is hit by a [Contact] attack.</p><p>Effect: The triggering creature has a 30% chance of either gaining @Affliction[paralysis 5], gaining @Affliction[drowsy 5], or gaining @Affliction[poison 5].</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user is hit by a [Contact] attack.</p><p>Effect: The attacking creature has a 10% chance of gaining @Affliction[paralysis 5], a 10% chance of gaining @Affliction[drowsy 5], and a 10% chance of gaining @Affliction[poison 5].</p>",
+        "img": "systems/ptr2e/img/svg/grass_icon.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a [Contact] attack.</p><p>Effect: The attacking creature has a 10% chance of gaining @Affliction[paralysis 5], a 10% chance of gaining @Affliction[drowsy 5], and a 10% chance of gaining @Affliction[poison 5].</p>",
@@ -65,7 +64,10 @@
             "priority": null,
             "ignored": false,
             "alterations": [],
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false
           },
           {
             "type": "roll-effect",
@@ -78,7 +80,10 @@
             "priority": null,
             "ignored": false,
             "alterations": [],
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false
           },
           {
             "type": "roll-effect",
@@ -91,19 +96,26 @@
             "priority": null,
             "ignored": false,
             "alterations": [],
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -115,13 +127,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.2.4.1",
         "createdTime": 1727997025623,
         "modifiedTime": 1741894094610,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
-      }
+        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/electromorphosis.json
+++ b/packs/core-abilities/electromorphosis.json
@@ -10,21 +10,20 @@
         ],
         "name": "Electromorphosis",
         "slug": "electromorphosis",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
           "trigger": "<p>The user is damaged by a Physical or Special-Category Attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 10
+          "unit": "m"
         },
         "description": "<p>Trigger: The user is damaged by a Physical or Special-Category Attack.</p><p>Effect: The user freely uses Charge.</p>",
         "img": "systems/ptr2e/img/svg/electric_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user is damaged by a Physical or Special-Category Attack. </p><p>Effect: Connection - Charge. The user freely uses Charge.</p>",
+    "description": "<p>Trigger: The user is damaged by a Physical or Special-Category Attack.</p><p>Effect: Connection - Charge. The user gains @UUID[Compendium.ptr2e.core-effects-new.ActiveEffect.chargedcondiitem]{Charged} and +1 SpDef for 5 activations.</p>",
     "traits": [
       "defensive",
       "connection"
@@ -53,16 +52,15 @@
         "changes": [
           {
             "type": "grant-item",
-            "key": "",
             "value": "Compendium.ptr2e.core-moves.Item.SyYgWBDdxlHBpXS6",
             "predicate": [
               "ability:electromorphosis:active"
             ],
             "alterations": [
               {
+                "method": 5,
                 "property": "system.actions.0.free",
-                "value": "true",
-                "method": 5
+                "value": "true"
               }
             ],
             "priority": null,
@@ -72,11 +70,41 @@
               "granter": "cascade"
             },
             "reevaluateOnUpdate": true,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
             "inMemoryOnly": false,
             "track": false,
-            "replaceSelf": false,
-            "method": 2
+            "replaceSelf": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.chargedcondiitem",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "damaging-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.jEX7s3GbbAtzgyS3",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "damaging-attack",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -90,7 +118,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -102,14 +132,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.2.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737397621209,
-        "modifiedTime": 1754317934463,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1778686342949,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/emergency-exit.json
+++ b/packs/core-abilities/emergency-exit.json
@@ -14,7 +14,6 @@
         "type": "generic",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
           "trigger": "<p>An attack is resolved against the user and the user meets the [Desperation 1/2] Condition.</p>"
         },
         "range": {
@@ -23,7 +22,7 @@
           "distance": 10
         },
         "description": "<p>Trigger: An attack is resolved against the user and the user meets the [Desperation 1/2] Condition.</p><p>Effect: The user freely Moves up to half of a Movement Score of their choice, and freely attacks a valid target with U-Turn.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/perk-icons/Juggler.svg"
       }
     ],
     "description": "<p>Trigger: An attack is resolved against the user and the user meets the [Desperation 1/2] Condition.</p><p>Effect: Connection - U-Turn. The user freely Moves up to half of a Movement Score of their choice, and freely attacks a valid target with U-Turn.</p>",
@@ -56,16 +55,15 @@
         "changes": [
           {
             "type": "grant-item",
-            "key": "",
             "value": "Compendium.ptr2e.core-moves.Item.DTnhRJBYhTBapjIK",
             "predicate": [
               "ability:emergency-exit:active"
             ],
             "alterations": [
               {
+                "method": 5,
                 "property": "system.actions.0.free",
-                "value": "true",
-                "method": 5
+                "value": "true"
               }
             ],
             "priority": null,
@@ -75,11 +73,23 @@
               "granter": "cascade"
             },
             "reevaluateOnUpdate": true,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
             "inMemoryOnly": false,
             "track": false,
-            "replaceSelf": false,
-            "method": 2
+            "replaceSelf": false
+          },
+          {
+            "type": "roll-note",
+            "value": "{actor|link} can use {item|link}.",
+            "phase": "initial",
+            "predicate": [],
+            "key": "desperation-1-2",
+            "visibility": null,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -93,7 +103,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -105,14 +117,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.2.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737397810021,
-        "modifiedTime": 1754318123245,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1778686478685,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/fae-spirit.json
+++ b/packs/core-abilities/fae-spirit.json
@@ -12,10 +12,9 @@
         ],
         "name": "Fae Spirit",
         "slug": "fae-spirit",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 4,
           "trigger": "<p>The user is hit by a Fairy-Type attack.</p>"
         },
         "range": {
@@ -23,7 +22,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user is hit by a Fairy-Type attack.</p><p>Effect: The user takes no damage from the triggering attack and is unaffected by its effects. Then, the user recovers 4 Ticks of HP.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/svg/fairy_icon.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a Fairy-Type attack.</p><p>Effect: The user takes no damage from the triggering attack and is unaffected by its effects. Then, the user recovers 4 Ticks of HP.</p>",
@@ -40,9 +39,86 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "s7fEcH6IviCJlCES",
-  "effects": []
+  "effects": [
+    {
+      "name": "Fae Spirit",
+      "type": "passive",
+      "_id": "Mx5SkWfsEq3i6wWf",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "value": -1000000,
+            "phase": "initial",
+            "predicate": [],
+            "key": "fairy-attack-damage-percentile",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+            "phase": "initial",
+            "predicate": [],
+            "key": "fairy-attack",
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 4
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778686989418,
+        "modifiedTime": 1778687028726,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/fatal-precision.json
+++ b/packs/core-abilities/fatal-precision.json
@@ -14,7 +14,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user deals 20% more damage with super effective attacks, and the user's attacks gain [Danger Close] if they would be super effective against a target.</p>",
         "img": "icons/svg/explosion.svg"
@@ -31,9 +32,82 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "CYl70u7WNI7zx5w2",
-  "effects": []
+  "effects": [
+    {
+      "name": "Fatal Precision",
+      "type": "passive",
+      "_id": "HWgxZqbS1ZigTtOf",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "value": 20,
+            "phase": "initial",
+            "predicate": [
+              "effectiveness:super"
+            ],
+            "key": "damaging-attack-damage",
+            "label": "Super-Effective DMG",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "danger-close",
+            "phase": "initial",
+            "predicate": [],
+            "property": "traits",
+            "definition": [
+              "effectiveness:super"
+            ],
+            "key": "attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778687150819,
+        "modifiedTime": 1778687226485,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/filter.json
+++ b/packs/core-abilities/filter.json
@@ -16,7 +16,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: Super effective damage against the user is reduced by 25%.</p>",
         "img": "icons/svg/explosion.svg"
@@ -35,9 +36,69 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "nMyIYhgTztXvdMGh",
-  "effects": []
+  "effects": [
+    {
+      "name": "Filter",
+      "type": "passive",
+      "_id": "YLmaWaboylrbXxxG",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "value": -20,
+            "phase": "initial",
+            "predicate": [
+              "effectiveness:super"
+            ],
+            "key": "damaging-attack-damage-percentile",
+            "label": "Filter",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778687282638,
+        "modifiedTime": 1778687318078,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/flaming-soul.json
+++ b/packs/core-abilities/flaming-soul.json
@@ -16,13 +16,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Effect: While the user meets the [Intrepid 3/4] Condition, all of the user's Fire-Type attacks gain [Priority 1], or have their [Priority X] increased by 1. This only works on attacks whose type is originally Fire-Type.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: While the user meets the @Trait[intrepid-3-4] Condition, all of the user's Fire-Type attacks gain @Trait[priority-15], or have their @Trait[priority-xy] increased by 15.</p>",
+        "img": "systems/ptr2e/img/svg/fire_icon.svg"
       }
     ],
-    "description": "<p>Effect: While the user meets the [Intrepid 3/4] Condition, all of the user's Fire-Type attacks gain [Priority 1], or have their [Priority X] increased by 1. This only works on attacks whose type is originally Fire-Type.</p>",
+    "description": "<p>Effect: While the user meets the @Trait[intrepid-3-4] Condition, all of the user's Fire-Type attacks gain @Trait[priority-15], or have their @Trait[priority-xy] increased by 15.</p>",
     "traits": [
       "intrepid-3-4"
     ],
@@ -35,9 +36,78 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "RUAXINCHaiR9VbHZ",
-  "effects": []
+  "effects": [
+    {
+      "name": "Flaming Soul",
+      "type": "passive",
+      "_id": "aT30u6OSickVcp0X",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advancecondition",
+            "phase": "initial",
+            "predicate": [
+              "intrepid-3-4"
+            ],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 15
+              }
+            ],
+            "dontMerge": false,
+            "key": "fire-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778687447468,
+        "modifiedTime": 1778687547692,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/flash-fire.json
+++ b/packs/core-abilities/flash-fire.json
@@ -14,19 +14,17 @@
         "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 3,
           "trigger": "<p>The user is hit by a Fire-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m",
-          "distance": 10
+          "unit": "m"
         },
-        "description": "<p>Trigger: The user is hit by a Fire-Type attack.</p><p>Effect: The user takes no damage from the triggering attack and is not affected by the triggering attack's effect. Then, the user freely uses Stoke.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user is hit by a Fire-Type attack.</p><p>Effect: Connection - Stoke. The user takes no damage from the triggering attack and is not affected by the triggering attack's effect. Then, the user gains @UUID[Compendium.ptr2e.core-effects-new.ActiveEffect.stokedcondititem]{Stoked} and +1 Speed Stage for 5 activations.</p>",
+        "img": "systems/ptr2e/img/svg/fire_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user is hit by a Fire-Type attack.</p><p>Effect: Connection - Stoke. The user takes no damage from the triggering attack and is not affected by the triggering attack's effect. Then, the user freely uses Stoke.</p>",
+    "description": "<p>Trigger: The user is hit by a Fire-Type attack.</p><p>Effect: Connection - Stoke. The user takes no damage from the triggering attack and is not affected by the triggering attack's effect. Then, the user gains @UUID[Compendium.ptr2e.core-effects-new.ActiveEffect.stokedcondititem]{Stoked} and +1 Speed Stage for 5 activations.</p>",
     "traits": [
       "connection",
       "defensive"
@@ -55,16 +53,15 @@
         "changes": [
           {
             "type": "grant-item",
-            "key": "",
             "value": "Compendium.ptr2e.core-moves.Item.51bKgpaPceb1kg5n",
             "predicate": [
               "ability:flash-fire:active"
             ],
             "alterations": [
               {
+                "method": 5,
                 "property": "system.actions.0.free",
-                "value": "true",
-                "method": 5
+                "value": "true"
               }
             ],
             "priority": null,
@@ -74,11 +71,52 @@
               "granter": "cascade"
             },
             "reevaluateOnUpdate": true,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
             "inMemoryOnly": false,
             "track": false,
-            "replaceSelf": false,
-            "method": 2
+            "replaceSelf": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "value": -100000,
+            "phase": "initial",
+            "predicate": [],
+            "key": "fire-attack-damage-percentile",
+            "label": "Flash Fire",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.stokedcondititem",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "fire-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.XeiSuS3APUcN0MLM",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "fire-attack",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -92,7 +130,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -104,14 +144,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.2.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737398204591,
-        "modifiedTime": 1754318218273,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1778687760280,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/frosty-chill.json
+++ b/packs/core-abilities/frosty-chill.json
@@ -17,11 +17,11 @@
           "distance": 1,
           "unit": "m"
         },
-        "description": "<p>Effect: The user's [Contact] attacks have a 20% chance of inflicting @Affliction[frostbite 5].</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user's [Contact] attacks have a 30% chance of inflicting @Affliction[frostbite 5].</p>",
+        "img": "systems/ptr2e/img/svg/ice_icon.svg"
       }
     ],
-    "description": "<p>Effect: The user's [Contact] attacks have a 20% chance of inflicting @Affliction[frostbite 5].</p>",
+    "description": "<p>Effect: The user's [Contact] attacks have a 30% chance of inflicting @Affliction[frostbite 5].</p>",
     "traits": [],
     "slug": "frosty-chill",
     "_migration": {
@@ -32,7 +32,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "c9pxwKHv7Ss9gZit",
@@ -50,23 +51,31 @@
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.frostbiteconditi",
             "predicate": [],
             "label": "Frosty Chill",
-            "chance": 20,
+            "chance": 30,
             "affects": "target",
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -78,13 +87,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.6",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737570368956,
-        "modifiedTime": 1737570390236,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
-      }
+        "modifiedTime": 1778687834640,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/frozen-armor.json
+++ b/packs/core-abilities/frozen-armor.json
@@ -38,9 +38,88 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "x0xXaOUbac8m2sXY",
-  "effects": []
+  "effects": [
+    {
+      "name": "Frozen Armor",
+      "type": "passive",
+      "_id": "iV9P3VSHAMEwcZke",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "trait:ice"
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "origin",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "contact-trait-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-option",
+            "value": "affliction:burn",
+            "phase": "initial",
+            "predicate": [],
+            "domain": "immunities",
+            "toggleable": false,
+            "count": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": [],
+            "state": true
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778687906375,
+        "modifiedTime": 1778691391284,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/frozen-soul.json
+++ b/packs/core-abilities/frozen-soul.json
@@ -16,13 +16,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Effect: While the user meets the [Intrepid 3/4] Condition, all of the user's Ice-Type attacks gain [Priority 1], or have their [Priority X] increased by 1. This only works on attacks whose type is originally Ice-Type.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: While the user meets the @Trait[intrepid-3-4] Condition, all of the user's Ice-Type attacks gain @Trait[priority-15], or have their @Trait[priority-xy] increased by 15.</p>",
+        "img": "systems/ptr2e/img/svg/ice_icon.svg"
       }
     ],
-    "description": "<p>Effect: While the user meets the [Intrepid 3/4] Condition, all of the user's Ice-Type attacks gain [Priority 1], or have their [Priority X] increased by 1. This only works on attacks whose type is originally Ice-Type.</p>",
+    "description": "<p>Effect: While the user meets the @Trait[intrepid-3-4] Condition, all of the user's Ice-Type attacks gain @Trait[priority-15], or have their @Trait[priority-xy] increased by 15.</p>",
     "traits": [
       "intrepid-3-4"
     ],
@@ -35,9 +36,78 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "A5E5BWWWMnrK6nbr",
-  "effects": []
+  "effects": [
+    {
+      "name": "Frozen Soul",
+      "type": "passive",
+      "_id": "Km7A4uvhodkDolGj",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advancecondition",
+            "phase": "initial",
+            "predicate": [
+              "intrepid-3-4"
+            ],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 15
+              }
+            ],
+            "dontMerge": false,
+            "key": "ice-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778688143240,
+        "modifiedTime": 1778688179304,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/furnace.json
+++ b/packs/core-abilities/furnace.json
@@ -11,10 +11,9 @@
         ],
         "name": "Furnace",
         "slug": "furnace",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 5,
           "trigger": "<p>The user is hit by a Rock-Type attack or effect.</p>"
         },
         "range": {
@@ -22,7 +21,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user is hit by a Rock-Type attack or effect.</p><p>Effect: The triggering attack or effect deals no damage and its effects do not affect the user. Then, the user gains +2 SPD Stages for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/svg/rock_icon.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a Rock-Type attack or effect.</p><p>Effect: The triggering attack or effect deals no damage and its effects do not affect the user. Then, the user gains +2 SPD Stages for 5 Activations.</p>",
@@ -36,9 +35,80 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "krORyhup8izksC1e",
-  "effects": []
+  "effects": [
+    {
+      "name": "Furnace",
+      "type": "passive",
+      "_id": "fmbmWDVYvZXNEvIF",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "value": -1000000,
+            "phase": "initial",
+            "predicate": [],
+            "key": "rock-attack-damage-percentile",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.XeiSuS3APUcN0MLZ",
+            "phase": "initial",
+            "predicate": [],
+            "key": "rock-attack",
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778688466442,
+        "modifiedTime": 1778688506547,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/game-hunter.json
+++ b/packs/core-abilities/game-hunter.json
@@ -14,13 +14,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Effect: The user's Physical- and Special-Category attacks deal 33% more damage to creatures that possess 50% of their max HP or less.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user's Physical- and Special-Category attacks deal 33% more damage to creatures that meet the @Trait[desperation-1-2] Condition.</p>",
+        "img": "systems/ptr2e/img/perk-icons/Hunting.svg"
       }
     ],
-    "description": "<p>Effect: The user's Physical- and Special-Category attacks deal 33% more damage to creatures that possess 50% of their max HP or less.</p>",
+    "description": "<p>Effect: The user's Physical- and Special-Category attacks deal 33% more damage to creatures that meet the @Trait[desperation-1-2] Condition.</p>",
     "traits": [],
     "slug": "game-hunter",
     "_migration": {
@@ -31,7 +32,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "fRaVCVtd9pDR7YHl",
@@ -53,19 +55,24 @@
             "priority": null,
             "ignored": false,
             "hideIfDisabled": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -77,13 +84,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "0.10.0-alpha.5.1.6",
         "createdTime": 1737571344650,
         "modifiedTime": 1737571379963,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
-      }
+        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/gluttony.json
+++ b/packs/core-abilities/gluttony.json
@@ -16,7 +16,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user can equip two additional [Food] items as Belt items, and can consume equipped [Food] items as a Free Action while they meet the [Desperation 1/2] Condition.</p>",
         "img": "icons/svg/explosion.svg"
@@ -35,9 +36,65 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "S4vHJCbkusuoETLh",
-  "effects": []
+  "effects": [
+    {
+      "name": "Gluttony",
+      "type": "passive",
+      "_id": "Cl0QDon0FeG6yBsP",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.inventory.belt.max",
+            "value": 2,
+            "phase": "initial",
+            "predicate": [],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778688670031,
+        "modifiedTime": 1778688700337,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/good-as-gold.json
+++ b/packs/core-abilities/good-as-gold.json
@@ -16,7 +16,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user is unaffected by other creatures' Status-Category Attacks that target it.</p>",
         "img": "icons/svg/explosion.svg"
@@ -35,9 +36,73 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "OUzdfBM415dwQk4g",
-  "effects": []
+  "effects": [
+    {
+      "name": "Good As Gold",
+      "type": "passive",
+      "_id": "RHt6dLFdMxIwcacz",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.CekJx2L2a3x60g1b",
+            "phase": "initial",
+            "predicate": [],
+            "affects": "defensive",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 100
+              }
+            ],
+            "key": "status-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778688750820,
+        "modifiedTime": 1778688797281,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/gorilla-tactics.json
+++ b/packs/core-abilities/gorilla-tactics.json
@@ -14,7 +14,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user's Base ATK is increased by 50%. Whenever the user uses an attack, that attack is @Affliction[choice-locked 5] (this effect does not stack).</p>",
         "img": "icons/svg/explosion.svg"
@@ -33,7 +34,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "o7w4293hAtU3PiKX",
@@ -51,20 +53,43 @@
             "value": 1.5,
             "predicate": [],
             "priority": null,
-            "ignored": false,
-            "method": 1
+            "method": 1,
+            "phase": "initial",
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.choicelockedcond",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "effect:choice-locked"
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "attack",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -76,13 +101,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.0.0",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1729418622641,
-        "modifiedTime": 1729418635205,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+        "modifiedTime": 1778688893481,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/heatproof.json
+++ b/packs/core-abilities/heatproof.json
@@ -16,7 +16,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user takes 50% reduced damage from Fire-Type attacks. If the user has @Affliction[burn], they only take half damage from the @Affliction[burn] damage.</p>",
         "img": "icons/svg/explosion.svg"
@@ -24,8 +25,7 @@
     ],
     "description": "<p>Effect: The user takes 50% reduced damage from Fire-Type attacks. If the user has @Affliction[burn], they only take half damage from the @Affliction[burn] damage. Heatproof also confers the @Trait[magma-wader] trait whilst active.</p>",
     "traits": [
-      "defensive",
-      "partial-automation"
+      "defensive"
     ],
     "slug": "heatproof",
     "_migration": {
@@ -55,30 +55,52 @@
             "value": -50,
             "predicate": [],
             "priority": null,
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "add-trait",
-            "key": "",
             "value": "magma-wader",
             "predicate": [],
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "effect-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [],
+            "key": "burn-received",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.formula",
+                "value": "1/32"
+              }
+            ],
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -90,13 +112,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.2.1.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1741605124301,
-        "modifiedTime": 1744796023540,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+        "modifiedTime": 1778689048611,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/heliophobia.json
+++ b/packs/core-abilities/heliophobia.json
@@ -17,7 +17,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user recovers recovers a tick of HP at the end of their turn in Gloomy Weather and loses a Tick of HP at the end of their turn in Sunny Weather.</p>",
         "img": "icons/svg/explosion.svg"
@@ -37,9 +38,111 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "UvZ50pJVH8HnTaua",
-  "effects": []
+  "effects": [
+    {
+      "name": "Gloomy Heliophobia",
+      "type": "affliction",
+      "_id": "OHrj3AUm1C0Kh1fm",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/16",
+        "type": "healing",
+        "predicate": [
+          "effect:summon:gloomy-weather"
+        ]
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778689164244,
+        "modifiedTime": 1778689198049,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    },
+    {
+      "name": "Sunny Heliophobia",
+      "type": "affliction",
+      "_id": "QGti0y5UsvKZ4AcB",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/16",
+        "type": "damage",
+        "predicate": [
+          "effect:summon:sunny-weather"
+        ]
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778689209248,
+        "modifiedTime": 1778689225666,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/hubris.json
+++ b/packs/core-abilities/hubris.json
@@ -10,7 +10,7 @@
         ],
         "name": "Hubris",
         "slug": "hubris",
-        "type": "attack",
+        "type": "generic",
         "cost": {
           "activation": "free",
           "trigger": "The user causes at least one creature to gain @Affliction[fainted]."
@@ -20,13 +20,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user causes at least one creature to gain @Affliction[fainted].</p><p>Effect: The user gains @UUID[Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAa]{+1 Special Attack Stage} for 5 Activations.</p>",
-        "img": "systems/ptr2e/img/icons/special_icon.png",
-        "types": [
-          "untyped"
-        ],
-        "category": "physical",
-        "free": true,
-        "predicate": []
+        "img": "systems/ptr2e/img/icons/special_icon.png"
       }
     ],
     "description": "<p>Trigger: The user causes at least one creature to gain @Affliction[fainted].</p><p>Effect: The user gains @UUID[Compendium.ptr2e.core-effects.Item.1TqcwIUNl32wJCAa]{+1 Special Attack Stage} for 5 Activations.</p>",
@@ -55,17 +49,18 @@
         "changes": [
           {
             "type": "roll-effect",
-            "key": "hubris-attack",
+            "key": "hubris-generic",
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.1TqcwIUNl32wJCAa",
             "predicate": [],
             "chance": 100,
             "affects": "self",
             "priority": null,
-            "ignored": false,
             "isFixedChance": false,
             "alterations": [],
             "dontMerge": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -79,7 +74,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -91,14 +88,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.347",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.6",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737563734209,
-        "modifiedTime": 1737563756918,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "modifiedTime": 1778689315143,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/hypnotist.json
+++ b/packs/core-abilities/hypnotist.json
@@ -42,7 +42,6 @@
     ],
     "description": "<p>Effect: Connection - Hypnosis. <br><br>@Trait[interrupt] Trigger: An enemy moves into range, allowing the user to activate Hypnosis as a Free Action @Trait[interrupt].<br><br>Passive: The user's Hypnosis gains Danger Close.</p>",
     "traits": [
-      "partial-automation",
       "connection"
     ],
     "slug": "hypnotist",
@@ -69,16 +68,15 @@
         "changes": [
           {
             "type": "grant-item",
-            "key": "",
             "value": "Compendium.ptr2e.core-moves.Item.s4q86Yo0UJilvVI0",
             "predicate": [
               "ability:hypnotist:active"
             ],
             "alterations": [
               {
+                "method": 5,
                 "property": "system.actions.0.free",
-                "value": "true",
-                "method": 5
+                "value": "true"
               }
             ],
             "priority": null,
@@ -88,11 +86,24 @@
               "granter": "cascade"
             },
             "reevaluateOnUpdate": true,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
             "inMemoryOnly": false,
             "track": false,
-            "replaceSelf": false,
-            "method": 2
+            "replaceSelf": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "danger-close",
+            "phase": "initial",
+            "predicate": [],
+            "property": "traits",
+            "definition": [],
+            "key": "hypnosis-attack",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -106,7 +117,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -118,14 +131,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.2.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737403414513,
-        "modifiedTime": 1754319221960,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1778689424570,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/ice-body.json
+++ b/packs/core-abilities/ice-body.json
@@ -17,7 +17,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: While Snowy Weather is active, the user recovers a tick of HP at the end of each of their Activations. The user is considered Ice Type for the effects of Snowy Weather.</p>",
         "img": "icons/svg/explosion.svg"
@@ -37,9 +38,61 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "GElvTZmOzC5mappR",
-  "effects": []
+  "effects": [
+    {
+      "name": "Ice Body",
+      "type": "affliction",
+      "_id": "KnLK92c4sBNFt9TU",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/16",
+        "type": "healing",
+        "predicate": [
+          "effect:summon:snowy-weather"
+        ]
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778689476324,
+        "modifiedTime": 1778689493384,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/ice-dew.json
+++ b/packs/core-abilities/ice-dew.json
@@ -10,10 +10,9 @@
         ],
         "name": "Ice Dew",
         "slug": "ice-dew",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 4,
           "trigger": "<p>The user is hit by an Ice-Type attack.</p>"
         },
         "range": {
@@ -21,7 +20,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user is hit by an Ice-Type attack.</p><p>Effect: The triggering attack deals no damage and the user does not suffer any of its effects. The user gains +1 ATK and SPATK for 3 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/svg/ice_icon.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by an Ice-Type attack.</p><p>Effect: The triggering attack deals no damage and the user does not suffer any of its effects. The user gains +1 ATK and SPATK for 3 Activations.</p>",
@@ -35,9 +34,106 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "grubP7n7tHJqh3ns",
-  "effects": []
+  "effects": [
+    {
+      "name": "Ice Dew",
+      "type": "passive",
+      "_id": "vrLxIipiRE1Y8tYG",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "value": -100000,
+            "phase": "initial",
+            "predicate": [],
+            "key": "ice-attack-damage-percentile",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.ZGwaMlzUwkSuCPyH",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "key": "ice-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.1TqcwIUNl32wJCAa",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "key": "ice-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778689643419,
+        "modifiedTime": 1778689710013,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/immunity.json
+++ b/packs/core-abilities/immunity.json
@@ -16,7 +16,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user is immune to the @Affliction[poison] and @Affliction[blight]. The user also resists Poison-Type damage.</p>",
         "img": "icons/svg/explosion.svg"
@@ -24,8 +25,7 @@
     ],
     "description": "<p>Effect: The user is immune to the @Affliction[poison] and @Affliction[blight]. The user also resists Poison-Type damage.</p>",
     "traits": [
-      "defensive",
-      "partial-automation"
+      "defensive"
     ],
     "slug": "immunity",
     "_migration": {
@@ -36,7 +36,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "yiNqcB30VYaNgEvC",
@@ -50,31 +51,44 @@
         "changes": [
           {
             "type": "roll-option",
-            "key": "",
             "value": "affliction:poison",
             "predicate": [],
             "domain": "immunities",
             "toggleable": false,
             "count": false,
             "priority": null,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
             "suboptions": [],
-            "state": true,
-            "method": 2
+            "state": true
           },
           {
             "type": "roll-option",
-            "key": "",
             "value": "affliction:blight",
             "predicate": [],
             "domain": "immunities",
             "toggleable": false,
             "count": false,
             "priority": null,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
             "suboptions": [],
-            "state": true,
-            "method": 2
+            "state": true
+          },
+          {
+            "type": "ephemeral-modifier",
+            "value": -1,
+            "phase": "initial",
+            "predicate": [],
+            "key": "poison-attack-effectiveness-stage",
+            "label": "Immunity",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
           }
         ],
         "slug": null,
@@ -83,12 +97,16 @@
         ],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "<p>Effect: The user is immune to the @Affliction[poison] and @Affliction[blight]. The user also resists Poison-Type damage.</p>",
       "origin": null,
@@ -100,13 +118,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.3.0",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1731340789942,
-        "modifiedTime": 1731340816322,
-        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-      }
+        "modifiedTime": 1778689864570,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/imperious-mind.json
+++ b/packs/core-abilities/imperious-mind.json
@@ -34,7 +34,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: While Psychic Terrain is active, the user's SPATK stat is increased by 50%. In Psychic Terrain, the user loses a Tick of HP at the end of each of their Activations.</p>",
         "img": "icons/svg/explosion.svg"
@@ -53,9 +54,73 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "FWdXCBjg2c6deJyP",
-  "effects": []
+  "effects": [
+    {
+      "name": "Imperious Mind",
+      "type": "affliction",
+      "_id": "ipRolrzhdJghQZ0F",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.modifiers.spaMultiplier",
+            "value": 0.5,
+            "phase": "initial",
+            "predicate": [
+              "effect:summon:psychic-terrain"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "1/16",
+        "type": "damage",
+        "predicate": [
+          "effect:summon:psychic-terrain"
+        ]
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778689951369,
+        "modifiedTime": 1778690021717,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/inflationary.json
+++ b/packs/core-abilities/inflationary.json
@@ -20,7 +20,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Trigger: The user is hit by a Fire- or Flying-Type attack.</p><p>Effect: The user takes half damage from the triggering attack, and then gains +1 DEF and SPDEF for 3 Activations.</p>",
         "img": "icons/svg/explosion.svg"
@@ -54,9 +55,158 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "Fo7dz96ut9bKc4e4",
-  "effects": []
+  "effects": [
+    {
+      "name": "Inflationary",
+      "type": "passive",
+      "_id": "uMEcvq9AEoKgmJL9",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.sMystTj3FBJ00AZp",
+            "phase": "initial",
+            "predicate": [],
+            "key": "fire-attack",
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.jEX7s3GbbAtzgyS3",
+            "phase": "initial",
+            "predicate": [],
+            "key": "fire-attack",
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.sMystTj3FBJ00AZp",
+            "phase": "initial",
+            "predicate": [],
+            "key": "flying-attack",
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.jEX7s3GbbAtzgyS3",
+            "phase": "initial",
+            "predicate": [],
+            "key": "flying-attack",
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "defensive",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "duration.turns",
+                "value": 3
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "add-trait",
+            "value": "flying",
+            "phase": "initial",
+            "predicate": [
+              "effect:summon:windy-weather"
+            ],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.flight.value",
+            "value": 5,
+            "phase": "initial",
+            "predicate": [
+              "effect:summon:windy-weather"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778690149224,
+        "modifiedTime": 1778690282136,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/iron-barbs.json
+++ b/packs/core-abilities/iron-barbs.json
@@ -11,10 +11,9 @@
         ],
         "name": "Iron Barbs",
         "slug": "iron-barbs",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 3,
           "trigger": "<p>The user is hit by a [Contact] attack.</p>"
         },
         "range": {
@@ -69,7 +68,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
@@ -82,7 +82,8 @@
             "alterations": [],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -96,7 +97,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -108,13 +111,17 @@
         "compendiumSource": "Compendium.ptr2e.core-gear.Item.Rmp9cDtLcTuRuf9x.ActiveEffect.N0vLanHTvK1vmCcE",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.350",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.6.beta",
         "createdTime": 1762714537361,
         "modifiedTime": 1762714576814,
         "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-abilities/juiced-fruit.json
+++ b/packs/core-abilities/juiced-fruit.json
@@ -11,18 +11,18 @@
         ],
         "name": "Juiced Fruit",
         "slug": "juiced-fruit",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user consumes a Berry based [Food] item.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Trigger: The user consumes a Berry based [Food] item.</p><p>Effect: The user recovers 6 Ticks of HP and gains +1 SPD Stage for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/perk-icons/Chef.svg"
       }
     ],
     "description": "<p>Trigger: The user consumes a Berry based [Food] item.</p><p>Effect: The user recovers 6 Ticks of HP and gains +1 SPD Stage for 5 Activations.</p>",
@@ -38,9 +38,90 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "maKnERu8ylgtRuT7",
-  "effects": []
+  "effects": [
+    {
+      "name": "Juiced Fruit",
+      "type": "passive",
+      "_id": "Dr9vu0NpkO2dPdN4",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.XeiSuS3APUcN0MLM",
+            "phase": "initial",
+            "predicate": [],
+            "key": "berry-generic",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+            "phase": "initial",
+            "predicate": [],
+            "key": "berry-generic",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 6
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778690645702,
+        "modifiedTime": 1778690693467,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/justified.json
+++ b/packs/core-abilities/justified.json
@@ -11,7 +11,7 @@
         ],
         "name": "Justified",
         "slug": "justified",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
           "trigger": "<p>The user is hit by a Dark-Type attack or is hit by an @Trait[interrupt] Action.</p>"
@@ -26,8 +26,7 @@
     ],
     "description": "<p>Trigger: The user is hit by a; Dark-Type attack, a Physical- or Special-Category Attack from a Dark-Type creature, or is hit by an @Trait[interrupt] Action.</p><p>Effect: The user's ATK Stage is increased by +1 for 5 Activations.</p>",
     "traits": [
-      "defensive",
-      "partial-automation"
+      "defensive"
     ],
     "slug": "justified",
     "_migration": {
@@ -59,21 +58,58 @@
             "chance": 100,
             "affects": "defensive",
             "priority": null,
-            "ignored": false,
             "alterations": [],
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "interrupt-trait-attack",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.ZGwaMlzUwkSuCPyH",
+            "predicate": [],
+            "chance": 100,
+            "affects": "defensive",
+            "priority": null,
+            "alterations": [],
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "key": "interrupt-trait-generic",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.ZGwaMlzUwkSuCPyH",
+            "predicate": [],
+            "chance": 100,
+            "affects": "defensive",
+            "priority": null,
+            "alterations": [],
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -85,13 +121,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.6",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737564981189,
-        "modifiedTime": 1737565010622,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
-      }
+        "modifiedTime": 1778690802816,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/lightning-rod.json
+++ b/packs/core-abilities/lightning-rod.json
@@ -41,9 +41,70 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "zGgfm8CE0qrdcmdf",
-  "effects": []
+  "effects": [
+    {
+      "name": "Lightning Rod",
+      "type": "passive",
+      "_id": "jTg5fdakODdTMg98",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.1TqcwIUNl32wJCAa",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "self",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "lightning-rod-generic",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778690937052,
+        "modifiedTime": 1778690969762,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/liquid-voice.json
+++ b/packs/core-abilities/liquid-voice.json
@@ -13,7 +13,6 @@
         "type": "generic",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The declares a [Sonic] attack.</p>"
         },
         "range": {
@@ -21,7 +20,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The declares a [Sonic] attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Water-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/perk-icons/Musician.svg"
       }
     ],
     "description": "<p>Trigger: The declares a [Sonic] attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Water-Type until the end of their current Activation.</p>",
@@ -35,7 +34,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "Ov7ZB62P2aCahDuu",

--- a/packs/core-abilities/magma-armor.json
+++ b/packs/core-abilities/magma-armor.json
@@ -11,10 +11,9 @@
         ],
         "name": "Magma Armor",
         "slug": "magma-armor",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 3,
           "trigger": "The user is hit by a [Contact] attack from a non Fire-Type creature."
         },
         "range": {
@@ -23,7 +22,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user is hit by a [Contact] attack from a non Fire-Type creature.</p><p>Effect: The triggering creature takes a Tick of HP damage. The user is immune to @Affliction[frostbite] and @Affliction[frozen].</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/svg/fire_icon.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by a [Contact] attack from a non Fire-Type creature.</p><p>Effect: The triggering creature takes a Tick of HP damage. The user is immune to @Affliction[frostbite] and @Affliction[frozen].</p>",
@@ -39,7 +38,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "9qojQ3vL1ZJm6IzT",
@@ -53,7 +53,6 @@
         "changes": [
           {
             "type": "roll-option",
-            "key": "",
             "value": "affliction:frozen",
             "predicate": [],
             "domain": "immunities",
@@ -62,23 +61,44 @@
             "state": false,
             "alwaysActive": false,
             "priority": null,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
-            "suboptions": [],
-            "method": 2
+            "suboptions": []
           },
           {
             "type": "roll-option",
-            "key": "",
             "value": "affliction:frostbite",
             "predicate": [],
             "domain": "immunities",
             "toggleable": false,
             "count": false,
             "priority": null,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
             "suboptions": [],
-            "state": true,
-            "method": 2
+            "state": true
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "trait:fire"
+              }
+            ],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "origin",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "contact-trait-attack",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -87,13 +107,17 @@
         ],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "description": "<p>Trigger: The user is hit by a [Contact] attack from a non Fire-Type creature. Effect: The triggering creature takes a Tick of HP damage. The user is immune to @Affliction[frostbite] and @Affliction[frozen].</p>",
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "origin": null,
       "tint": "#ffffff",
@@ -104,13 +128,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.3.3.0",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1731340553943,
-        "modifiedTime": 1731340723124,
-        "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-      }
+        "modifiedTime": 1778691408966,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/marine-apex.json
+++ b/packs/core-abilities/marine-apex.json
@@ -17,7 +17,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Trigger: The user attacks a Swimming creature, or is Swimming.</p><p>Effect: The user's attacks have their Power increased by 50%, and the user takes 20% less damage from Physical- and Special-Category attacks.</p>",
         "img": "icons/svg/explosion.svg"
@@ -36,9 +37,86 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "f3n7PYbX40yiCnYD",
-  "effects": []
+  "effects": [
+    {
+      "name": "Marine Apex",
+      "type": "passive",
+      "_id": "vnyUJaPbGEhRrWLl",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "value": 50,
+            "phase": "initial",
+            "predicate": [
+              {
+                "or": [
+                  "self:state:swim",
+                  "target:state:swim"
+                ]
+              }
+            ],
+            "key": "attack-power",
+            "label": "Marine Apex",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "ephemeral-modifier",
+            "value": -20,
+            "phase": "initial",
+            "predicate": [
+              "target:state:swim"
+            ],
+            "key": "attack-damage-percentile",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778691888425,
+        "modifiedTime": 1778692109667,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/mega-launcher.json
+++ b/packs/core-abilities/mega-launcher.json
@@ -14,13 +14,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The Power of the user's [Pulse] attacks is increased by 30%.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "<p>Effect: The Power of the user's [Pulse] attacks is increased by 30%.</p>",
+    "description": "<p>Effect: The Power of the user's [Pulse] attacks is increased by 50%.</p>",
     "traits": [],
     "slug": "mega-launcher",
     "_migration": {
@@ -31,7 +32,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "LkYKRjbpzyCOCCsK",
@@ -46,25 +48,30 @@
           {
             "type": "percentile-modifier",
             "key": "pulse-trait-attack-power",
-            "value": 30,
+            "value": 50,
             "predicate": [],
             "label": "Mega Launcher",
             "priority": null,
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -76,13 +83,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.2.0.3",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1722260237249,
-        "modifiedTime": 1722260264209,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+        "modifiedTime": 1778692158692,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/merciless.json
+++ b/packs/core-abilities/merciless.json
@@ -36,9 +36,74 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "oneZH0NTxPfEVX4D",
-  "effects": []
+  "effects": [
+    {
+      "name": "Merciless",
+      "type": "passive",
+      "_id": "d0Pye4n4ZGyscU3R",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "crit-4",
+            "phase": "initial",
+            "predicate": [],
+            "key": "attack",
+            "property": "traits",
+            "definition": [
+              {
+                "or": [
+                  "target:effect:poison",
+                  "target:effect:blight"
+                ]
+              }
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778692490139,
+        "modifiedTime": 1778692564647,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/misty-mask.json
+++ b/packs/core-abilities/misty-mask.json
@@ -17,7 +17,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: While affected by Misty Terrain, the user has +1 default EVA. The user is immune to the negative effects of Misty Terrain.</p>",
         "img": "icons/svg/explosion.svg"
@@ -37,9 +38,67 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "4y8hcJY0FBud0AlG",
-  "effects": []
+  "effects": [
+    {
+      "name": "Misty Mask",
+      "type": "passive",
+      "_id": "cEwx50KiGcZFT7nR",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.battleStats.evasion.stage",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "effect:summon:misty-terrain"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778692666887,
+        "modifiedTime": 1778692691621,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/monks-spirit.json
+++ b/packs/core-abilities/monks-spirit.json
@@ -14,13 +14,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Effect: The user's damaging Fighting and Psychic-Type attacks are resisted one step less.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user's damaging Fighting and Psychic-Type attacks gain +1 Effectiveness Stage.</p>",
+        "img": "systems/ptr2e/img/svg/psychic_icon.svg"
       }
     ],
-    "description": "<p>Effect: The user's damaging Fighting and Psychic-Type attacks are resisted one step less.</p>",
+    "description": "<p>Effect: The user's damaging Fighting and Psychic-Type attacks gain +1 Effectiveness Stage.</p>",
     "traits": [],
     "slug": "monks-spirit",
     "_migration": {
@@ -31,9 +32,76 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "ac26FDlHtcA87Qzq",
-  "effects": []
+  "effects": [
+    {
+      "name": "Monk's Spirit",
+      "type": "passive",
+      "_id": "SLfX2zbTlfBNAsRW",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [],
+            "key": "fighting-attack-effectiveness-stage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "flat-modifier",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [],
+            "key": "psychic-attack-effectiveness-stage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778692741796,
+        "modifiedTime": 1778692819140,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/motor-drive.json
+++ b/packs/core-abilities/motor-drive.json
@@ -10,10 +10,9 @@
         ],
         "name": "Motor Drive",
         "slug": "motor-drive",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
           "trigger": "<p>The user is hit by an Electric-Type attack.</p>"
         },
         "range": {
@@ -21,7 +20,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user is hit by an Electric-Type attack.</p><p>Effect: The user takes no damage from the triggering attack and is unaffected by the triggering attack's effect. Then the user raises their SPD Stage by +1 for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/svg/electric_icon.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by an Electric-Type attack.</p><p>Effect: The user takes no damage from the triggering attack and is unaffected by the triggering attack's effect. Then the user raises their SPD Stage by +1 for 5 Activations.</p>",
@@ -37,9 +36,80 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "Q9eDxavx46UPn5Q5",
-  "effects": []
+  "effects": [
+    {
+      "name": "Motor Drive",
+      "type": "passive",
+      "_id": "dJVljVl1MeGuaT3K",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "value": -10000,
+            "phase": "initial",
+            "predicate": [],
+            "key": "electric-attack-damage-percentile",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.XeiSuS3APUcN0MLM",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "electric-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778692916015,
+        "modifiedTime": 1778692956531,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/mountaineer.json
+++ b/packs/core-abilities/mountaineer.json
@@ -16,7 +16,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user is immune to Rock-Type attacks and effects.</p>",
         "img": "icons/svg/explosion.svg"
@@ -35,9 +36,70 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "uRP9KecfJjZwhgYL",
-  "effects": []
+  "effects": [
+    {
+      "name": "Mountaineer",
+      "type": "passive",
+      "_id": "Vhhi5Gk4gt4mojr1",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "trait:rock",
+            "phase": "initial",
+            "predicate": [],
+            "domain": "immunities",
+            "toggleable": false,
+            "count": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": [],
+            "state": true
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778693424420,
+        "modifiedTime": 1778693436657,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/neuroforce.json
+++ b/packs/core-abilities/neuroforce.json
@@ -16,13 +16,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user's Super Effective attacks deal 25% more damage.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
-    "description": "EEffect: The user's Super Effective attacks deal 25% more damage.</p>",
+    "description": "<p>Effect: The user's Super Effective attacks deal 25% more damage.</p>",
     "traits": [
       "legendary"
     ],
@@ -35,9 +36,69 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "qef8gsEsnhXAKbcK",
-  "effects": []
+  "effects": [
+    {
+      "name": "Neuroforce",
+      "type": "passive",
+      "_id": "IbyIxWbNQZHE2Qvw",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "value": 25,
+            "phase": "initial",
+            "predicate": [
+              "effectiveness:super"
+            ],
+            "key": "damaging-attack-damage",
+            "label": "Neuroforce",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778693158803,
+        "modifiedTime": 1778693201418,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/overwhelm.json
+++ b/packs/core-abilities/overwhelm.json
@@ -14,13 +14,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Effect: Fairy-Type creatures resist the user's Dragon-Type Attacks by one step rather than gaining immune. The user cannot be afflicted with the @Affliction[fear] Affliction.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user's @Trait[dragon]-type attacks gain @Trait[ignore-type-immunity]. The user cannot be afflicted with the @Affliction[fear] Affliction.</p>",
+        "img": "systems/ptr2e/img/svg/dragon_icon.svg"
       }
     ],
-    "description": "<p>Effect: Fairy-Type creatures resist the user's Dragon-Type Attacks by one step rather than gaining immune. The user cannot be afflicted with the @Affliction[fear] Affliction.</p>",
+    "description": "<p>Effect: The user's @Trait[dragon]-type attacks gain @Trait[ignore-type-immunity]. The user cannot be afflicted with the @Affliction[fear] Affliction.</p>",
     "traits": [],
     "slug": "overwhelm",
     "_migration": {
@@ -31,9 +32,81 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "5jz8GZsbhiv85gQd",
-  "effects": []
+  "effects": [
+    {
+      "name": "Overwhelm",
+      "type": "passive",
+      "_id": "2LtrFNkbOXysaOfZ",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "ignore-type-immunity",
+            "phase": "initial",
+            "predicate": [],
+            "property": "traits",
+            "definition": [],
+            "key": "dragon-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-option",
+            "value": "affliction:fear",
+            "phase": "initial",
+            "predicate": [],
+            "domain": "immunities",
+            "toggleable": false,
+            "count": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": [],
+            "state": true
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778693546921,
+        "modifiedTime": 1778693587790,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/overzealous.json
+++ b/packs/core-abilities/overzealous.json
@@ -8,7 +8,7 @@
         "traits": [],
         "name": "Overzealous",
         "slug": "overzealous",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free"
         },
@@ -18,7 +18,7 @@
           "unit": "m"
         },
         "description": "<p>Effect: The user's [Contact] attacks have a 30% chance of inflicting @Affliction[delay 15].</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/conditions/flinched.svg"
       }
     ],
     "description": "<p>Effect: The user's [Contact] attacks have a 30% chance of inflicting @Affliction[delay 15].</p>",
@@ -32,9 +32,76 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "dzB18kSyLwW7xm4s",
-  "effects": []
+  "effects": [
+    {
+      "name": "Overzealous",
+      "type": "passive",
+      "_id": "m34rsNAsizypHKI6",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 30,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 15
+              }
+            ],
+            "dontMerge": false,
+            "key": "contact-trait-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778693645211,
+        "modifiedTime": 1778693674227,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/own-tempo.json
+++ b/packs/core-abilities/own-tempo.json
@@ -16,13 +16,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Effect: The user is immune to the @Affliction[confused] Affliction, and also is unaffected by [Social] Ability effects.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user is immune to the @Affliction[confused] Affliction, and also is unaffected by [Social] effects.</p>",
+        "img": "systems/ptr2e/img/conditions/cheered.svg"
       }
     ],
-    "description": "<p>Effect: The user is immune to the @Affliction[confused] Affliction, and also is unaffected by [Social] Ability effects.</p>",
+    "description": "<p>Effect: The user is immune to the @Affliction[confused] Affliction, and also is unaffected by [Social] effects.</p>",
     "traits": [
       "defensive"
     ],
@@ -35,9 +36,84 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "lnWSp7oPRAS9tHzg",
-  "effects": []
+  "effects": [
+    {
+      "name": "Own Tempo",
+      "type": "passive",
+      "_id": "LKhKFNJR7ijT5Syp",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "affliction:confused",
+            "phase": "initial",
+            "predicate": [],
+            "key": "immunities",
+            "domain": "immunities",
+            "toggleable": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": [],
+            "state": true
+          },
+          {
+            "type": "roll-option",
+            "value": "trait:social",
+            "phase": "initial",
+            "predicate": [],
+            "key": "immunities",
+            "domain": "immunities",
+            "toggleable": false,
+            "count": false,
+            "method": 2,
+            "ignored": false,
+            "suboptions": [],
+            "state": true
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778693735396,
+        "modifiedTime": 1778693768900,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/perforate.json
+++ b/packs/core-abilities/perforate.json
@@ -14,13 +14,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Effect: Attacks that the user gains STAB on are resisted one step less. These attacks that a target would normally be immune to are instead resisted one step.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: Attacks that the user gains STAB on gain +1 Effectiveness Stage. These attacks gain @Trait[ignore-type-immunity].</p>",
+        "img": "icons/skills/melee/shield-damaged-broken-blue.webp"
       }
     ],
-    "description": "<p>Effect: Attacks that the user gains STAB on are resisted one step less. These attacks that a target would normally be immune to are instead resisted one step.</p>",
+    "description": "<p>Effect: Attacks that the user gains STAB on gain +1 Effectiveness Stage. These attacks gain @Trait[ignore-type-immunity].</p>",
     "traits": [],
     "slug": "perforate",
     "_migration": {
@@ -31,9 +32,81 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "fWJ3ImW09ZT9qvP1",
-  "effects": []
+  "effects": [
+    {
+      "name": "Perforate",
+      "type": "passive",
+      "_id": "r8QQEq2BvjftRHg2",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "flat-modifier",
+            "value": 1,
+            "phase": "initial",
+            "predicate": [
+              "effectiveness:super"
+            ],
+            "key": "attack-effectiveness-stage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "ignore-type-immunity",
+            "phase": "initial",
+            "predicate": [],
+            "property": "traits",
+            "definition": [
+              "effectiveness:super"
+            ],
+            "key": "attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778693908887,
+        "modifiedTime": 1778693956279,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/perish-body.json
+++ b/packs/core-abilities/perish-body.json
@@ -25,7 +25,7 @@
         "img": "icons/svg/biohazard.svg"
       }
     ],
-    "description": "<p>Trigger: The user is hit by a [Contact] attack.</p><p>Effect: The user and and the triggering creature gain @Affliction[perish 7].</p>",
+    "description": "<p>Trigger: The user is hit by a [Contact] attack.</p><p>Effect: The user and and the triggering creature gain @Affliction[perish 3].</p>",
     "traits": [
       "defensive"
     ],
@@ -61,14 +61,15 @@
             "affects": "origin",
             "alterations": [
               {
+                "method": 5,
                 "property": "duration.turns",
-                "value": 7,
-                "method": 5
+                "value": 3
               }
             ],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "roll-effect",
@@ -80,14 +81,15 @@
             "affects": "defensive",
             "alterations": [
               {
+                "method": 5,
                 "property": "duration.turns",
-                "value": 7,
-                "method": 5
+                "value": 3
               }
             ],
             "dontMerge": false,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -101,7 +103,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -114,13 +118,16 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.3.8.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1753363957053,
-        "modifiedTime": 1753364040216,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+        "modifiedTime": 1778694034119,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/poison-absorb.json
+++ b/packs/core-abilities/poison-absorb.json
@@ -12,10 +12,9 @@
         ],
         "name": "Poison Absorb",
         "slug": "poison-absorb",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
           "trigger": "<p>The user is hit by an Poison-Type Attack.</p>"
         },
         "range": {
@@ -23,7 +22,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user is hit by an Poison-Type Attack.</p><p>Effect: The user takes no damage from the triggering attack and is unaffected by its effects. Then, the user recovers 4 Ticks of HP.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/svg/poison_icon.svg"
       }
     ],
     "description": "<p>Trigger: The user is hit by an Poison-Type Attack.</p><p>Effect: The user takes no damage from the triggering attack and is unaffected by its effects. Then, the user recovers 4 Ticks of HP.</p>",
@@ -40,9 +39,86 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "hQChOYGLuVJXg0kx",
-  "effects": []
+  "effects": [
+    {
+      "name": "Poison Absorb",
+      "type": "passive",
+      "_id": "rHvrLlaL1YVMRhzU",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-modifier",
+            "value": -100000,
+            "phase": "initial",
+            "predicate": [],
+            "key": "poison-attack-damage-percentile",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+            "phase": "initial",
+            "predicate": [],
+            "key": "poison-attack",
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "defensive",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 4
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778694178017,
+        "modifiedTime": 1778694233747,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/prankster.json
+++ b/packs/core-abilities/prankster.json
@@ -23,11 +23,11 @@
           "unit": "m",
           "distance": 10
         },
-        "description": "<p>Trigger: A creature within 6m of the user declares an Attack.</p><p>Effect: The user spends 3 PP, and then uses a Status-Category Attack, as a Free Action, consuming PP as normal.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: A creature within 6m of the user declares an Attack.</p><p>Effect: The user spends 3 PP, and then uses a Status-Category Attack, as a Free Action, consuming PP as normal.</p><p>The user gains @Affliction[nullified 1] after use.</p>",
+        "img": "systems/ptr2e/img/svg/dark_icon.svg"
       }
     ],
-    "description": "<p>Trigger: A creature within 6m of the user declares an Attack.</p><p>Effect: The user spends 3 PP, and then uses a Status-Category Attack, as a Free Action, consuming PP as normal.</p>",
+    "description": "<p>Trigger: A creature within 6m of the user declares an Attack.</p><p>Effect: The user spends 3 PP, and then uses a Status-Category Attack, as a Free Action, consuming PP as normal.</p><p>The user gains @Affliction[nullified 1] after use.</p>",
     "traits": [
       "interrupt",
       "priority-20"
@@ -71,7 +71,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -85,7 +86,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -98,13 +101,16 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.3.8.beta",
         "createdTime": 1753363858536,
         "modifiedTime": 1753363896540,
         "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/prismatic-guard.json
+++ b/packs/core-abilities/prismatic-guard.json
@@ -11,7 +11,7 @@
         ],
         "name": "Prismatic Guard",
         "slug": "prismatic-guard",
-        "type": "passive",
+        "type": "generic",
         "cost": {
           "activation": "free",
           "powerPoints": 2,
@@ -23,7 +23,7 @@
           "unit": "m"
         },
         "description": "<p>Trigger: When the user is hit by a non-[Contact] Physical- or Special-Category attack.</p><p>Effect: The attacking creature takes 2 Ticks of HP damage and loses -1 ACC Stage for 5 Activations.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "icons/magic/light/beam-impact-deflect-teal.webp"
       }
     ],
     "description": "<p>Trigger: When the user is hit by a non-[Contact] Physical- or Special-Category attack.</p><p>Effect: The attacking creature takes 2 Ticks of HP damage and loses -1 ACC Stage for 5 Activations.</p>",
@@ -39,9 +39,90 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "owUGKDLgaY7y92FR",
-  "effects": []
+  "effects": [
+    {
+      "name": "Prismatic Guard",
+      "type": "passive",
+      "_id": "M8Ka5LmkdexkD2G4",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+            "phase": "initial",
+            "predicate": [],
+            "key": "prismatic-guard-generic",
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": -2
+              }
+            ],
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.wA5oCsgHmZLcHHSn",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "prismatic-guard-generic",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778694437230,
+        "modifiedTime": 1778694507559,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/tinted-lens.json
+++ b/packs/core-abilities/tinted-lens.json
@@ -14,7 +14,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user's Physical or Special-Category attacks that are resisted by their targets deals double damage on hit.</p>",
         "img": "icons/svg/explosion.svg"
@@ -31,9 +32,68 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "DnlBpzjzOQD37SSy",
-  "effects": []
+  "effects": [
+    {
+      "name": "Tinted Lens",
+      "type": "passive",
+      "_id": "yvJ1LImFFItra4g9",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "value": 100,
+            "phase": "initial",
+            "predicate": [
+              "effectiveness:resisted"
+            ],
+            "key": "damaging-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778686576258,
+        "modifiedTime": 1778686606833,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }


### PR DESCRIPTION
In connection with ability review, streamlining, QOL and overwhelmingly buffs given the limited nature of abilities.
- Update Ability: Abyssal Claw
- Update Ability: Aerodynamic
- Update Ability: Amplifier
- Update Ability: Anger Shell
- Update Ability: Antivenom
- Update Ability: Benevolence
- Update Ability: Bone Zone
- Update Ability: Capoeira
- Update Ability: Cascade
- Update Ability: Caustic Heat
- Update Ability: Celestial Blessing
- Update Ability: Cheek Pouch
- Update Ability: Coil Up
- Update Ability: Cold Rebound
- Update Ability: Coldflame
- Update Ability: Competitive
- Update Ability: Content
- Update Ability: Corrosion
- Update Ability: Costar
- Update Ability: Cotton Down
- Update Ability: Deep Freeze
- Update Ability: Defiant
- Update Ability: Discretion
- Update Ability: Dry Skin
- Update Ability: Earth Eater
- Update Ability: Effect Spore
- Update Ability: Electromorphosis
- Update Ability: Emergency Exit
- Update Ability: Tinted Lens
- Update Ability: Fae Spirit
- Update Ability: Fatal Precision
- Update Ability: Filter
- Update Ability: Flaming Soul
- Update Ability: Flash Fire
- Update Ability: Frosty Chill
- Update Ability: Frozen Armor
- Update Ability: Frozen Soul
- Update Ability: Furnace
- Update Ability: Game Hunter
- Update Ability: Gluttony
- Update Ability: Good as Gold
- Update Ability: Gorilla Tactics
- Update Ability: Heatproof
- Update Ability: Heliophobia
- Update Ability: Hubris
- Update Ability: Hypnotist
- Update Ability: Ice Body
- Update Ability: Ice Dew
- Update Ability: Immunity
- Update Ability: Imperious Mind
- Update Ability: Inflationary
- Update Ability: Iron Barbs
- Update Ability: Juiced Fruit
- Update Ability: Justified
- Update Ability: Lightning Rod
- Update Ability: Liquid Voice
- Update Ability: Magma Armor
- Update Ability: Marine Apex
- Update Ability: Mega Launcher
- Update Ability: Merciless
- Update Ability: Misty Mask
- Update Ability: Monk's Spirit
- Update Ability: Motor Drive
- Update Ability: Neuroforce
- Update Ability: Mountaineer
- Update Ability: Overwhelm
- Update Ability: Overzealous
- Update Ability: Own Tempo
- Update Ability: Perforate
- Update Ability: Perish Body
- Update Ability: Poison Absorb
- Update Ability: Prankster
- Update Ability: Prismatic Guard