### PR TITLE
Blast Revisions

### DIFF
--- a/packs/core-moves/ally-recall.json
+++ b/packs/core-moves/ally-recall.json
@@ -22,7 +22,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/psychic_icon.svg",
         "traits": [
-          "flinch-20",
+          "flinch-30",
           "blast-5",
           "teleport"
         ],
@@ -33,8 +33,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6,
-          "delay": 2
+          "powerPoints": 6
         },
         "types": [
           "psychic"

--- a/packs/core-moves/aura-storm.json
+++ b/packs/core-moves/aura-storm.json
@@ -19,7 +19,7 @@
         ],
         "range": {
           "target": "blast",
-          "distance": 10,
+          "distance": 8,
           "unit": "m"
         },
         "cost": {

--- a/packs/core-moves/blossom-blast.json
+++ b/packs/core-moves/blossom-blast.json
@@ -12,7 +12,7 @@
         "type": "attack",
         "img": "systems/ptr2e/img/svg/grass_icon.svg",
         "traits": [
-          "blast-3"
+          "blast-2"
         ],
         "range": {
           "target": "blast",

--- a/packs/core-moves/centennial-storm.json
+++ b/packs/core-moves/centennial-storm.json
@@ -19,7 +19,7 @@
           "sky"
         ],
         "range": {
-          "target": "creature",
+          "target": "blast",
           "distance": 15,
           "unit": "m"
         },

--- a/packs/core-moves/chemical-bomb.json
+++ b/packs/core-moves/chemical-bomb.json
@@ -17,7 +17,7 @@
           "blast-2"
         ],
         "range": {
-          "target": "creature",
+          "target": "blast",
           "distance": 8,
           "unit": "m"
         },

--- a/packs/core-moves/crop-circle.json
+++ b/packs/core-moves/crop-circle.json
@@ -12,7 +12,7 @@
         "type": "attack",
         "img": "icons/svg/explosion.svg",
         "traits": [
-          "blast-3"
+          "blast-4"
         ],
         "range": {
           "target": "blast",

--- a/packs/core-moves/dark-matter.json
+++ b/packs/core-moves/dark-matter.json
@@ -11,7 +11,7 @@
         "type": "attack",
         "traits": [
           "flinch-50",
-          "blast-3",
+          "blast-4",
           "pulse"
         ],
         "range": {
@@ -21,7 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 8
+          "powerPoints": 9
         },
         "category": "special",
         "power": 150,

--- a/packs/core-moves/depth-charge.json
+++ b/packs/core-moves/depth-charge.json
@@ -10,7 +10,7 @@
         "name": "Depth Charge",
         "type": "attack",
         "traits": [
-          "blast-2",
+          "blast-1",
           "explode"
         ],
         "range": {

--- a/packs/core-moves/draco-comet.json
+++ b/packs/core-moves/draco-comet.json
@@ -23,14 +23,14 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 3
+          "powerPoints": 4
         },
         "variant": null,
         "types": [
           "dragon"
         ],
         "category": "special",
-        "power": 60,
+        "power": 70,
         "accuracy": 90,
         "contestType": "",
         "contestEffect": "",

--- a/packs/core-moves/draco-meteor.json
+++ b/packs/core-moves/draco-meteor.json
@@ -10,7 +10,8 @@
         "name": "Draco Meteor",
         "type": "attack",
         "traits": [
-          "blast-3"
+          "blast-3",
+          "missile"
         ],
         "range": {
           "target": "blast",

--- a/packs/core-moves/dragonic-raze.json
+++ b/packs/core-moves/dragonic-raze.json
@@ -12,7 +12,7 @@
         "type": "attack",
         "img": "icons/svg/explosion.svg",
         "traits": [
-          "blast-4"
+          "blast-3"
         ],
         "range": {
           "target": "blast",

--- a/packs/core-moves/gaia-force.json
+++ b/packs/core-moves/gaia-force.json
@@ -15,7 +15,7 @@
         ],
         "range": {
           "target": "blast",
-          "distance": 10,
+          "distance": 8,
           "unit": "m"
         },
         "cost": {

--- a/packs/core-moves/gunk-shot.json
+++ b/packs/core-moves/gunk-shot.json
@@ -10,7 +10,7 @@
         "name": "Gunk Shot",
         "type": "attack",
         "traits": [
-          "blast-2"
+          "blast-1"
         ],
         "range": {
           "target": "blast",

--- a/packs/core-moves/infestation.json
+++ b/packs/core-moves/infestation.json
@@ -20,7 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 3
         },
         "category": "special",
         "power": 20,

--- a/packs/core-moves/lotus-pods.json
+++ b/packs/core-moves/lotus-pods.json
@@ -11,7 +11,7 @@
         "type": "attack",
         "traits": [
           "powder",
-          "blast-3"
+          "blast-2"
         ],
         "range": {
           "target": "blast",
@@ -20,7 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 8
+          "powerPoints": 6
         },
         "category": "special",
         "power": 75,

--- a/packs/core-moves/mortal-wave.json
+++ b/packs/core-moves/mortal-wave.json
@@ -18,12 +18,12 @@
         ],
         "range": {
           "target": "blast",
-          "distance": 10,
+          "distance": 5,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7
+          "powerPoints": 5
         },
         "types": [
           "normal"

--- a/packs/core-moves/mud-bomb.json
+++ b/packs/core-moves/mud-bomb.json
@@ -11,16 +11,16 @@
         "type": "attack",
         "traits": [
           "explode",
-          "blast-3"
+          "blast-2"
         ],
         "range": {
           "target": "blast",
-          "distance": 10,
+          "distance": 8,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5
+          "powerPoints": 3
         },
         "category": "special",
         "power": 65,
@@ -33,7 +33,7 @@
         "predicate": []
       }
     ],
-    "grade": "B",
+    "grade": "C",
     "_migration": {
       "version": null,
       "previous": null

--- a/packs/core-moves/pestilience.json
+++ b/packs/core-moves/pestilience.json
@@ -7,7 +7,7 @@
     "slug": "pestilience",
     "actions": [
       {
-        "name": "Item",
+        "name": "Pestilience",
         "slug": "pestilence",
         "type": "attack",
         "img": "systems/ptr2e/img/svg/bug_icon.svg",

--- a/packs/core-moves/powder.json
+++ b/packs/core-moves/powder.json
@@ -11,7 +11,6 @@
         "type": "attack",
         "traits": [
           "powder",
-          "blast-1",
           "explode",
           "priority-30"
         ],
@@ -22,14 +21,13 @@
         },
         "cost": {
           "activation": "simple",
-          "powerPoints": 2,
-          "priority": 3
+          "powerPoints": 3
         },
         "category": "status",
         "types": [
           "bug"
         ],
-        "description": "<p>Effect: All valid targets are covered in a flammable @UUID[Compendium.ptr2e.core-effects.NUba7VJbIYn7MpEh]{Powder} for 5 Activations. If a creature covered in @UUID[Compendium.ptr2e.core-effects.NUba7VJbIYn7MpEh]{Powder} attempts to use a Fire-typed move, the attack fails and they suffer @Tick[-4] as well all adjacent creatures, and the @UUID[Compendium.ptr2e.core-effects.NUba7VJbIYn7MpEh]{Powder} is removed. If a creature covered in @UUID[Compendium.ptr2e.core-effects.NUba7VJbIYn7MpEh]{Powder} is hit by a Fire-type move, they suffer @Tick[-4] alongside all adjacent creatures, and the @UUID[Compendium.ptr2e.core-effects.NUba7VJbIYn7MpEh]{Powder} is removed.</p>",
+        "description": "<p>Effect: The target and creatures adjacent to the target are are afflicted with @UUID[Compendium.ptr2e.core-effects.NUba7VJbIYn7MpEh]{Powder 5} for 5 Activations.",
         "img": "systems/ptr2e/img/svg/bug_icon.svg",
         "predicate": []
       }

--- a/packs/core-moves/present.json
+++ b/packs/core-moves/present.json
@@ -9,9 +9,7 @@
         "slug": "present",
         "name": "Present",
         "type": "attack",
-        "traits": [
-          "blast-1"
-        ],
+        "traits": [],
         "range": {
           "target": "creature",
           "distance": 15,
@@ -38,9 +36,7 @@
         "slug": "present-2",
         "name": "Present x2",
         "type": "attack",
-        "traits": [
-          "blast-1"
-        ],
+        "traits": [],
         "range": {
           "target": "creature",
           "distance": 15,
@@ -68,9 +64,7 @@
         "slug": "present-3",
         "name": "Present x3",
         "type": "attack",
-        "traits": [
-          "blast-1"
-        ],
+        "traits": [],
         "range": {
           "target": "creature",
           "distance": 15,
@@ -99,7 +93,6 @@
         "name": "Present (Gift)",
         "type": "attack",
         "traits": [
-          "blast-1",
           "healing"
         ],
         "range": {

--- a/packs/core-moves/rock-slide.json
+++ b/packs/core-moves/rock-slide.json
@@ -14,12 +14,12 @@
         ],
         "range": {
           "target": "blast",
-          "distance": 5,
+          "distance": 6,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6
+          "powerPoints": 5
         },
         "category": "physical",
         "power": 75,

--- a/packs/core-moves/rock-wrecker.json
+++ b/packs/core-moves/rock-wrecker.json
@@ -11,7 +11,7 @@
         "type": "attack",
         "traits": [
           "flinch-40",
-          "blast-3",
+          "blast-2",
           "missile"
         ],
         "range": {
@@ -21,7 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 8
+          "powerPoints": 7
         },
         "category": "physical",
         "power": 150,

--- a/packs/core-moves/rune-ray.json
+++ b/packs/core-moves/rune-ray.json
@@ -13,7 +13,7 @@
         "img": "systems/ptr2e/img/svg/normal_icon.svg",
         "traits": [
           "ray",
-          "blast-3",
+          "blast-2",
           "flinch-20"
         ],
         "range": {
@@ -23,7 +23,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 12,
+          "powerPoints": 10,
           "delay": 2
         },
         "types": [

--- a/packs/core-moves/sand-tomb.json
+++ b/packs/core-moves/sand-tomb.json
@@ -20,7 +20,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 5
+          "powerPoints": 4
         },
         "category": "physical",
         "power": 35,

--- a/packs/core-moves/snow-cannon.json
+++ b/packs/core-moves/snow-cannon.json
@@ -12,7 +12,7 @@
         "type": "attack",
         "img": "icons/svg/explosion.svg",
         "traits": [
-          "blast-2",
+          "blast-1",
           "missile"
         ],
         "range": {
@@ -22,7 +22,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 6
+          "powerPoints": 5
         },
         "types": [
           "ice"

--- a/packs/core-moves/spike-bomb.json
+++ b/packs/core-moves/spike-bomb.json
@@ -12,7 +12,7 @@
         "type": "attack",
         "img": "icons/svg/explosion.svg",
         "traits": [
-          "blast-2",
+          "blast-3",
           "explode",
           "hazard"
         ],

--- a/packs/core-moves/subduction.json
+++ b/packs/core-moves/subduction.json
@@ -10,11 +10,12 @@
         "name": "Subduction",
         "type": "attack",
         "traits": [
-          "blast-3"
+          "blast-4",
+          "earthbound"
         ],
         "range": {
           "target": "blast",
-          "distance": 10,
+          "distance": 9,
           "unit": "m"
         },
         "cost": {

--- a/packs/core-moves/syrup-bomb.json
+++ b/packs/core-moves/syrup-bomb.json
@@ -11,16 +11,16 @@
         "type": "attack",
         "traits": [
           "explode",
-          "blast-3"
+          "blast-2"
         ],
         "range": {
           "target": "blast",
-          "distance": 10,
+          "distance": 7,
           "unit": "m"
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7
+          "powerPoints": 5
         },
         "category": "special",
         "power": 65,

--- a/packs/core-moves/tar-shot.json
+++ b/packs/core-moves/tar-shot.json
@@ -10,7 +10,7 @@
         "name": "Tar Shot",
         "type": "attack",
         "traits": [
-          "blast-2"
+          "blast-1"
         ],
         "range": {
           "target": "blast",
@@ -19,7 +19,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 4
+          "powerPoints": 3
         },
         "category": "status",
         "power": null,

--- a/packs/core-moves/twister.json
+++ b/packs/core-moves/twister.json
@@ -21,7 +21,7 @@
         },
         "cost": {
           "activation": "complex",
-          "powerPoints": 7
+          "powerPoints": 6
         },
         "category": "special",
         "power": 40,

--- a/static/traits.json
+++ b/static/traits.json
@@ -2757,79 +2757,16 @@
     "slug": "blast-x",
     "label": "Blast X",
     "related": [],
-    "description": "Utilized with ranged attacks and effects. Affects entities within a X+1m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-1",
-    "label": "Blast 1",
-    "related": [],
-    "description": "Affects entities within a 2m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-2",
-    "label": "Blast 2",
-    "related": [],
-    "description": "Affects entities within a 3m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-3",
-    "label": "Blast 3",
-    "related": [],
-    "description": "Affects entities within a 4m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-4",
-    "label": "Blast 4",
-    "related": [],
-    "description": "Affects entities within a 5m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-5",
-    "label": "Blast 5",
-    "related": [],
-    "description": "Affects entities within a 6m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-6",
-    "label": "Blast 6",
-    "related": [],
-    "description": "Affects entities within a 7m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-7",
-    "label": "Blast 7",
-    "related": [],
-    "description": "Affects entities within a 8m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-8",
-    "label": "Blast 8",
-    "related": [],
-    "description": "Affects entities within a 9m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-9",
-    "label": "Blast 9",
-    "related": [],
-    "description": "Affects entities within a 10m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-10",
-    "label": "Blast 10",
-    "related": [],
-    "description": "Affects entities within a 11m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-11",
-    "label": "Blast 11",
-    "related": [],
-    "description": "Affects entities within a 12m radius circle/sphere, centered on a selected space."
-  },
-  {
-    "slug": "blast-12",
-    "label": "Blast 12",
-    "related": [],
-    "description": "Affects entities within a 13m radius circle/sphere, centered on a selected space."
+    "description": "Utilized with ranged attacks and effects. Affects entities within a Xm radius circle/sphere, centered on a selected space.",
+    "placeholders": [
+      {
+        "keyPattern": "\\blast-d+",
+        "labelPattern": "X",
+        "valuePattern": "\\d+",
+        "descriptionPattern": "Utilized with ranged attacks and effects. Affects entities within a Xm radius circle/sphere, centered on a selected space.",
+        "descriptionReplacement": "Utilized with ranged attacks and effects. Affects entities within a {{x}}m radius circle/sphere, centered on a selected space."
+      }
+    ]
   },
   {
     "slug": "bone",


### PR DESCRIPTION
Creating a patterned Trait for Blast-X similar to Blindsense-X.
Reverting the rules for Blast, such that the Trait’s number = the template's radius.
Tweaking non-Legendary, non-Max, non-Zenith non-Hazard Blast values.
