### PR TITLE
Foundry Data Sync - Delay UUID Correction Batch 1

### DIFF
--- a/packs/core-abilities/feedback.json
+++ b/packs/core-abilities/feedback.json
@@ -67,12 +67,13 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-effect",
             "key": "damaging-attack",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delayconditiitem",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
             "predicate": [],
             "chance": 100,
             "isFixedChance": false,
@@ -86,7 +87,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -100,7 +102,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -112,13 +116,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1757875098876,
-        "modifiedTime": 1757875272511,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1778709014780,
+        "lastModifiedBy": "MGsN9sFsYejE0iWa"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-abilities/loud-bang.json
+++ b/packs/core-abilities/loud-bang.json
@@ -16,7 +16,8 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Effect: The user's Sonic Attacks have a 30% to chance to cause target(s) to be @Affliction[delay 20] and lose -1 EVA Stage for 5 Activations.</p>",
         "img": "icons/svg/explosion.svg"
@@ -51,7 +52,7 @@
           {
             "type": "roll-effect",
             "key": "sonic-trait-attack",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delayconditiitem",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
             "predicate": [],
             "chance": 30,
             "affects": "target",
@@ -64,7 +65,9 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false
           },
           {
             "type": "roll-effect",
@@ -76,19 +79,25 @@
             "alterations": [],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -101,13 +110,16 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.344",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "1.3.3.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1748204873108,
-        "modifiedTime": 1748204977323,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1778709062592,
+        "lastModifiedBy": "MGsN9sFsYejE0iWa"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/stench.json
+++ b/packs/core-abilities/stench.json
@@ -15,7 +15,8 @@
         },
         "range": {
           "target": "creature",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Trigger: The user hits target(s) with a Physical or Special-Category attack.</p><p>Effect: All valid target(s) has a 10% chance to be @Affliction[delay 40].</p>",
         "img": "icons/svg/explosion.svg"
@@ -32,7 +33,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "mNww18uHVxa0yoaz",
@@ -47,7 +49,7 @@
           {
             "type": "roll-effect",
             "key": "damaging-attack",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delayconditiitem",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
             "predicate": [],
             "chance": 10,
             "affects": "target",
@@ -60,19 +62,26 @@
             ],
             "priority": null,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -84,13 +93,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.3.0",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1738250046138,
-        "modifiedTime": 1738250095556,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
-      }
+        "modifiedTime": 1778709100549,
+        "lastModifiedBy": "MGsN9sFsYejE0iWa",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-moves/astonish.json
+++ b/packs/core-moves/astonish.json
@@ -44,7 +44,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "05gTyZzErLsW9RtE",
@@ -59,7 +60,7 @@
           {
             "type": "roll-effect",
             "key": "astonish-attack",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delayconditiitem",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
             "predicate": [],
             "chance": 30,
             "affects": "target",
@@ -72,19 +73,26 @@
             ],
             "priority": null,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -96,13 +104,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.2.1",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737678446356,
-        "modifiedTime": 1737678577654,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX"
-      }
+        "modifiedTime": 1778709130272,
+        "lastModifiedBy": "MGsN9sFsYejE0iWa",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-moves/iron-head.json
+++ b/packs/core-moves/iron-head.json
@@ -44,7 +44,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "0rhyfVFsZ1asQIwv",
@@ -59,7 +60,7 @@
           {
             "type": "roll-effect",
             "key": "iron-head-attack",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delayconditiitem",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
             "predicate": [],
             "chance": 30,
             "affects": "target",
@@ -72,19 +73,26 @@
             ],
             "priority": null,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -96,13 +104,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.2.1",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1737741500088,
-        "modifiedTime": 1737741554902,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+        "modifiedTime": 1778709644114,
+        "lastModifiedBy": "MGsN9sFsYejE0iWa",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-moves/magick-blaster.json
+++ b/packs/core-moves/magick-blaster.json
@@ -59,7 +59,7 @@
           {
             "type": "roll-effect",
             "key": "magick-blaster-attack",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delayconditiitem",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
             "predicate": [],
             "chance": 50,
             "affects": "target",
@@ -72,19 +72,26 @@
             ],
             "priority": null,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false,
+            "dontMerge": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -96,15 +103,18 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-moves.Item.3KCZGRV9lMmb44FC.ActiveEffect.uM9lEbJS6Ee0AHd9",
         "duplicateSource": null,
-        "coreVersion": "12.331",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
-        "systemVersion": "1.1.0.beta",
-        "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null
-      }
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778709223301,
+        "modifiedTime": 1778709223301,
+        "lastModifiedBy": "MGsN9sFsYejE0iWa",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
-  "flags": {},
   "_id": "0QldRXlb3HavAAW3"
 }

--- a/packs/core-moves/mortal-coil.json
+++ b/packs/core-moves/mortal-coil.json
@@ -23,18 +23,13 @@
           "activation": "complex",
           "powerPoints": 2
         },
-        "variant": null,
         "types": [
           "ghost"
         ],
         "category": "physical",
         "power": 70,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null,
-        "description": ""
+        "predicate": []
       },
       {
         "name": "Mortal Coil (Cursed)",
@@ -61,20 +56,23 @@
         "category": "physical",
         "power": 70,
         "accuracy": 100,
-        "contestType": "",
-        "contestEffect": "",
         "free": true,
-        "slot": null,
-        "description": "<p>Trigger: The target has @Affliction[cursed].</p><p>Effect: Effect: On resolution, the target is cured of @Affliction[crused] and is Delayed by 50%.</p>"
+        "description": "<p>Trigger: The target has @Affliction[cursed].</p><p>Effect: Effect: On resolution, the target is cured of @Affliction[crused] and is Delayed by 50%.</p>",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "B",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "effects": [
@@ -88,7 +86,7 @@
           {
             "type": "roll-effect",
             "key": "mortal-coil-cursed-attack",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delayconditiitem",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
             "predicate": [],
             "chance": 100,
             "dontMerge": true,
@@ -102,35 +100,47 @@
                 "method": 5
               }
             ],
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "duration": {
         "units": "turns",
-        "value": null
-      }
+        "value": null,
+        "expiry": null,
+        "expired": false
+      },
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778709348967,
+        "modifiedTime": 1778709348967,
+        "lastModifiedBy": "MGsN9sFsYejE0iWa",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "disabled": false,
+      "start": null,
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {}
     }
-  ],
-  "sort": 0,
-  "ownership": {
-    "default": 0,
-    "CYLdyr5mPSDmNpTp": 3
-  },
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.328",
-    "systemId": "ptr2e",
-    "systemVersion": "0.10.0-alpha.1.5.2",
-    "createdTime": 1720461611630,
-    "modifiedTime": 1720461695318,
-    "lastModifiedBy": "CYLdyr5mPSDmNpTp"
-  }
+  ]
 }

--- a/packs/core-moves/wake-up-slap.json
+++ b/packs/core-moves/wake-up-slap.json
@@ -27,11 +27,8 @@
         "types": [
           "fighting"
         ],
-        "description": "",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       },
       {
         "slug": "wake-up-slap-sleeper",
@@ -57,20 +54,24 @@
           "fighting"
         ],
         "description": "<p>Trigger: The target has @Affliction[drowsy] or @Affliction[nightmares].</p><p>Effect: On resolution, the target is cured of @Affliction[drowsy] and @Affliction[nightmares], and is Delayed by 50%.</p>",
-        "contestType": "",
-        "contestEffect": "",
         "variant": "wake-up-slap",
         "free": true,
-        "slot": null
+        "img": "icons/svg/explosion.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "B",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "0Fa6CTcxg45VyXNP",
@@ -85,7 +86,7 @@
           {
             "type": "roll-effect",
             "key": "wake-up-slap-sleeper-attack",
-            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delayconditiitem",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.delaycondition00",
             "predicate": [],
             "chance": 100,
             "dontMerge": true,
@@ -99,19 +100,47 @@
                 "method": 5
               }
             ],
-            "method": 2
+            "method": 2,
+            "phase": "initial",
+            "isFixedChance": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "duration": {
         "units": "turns",
-        "value": null
-      }
+        "value": null,
+        "expiry": null,
+        "expired": false
+      },
+      "_stats": {
+        "coreVersion": "14.360",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1778709165576,
+        "modifiedTime": 1778709165576,
+        "lastModifiedBy": "MGsN9sFsYejE0iWa",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "disabled": false,
+      "start": null,
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {}
     }
   ]
 }


### PR DESCRIPTION
Another attempt to update the UUID of Delay effects which aren't embedding
- Update Ability: Feedback
- Update Ability: Loud Bang
- Update Ability: Stench
- Update Move: Astonish
- Update Move: Wake-Up Slap
- Update Move: Magick Blaster
- Update Move: Mortal Coil
- Update Move: Iron Head