### PR TITLE
Foundry Data Sync - Type Shift Abilities Automation

### DIFF
--- a/packs/core-abilities/aerilate.json
+++ b/packs/core-abilities/aerilate.json
@@ -12,21 +12,21 @@
         ],
         "name": "Aerilate",
         "slug": "aerilate",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Flying-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Flying-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/flying_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Flying-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Flying-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "flying"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "4YHKc7B2aJxDOmq9",
-  "effects": []
+  "effects": [
+    {
+      "name": "Aerilate",
+      "type": "passive",
+      "_id": "fC7NHHI5vHNSuA97",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "flying",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779012107150,
+        "modifiedTime": 1779012129950,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/aquaboost.json
+++ b/packs/core-abilities/aquaboost.json
@@ -12,21 +12,21 @@
         ],
         "name": "Aquaboost",
         "slug": "aquaboost",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Water-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Water-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/water_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Water-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Water-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "water"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "GFDWD4lGA525TKbQ",
-  "effects": []
+  "effects": [
+    {
+      "name": "Aquaboost",
+      "type": "passive",
+      "_id": "I7krRYF9Eks0RTi7",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "water",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779012798511,
+        "modifiedTime": 1779012828589,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/atomize.json
+++ b/packs/core-abilities/atomize.json
@@ -20,13 +20,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Nuclear-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Nuclear-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/nuclear_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Nuclear-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Nuclear-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "nuclear"
@@ -45,6 +46,73 @@
     }
   },
   "_id": "6pHLt3yR0m0zoeFM",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Atomize",
+      "type": "passive",
+      "_id": "AcNJHbGvwNEGrK9I",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "nuclear",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779012978310,
+        "modifiedTime": 1779012996743,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
   "folder": "0nG9TRDSwrmcTFwO"
 }

--- a/packs/core-abilities/draconize.json
+++ b/packs/core-abilities/draconize.json
@@ -12,21 +12,21 @@
         ],
         "name": "Draconize",
         "slug": "draconize",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Dragon-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Dragon-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/dragon_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Dragon-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Dragon-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "dragon"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "csRO06WcXCGCfSYu",
-  "effects": []
+  "effects": [
+    {
+      "name": "Draconize",
+      "type": "passive",
+      "_id": "2mr89VCQKVlVCKgp",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "dragon",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779013240969,
+        "modifiedTime": 1779013262496,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/fighting-spirit.json
+++ b/packs/core-abilities/fighting-spirit.json
@@ -12,21 +12,21 @@
         ],
         "name": "Fighting Spirit",
         "slug": "fighting-spirit",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Fighting-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Fighting-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/fighting_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Fighting-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Fighting-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "fighting"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "h2iEktpkiDLTL66H",
-  "effects": []
+  "effects": [
+    {
+      "name": "Fighting Spirit",
+      "type": "passive",
+      "_id": "AFoL6GittgTpmb80",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "fighting",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779013562780,
+        "modifiedTime": 1779013585267,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/full-metal-body.json
+++ b/packs/core-abilities/full-metal-body.json
@@ -12,21 +12,21 @@
         ],
         "name": "Full Metal Body",
         "slug": "full-metal-body",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Steel-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Steel-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/steel_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Steel-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Steel-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "steel"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "w4fSmEMdjPa661w3",
-  "effects": []
+  "effects": [
+    {
+      "name": "Full Metal Body",
+      "type": "passive",
+      "_id": "alxOMC4r49j0iPfw",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "steel",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779013659952,
+        "modifiedTime": 1779013679274,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/galvanize.json
+++ b/packs/core-abilities/galvanize.json
@@ -12,21 +12,21 @@
         ],
         "name": "Galvanize",
         "slug": "galvanize",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Electric-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Electric-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/electric_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Electric-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Electric-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "electric"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "OQ46fHb8rtW2H8gh",
-  "effects": []
+  "effects": [
+    {
+      "name": "Galvanize",
+      "type": "passive",
+      "_id": "gtM5IY7Wd7AcLxPp",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "electric",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779013841344,
+        "modifiedTime": 1779013880312,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/germinate.json
+++ b/packs/core-abilities/germinate.json
@@ -12,21 +12,21 @@
         ],
         "name": "Germinate",
         "slug": "germinate",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Grass-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Grass-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/grass_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Grass-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Grass-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "grass"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "MeJaT3UMQETtE153",
-  "effects": []
+  "effects": [
+    {
+      "name": "Germinate",
+      "type": "passive",
+      "_id": "5axzO3M7TFxzEw2q",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "grass",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779013925173,
+        "modifiedTime": 1779013943489,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/ignite.json
+++ b/packs/core-abilities/ignite.json
@@ -12,21 +12,21 @@
         ],
         "name": "Ignite",
         "slug": "ignite",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Fire-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Fire-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/fire_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Fire-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Fire-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "fire"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "2HRhhJt5Z9NXV1pm",
-  "effects": []
+  "effects": [
+    {
+      "name": "Ignite",
+      "type": "passive",
+      "_id": "PaEHd5QvJFBmqf5G",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "fire",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779039512032,
+        "modifiedTime": 1779039531036,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/infested.json
+++ b/packs/core-abilities/infested.json
@@ -12,21 +12,21 @@
         ],
         "name": "Infested",
         "slug": "infested",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Bug-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Bug-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/bug_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Bug-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Bug-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "bug"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "gmtt827jZ7JF23t5",
-  "effects": []
+  "effects": [
+    {
+      "name": "Infested",
+      "type": "passive",
+      "_id": "8ZJDdT7bQoMRM7k1",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "bug",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779039637556,
+        "modifiedTime": 1779039658778,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/intoxicate.json
+++ b/packs/core-abilities/intoxicate.json
@@ -12,21 +12,21 @@
         ],
         "name": "Intoxicate",
         "slug": "intoxicate",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Poison-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Poison-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/poison_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Poison-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Poison-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "poison"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "U64UhlxDqzfkfmyy",
-  "effects": []
+  "effects": [
+    {
+      "name": "Intoxicate",
+      "type": "passive",
+      "_id": "z3pjXFPASKTERM1X",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "poison",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779039778332,
+        "modifiedTime": 1779039809406,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/liquid-voice.json
+++ b/packs/core-abilities/liquid-voice.json
@@ -10,10 +10,9 @@
         ],
         "name": "Liquid Voice",
         "slug": "liquid-voice",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The declares a [Sonic] attack.</p>"
         },
         "range": {
@@ -21,11 +20,14 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The declares a [Sonic] attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Water-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/perk-icons/Musician.svg"
       }
     ],
     "description": "<p>Trigger: The declares a [Sonic] attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Water-Type until the end of their current Activation.</p>",
-    "traits": [],
+    "traits": [
+      "type-shift",
+      "water"
+    ],
     "slug": "liquid-voice",
     "_migration": {
       "version": null,
@@ -35,9 +37,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "Ov7ZB62P2aCahDuu",
-  "effects": []
+  "effects": [
+    {
+      "name": "Liquid Voice",
+      "type": "passive",
+      "_id": "ryyV8Z8z7bCJrVp4",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "sonic-trait-attack-power",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "water",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "sonic-trait-attack",
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779011811414,
+        "modifiedTime": 1779011863053,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/neurolize.json
+++ b/packs/core-abilities/neurolize.json
@@ -12,21 +12,21 @@
         ],
         "name": "Neurolize",
         "slug": "neurolize",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Psychic-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Psychic-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/psychic_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Psychic-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Psychic-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "psychic"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "aszECYVIiYy3rYQa",
-  "effects": []
+  "effects": [
+    {
+      "name": "Neurolize",
+      "type": "passive",
+      "_id": "qcB5gsNPIP4XviLg",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "psychic",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779039847072,
+        "modifiedTime": 1779039867942,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/normalize.json
+++ b/packs/core-abilities/normalize.json
@@ -12,21 +12,21 @@
         ],
         "name": "Normalize",
         "slug": "normalize",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares an attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares an attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Normal-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares an attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Normal-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/normal_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares an attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Normal-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares an attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Normal-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "normal"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "6XBFREQhA7iiyCGn",
-  "effects": []
+  "effects": [
+    {
+      "name": "Normalize",
+      "type": "passive",
+      "_id": "UsghCJ2DCDRzw09r",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "normal",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779039921191,
+        "modifiedTime": 1779039946583,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/petrified.json
+++ b/packs/core-abilities/petrified.json
@@ -12,21 +12,21 @@
         ],
         "name": "Petrified",
         "slug": "petrified",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Rock-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Rock-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/rock_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Rock-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Rock-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "rock"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "DnYGUJrg1tctMZrM",
-  "effects": []
+  "effects": [
+    {
+      "name": "Petrified",
+      "type": "passive",
+      "_id": "VwsczOr5eZdntSCo",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "rock",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779040080033,
+        "modifiedTime": 1779040121228,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/pixilate.json
+++ b/packs/core-abilities/pixilate.json
@@ -12,21 +12,21 @@
         ],
         "name": "Pixilate",
         "slug": "pixilate",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Fairy-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Fairy-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/fairy_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Fairy-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Fairy-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "fairy"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "CW3byw2yFy9lcujk",
-  "effects": []
+  "effects": [
+    {
+      "name": "Pixilate",
+      "type": "passive",
+      "_id": "PWTSMerYsfSgC9r4",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "fairy",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779012060740,
+        "modifiedTime": 1779012081254,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/refrigerate.json
+++ b/packs/core-abilities/refrigerate.json
@@ -12,21 +12,21 @@
         ],
         "name": "Refrigerate",
         "slug": "refrigerate",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Ice-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Ice-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/ice_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Ice-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Ice-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "ice"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "OcFUwZ3i5fu4EUkd",
-  "effects": []
+  "effects": [
+    {
+      "name": "Refrigerate",
+      "type": "passive",
+      "_id": "2PUfheiwQBdevmP1",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "ice",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779040176367,
+        "modifiedTime": 1779040191583,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/sand-song.json
+++ b/packs/core-abilities/sand-song.json
@@ -19,14 +19,18 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "description": "<p>Trigger: The declares a [Sonic] attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Ground-Type until the end of their current Activation.</p>",
         "img": "icons/svg/explosion.svg"
       }
     ],
     "description": "<p>Trigger: The declares a [Sonic] attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Ground-Type until the end of their current Activation.</p>",
-    "traits": [],
+    "traits": [
+      "type-shift",
+      "ground"
+    ],
     "slug": "sand-song",
     "_migration": {
       "version": null,
@@ -36,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "MDD8dxSrQdIh30PO",
-  "effects": []
+  "effects": [
+    {
+      "name": "Sand Song",
+      "type": "passive",
+      "_id": "MN0SZNSYrzOOMXQP",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "ground",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "sonic-trait-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "sonic-trait-attack-power",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779011915582,
+        "modifiedTime": 1779011940442,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/sedimentize.json
+++ b/packs/core-abilities/sedimentize.json
@@ -12,21 +12,21 @@
         ],
         "name": "Sedimentize",
         "slug": "sedimentize",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Ground-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Ground-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/ground_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Ground-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Ground-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "ground"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "lJ9hwyyMOujrG9xd",
-  "effects": []
+  "effects": [
+    {
+      "name": "Sedimentize",
+      "type": "passive",
+      "_id": "qMVULe3tRSiMPzCg",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "fairy",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779040292663,
+        "modifiedTime": 1779040310843,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/spectralize.json
+++ b/packs/core-abilities/spectralize.json
@@ -12,21 +12,21 @@
         ],
         "name": "Spectralize",
         "slug": "spectralize",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Ghost-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Ghost-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/ghost_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Ghost-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Ghost-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "ghost"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "Kfc3T1YHnJTY2Toz",
-  "effects": []
+  "effects": [
+    {
+      "name": "Spectralize",
+      "type": "passive",
+      "_id": "Q9QFn7hK1efjezJS",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "ghost",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779040345281,
+        "modifiedTime": 1779040367111,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/underhanded.json
+++ b/packs/core-abilities/underhanded.json
@@ -12,21 +12,21 @@
         ],
         "name": "Underhanded",
         "slug": "underhanded",
-        "type": "generic",
+        "type": "passive",
         "cost": {
           "activation": "free",
-          "powerPoints": 1,
           "trigger": "<p>The user declares a Normal-Type attack.</p>"
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Dark-Type until the end of their current Activation.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Dark-Type until the end of their current Activation.</p>",
+        "img": "systems/ptr2e/img/svg/dark_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 20% and changes its Type to Dark-Type until the end of their current Activation.</p>",
+    "description": "<p>Trigger: The user declares a Normal-Type attack.</p><p>Effect: The user increases the Power of the triggering attack by 30% and changes its Type to Dark-Type until the end of their current Activation.</p>",
     "traits": [
       "type-shift",
       "dark"
@@ -40,9 +40,77 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "wrvaVOIEn4F2ZR1R",
-  "effects": []
+  "effects": [
+    {
+      "name": "Underhanded",
+      "type": "passive",
+      "_id": "U798S8CdnBTlV6q2",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "dark",
+            "phase": "initial",
+            "predicate": [],
+            "method": 5,
+            "property": "type",
+            "definition": [],
+            "key": "normal-attack",
+            "ignored": false
+          },
+          {
+            "type": "percentile-modifier",
+            "value": 30,
+            "phase": "initial",
+            "predicate": [],
+            "key": "normal-attack-damage",
+            "method": 2,
+            "ignored": false,
+            "hideIfDisabled": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779040438230,
+        "modifiedTime": 1779040460904,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Ability: Pixilate
- Update Ability: Aerilate
- Update Ability: Liquid Voice
- Update Ability: Sand Song
- Update Ability: Aquaboost
- Update Ability: Atomize
- Update Ability: Draconize
- Update Ability: Fighting Spirit
- Update Ability: Full Metal Body
- Update Ability: Galvanize
- Update Ability: Germinate
- Update Ability: Ignite
- Update Ability: Infested
- Update Ability: Intoxicate
- Update Ability: Neurolize
- Update Ability: Normalize
- Update Ability: Petrified
- Update Ability: Refrigerate
- Update Ability: Sedimentize
- Update Ability: Spectralize
- Update Ability: Underhanded