### PR TITLE
Foundry Data Sync - Perk Automations + Potion Fix + 2 New Perks

### DIFF
--- a/packs/core-gear/potion.json
+++ b/packs/core-gear/potion.json
@@ -36,7 +36,8 @@
       "combat",
       "held",
       "restorative",
-      "consumable"
+      "consumable",
+      "healing"
     ],
     "description": "<p>The target is healed @HP[30].</p>",
     "quantity": 1,
@@ -77,7 +78,8 @@
           "unit": "m"
         }
       }
-    ]
+    ],
+    "ammoType": []
   },
   "_id": "YuNyZ1fm5ALuQIVf",
   "effects": [
@@ -110,7 +112,8 @@
             ],
             "dontMerge": false,
             "ignored": false,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -124,7 +127,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -136,13 +141,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.360",
         "systemId": "ptr2e",
         "systemVersion": "1.4.4.beta",
         "createdTime": 1758364341903,
         "modifiedTime": 1758364517459,
         "lastModifiedBy": "Kc3DOunCh3ClAeHS"
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "folder": "srQci2ThhRKdmC6g"

--- a/packs/core-perks/dont-interrupt-me.json
+++ b/packs/core-perks/dont-interrupt-me.json
@@ -3,7 +3,71 @@
   "_id": "8TTvldPmY0wT9isl",
   "type": "perk",
   "img": "icons/creatures/magical/construct-face-stone-pink.webp",
-  "effects": [],
+  "effects": [
+    {
+      "name": "Don't Interrupt Me",
+      "type": "passive",
+      "_id": "kAicqqYB37L2aNMS",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "ephemeral-effect",
+            "key": "attack",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.QdbBH4Zmewj1ZB9q",
+            "phase": "initial",
+            "predicate": [
+              {
+                "not": "target:mark:duel"
+              },
+              {
+                "not": "origin:mark:duel"
+              }
+            ],
+            "affects": "defensive",
+            "alterations": [],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779316034946,
+        "modifiedTime": 1779316092087,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
   "system": {
     "_migration": {
       "version": 0.111,
@@ -20,7 +84,9 @@
     "slug": "dont-interrupt-me",
     "description": "<p>Effect: While Afflicted with @Affliction[duel], the user has +2 EVA Stages against Attacks originating from creatures other than their Duel Partner.</p>",
     "traits": [],
-    "prerequisites": [],
+    "prerequisites": [
+      "item:perk:high-noon"
+    ],
     "autoUnlock": [],
     "cost": 3,
     "design": {
@@ -34,16 +100,23 @@
       {
         "x": 61,
         "y": 188,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "duelists-glory",
           "run-down",
           "duelists-eye"
         ],
-        "hidden": false,
-        "type": "normal",
+        "config": {
+          "texture": null,
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
+        },
         "tier": null
       }
-    ]
+    ],
+    "traitWebs": []
   },
   "folder": "W85LoOCz3WlwbyhZ"
 }

--- a/packs/core-perks/duelists-eye.json
+++ b/packs/core-perks/duelists-eye.json
@@ -51,9 +51,7 @@
       }
     ],
     "slug": "duelists-eye",
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "traitWebs": []
   },
   "img": "icons/svg/target.svg",
   "effects": [
@@ -69,24 +67,30 @@
             "key": "system.battleStats.accuracy.stage",
             "value": 2,
             "predicate": [
-              "effect:affliction:duel"
+              "target:mark:duel",
+              "origin:mark:duel"
             ],
             "label": "Duelist's Eye - Duel Partner?",
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -98,16 +102,18 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.2.1.beta",
-        "createdTime": null,
-        "modifiedTime": null,
-        "lastModifiedBy": null,
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779316146270,
+        "modifiedTime": 1779316146270,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
-  "flags": {},
   "_id": "hqLlxrNgq2V9zDSL"
 }

--- a/packs/core-perks/duelists-glory.json
+++ b/packs/core-perks/duelists-glory.json
@@ -52,9 +52,7 @@
       }
     ],
     "slug": "duelists-glory",
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "traitWebs": []
   },
   "img": "systems/ptr2e/img/icons/weapon_icon.webp",
   "effects": [
@@ -70,25 +68,31 @@
             "key": "attack-damage",
             "value": 15,
             "predicate": [
-              "effect:affliction:duel"
+              "target:mark:duel",
+              "origin:mark:duel"
             ],
             "label": "Duelist's Glory - Duel Partner?",
             "priority": null,
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -100,16 +104,18 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.3.1.beta",
-        "createdTime": null,
-        "modifiedTime": 1750815112813,
-        "lastModifiedBy": "nrhyib0OvR59Mlxq",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779316162077,
+        "modifiedTime": 1779316162077,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
-  "flags": {},
   "_id": "eikDsQbPZgZBF4Pv"
 }

--- a/packs/core-perks/healing-hands.json
+++ b/packs/core-perks/healing-hands.json
@@ -60,9 +60,71 @@
       ],
       "notes": ""
     },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "traitWebs": []
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Healing Hands",
+      "type": "passive",
+      "_id": "PHlcyrCkF7CeUHhP",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "effect-alteration",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [
+              "item:trait:healing"
+            ],
+            "alterations": [
+              {
+                "method": 1,
+                "property": "system.changes.0.value",
+                "value": 1.25
+              }
+            ],
+            "key": "hp-tick-effect-applied",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779314768318,
+        "modifiedTime": 1779314918818,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-perks/metamove-effect-penetration.json
+++ b/packs/core-perks/metamove-effect-penetration.json
@@ -1,0 +1,129 @@
+{
+  "name": "Metamove: Effect Penetration",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [],
+    "description": "<p>When making an attack, the user may spend X PP, up to 5. The attack gains +20% * X Effect Hit Rate until it is resolved.</p><p>This is managed via the embedded Effect Penetration clock.</p>",
+    "traits": [],
+    "prerequisites": [],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "mental",
+      "approach": "finesse",
+      "archetype": "metamove"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 120,
+        "y": 172,
+        "connected": [
+          "focused-fire-1",
+          "minor-buff-57",
+          "minor-buff-15",
+          "minor-buff-14"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "jWpBbCAiU61RcZyx",
+  "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+  "effects": [
+    {
+      "name": "Metamove: Effect Penetration",
+      "type": "passive",
+      "_id": "9rBg9m2yjoNbJWX8",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "create-clock",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [],
+            "max": 5,
+            "private": false,
+            "color": "#ff80ff",
+            "key": "effectpenetratio",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "value": "20*@actor.clocks.effectpenetratio",
+            "phase": "initial",
+            "predicate": [],
+            "key": "system.modifiers.effectHitRate",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "@actor.clocks.effectpenetratio",
+            "phase": "initial",
+            "predicate": [],
+            "property": "pp-cost",
+            "definition": [],
+            "key": "attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779321681590,
+        "modifiedTime": 1779321681590,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "folder": "zrVtKATNxzLNxTUX",
+  "flags": {}
+}

--- a/packs/core-perks/metamove-guarded-strike.json
+++ b/packs/core-perks/metamove-guarded-strike.json
@@ -7,7 +7,7 @@
   "system": {
     "actions": [],
     "slug": "metamove-guarded-strike",
-    "description": "<p>When you declare an Attack, spend 2PP. The Attack gains the effect \"On hit, the user gains @Affliction[resolved 2].\" until the end of user's Activation.</p>",
+    "description": "<p>When the user attacks, they may spend 2PP to gain @Affliction[resolved 2] as a secondary effect of the attack.</p><p></p><p>This is managed with the Guarded Strike Toggle on the Effects tab of the character sheet.</p>",
     "traits": [],
     "prerequisites": [],
     "cost": 1,
@@ -17,6 +17,10 @@
     },
     "nodes": [
       {
+        "x": 118,
+        "y": 176,
+        "hidden": false,
+        "type": "normal",
         "connected": [
           "metamove-bullseye",
           "metamove-target-split",
@@ -31,18 +35,11 @@
           "focused-fire-1"
         ],
         "config": {
-          "alpha": null,
-          "backgroundColor": "#808080",
-          "borderColor": null,
-          "borderWidth": null,
           "texture": "systems/ptr2e/img/perk-icons/Arcana.svg",
-          "tint": null,
-          "scale": null
+          "backgroundColor": null,
+          "borderColor": null,
+          "tint": null
         },
-        "hidden": false,
-        "type": "normal",
-        "x": 118,
-        "y": 176,
         "tier": null
       }
     ],
@@ -61,9 +58,98 @@
       ],
       "notes": ""
     },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "traitWebs": []
   },
-  "effects": []
+  "effects": [
+    {
+      "name": "Metamove: Guarded Strike",
+      "type": "passive",
+      "_id": "XzPLOzl1wTQZ6yHU",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "guarded:strike",
+            "phase": "initial",
+            "predicate": [],
+            "domain": "all",
+            "toggleable": true,
+            "count": false,
+            "state": true,
+            "label": "Guarded Strike",
+            "alwaysActive": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.resolvedconditio",
+            "phase": "initial",
+            "predicate": [
+              "guarded:strike"
+            ],
+            "chance": 100,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "value": 2,
+            "phase": "initial",
+            "predicate": [],
+            "property": "pp-cost",
+            "definition": [
+              "guarded:strike"
+            ],
+            "key": "attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779314340687,
+        "modifiedTime": 1779314414000,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-perks/unown-song-andante.json
+++ b/packs/core-perks/unown-song-andante.json
@@ -1,0 +1,85 @@
+{
+  "name": "Unown Song: Andante",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "PTR 2e Core",
+      "authors": [
+        "Fox"
+      ],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Unown Song: Andante",
+        "slug": "unown-song-andante",
+        "description": "<p>Effect: The user creates an Andante summon. This summon has 150AV and lasts for 3 activations. While the Andante summon is active all Teleport Movement is disabled. Additionally, this summon cleanses the @Affliction[transient] affliction on creation and disables the @Trait[phasing] trait while active.</p>",
+        "traits": [
+          "sage",
+          "partial-automation",
+          "summon"
+        ],
+        "type": "generic",
+        "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+        "cost": {
+          "activation": "complex",
+          "powerPoints": 3
+        },
+        "summon": "Compendium.ptr2e.core-summons.Item.bCnh6SKOLrutRMRl",
+        "range": {
+          "target": "field",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ],
+    "description": "<p>Effect: The user creates an Andante summon. This summon has 150AV and lasts for 3 activations. While the Andante summon is active all Teleport Movement is disabled. Additionally, this summon cleanses the @Affliction[transient] affliction on creation and disables the @Trait[phasing] trait while active.</p>",
+    "traits": [
+      "sage",
+      "partial-automation",
+      "summon"
+    ],
+    "prerequisites": [
+      {
+        "gte": [
+          "{actor|skills.thaumaturgy.mod}",
+          35
+        ]
+      }
+    ],
+    "autoUnlock": [],
+    "cost": 2,
+    "design": {
+      "arena": "mental",
+      "approach": "resilience",
+      "archetype": "sage"
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": [
+      {
+        "x": 132,
+        "y": 108,
+        "connected": [
+          "exorcism",
+          "type-domain",
+          "defer-destiny",
+          "unown-song-fugue"
+        ],
+        "hidden": false,
+        "type": "normal",
+        "tier": null
+      }
+    ]
+  },
+  "_id": "QV4bwv7iUzzPlUJG",
+  "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+  "effects": [],
+  "folder": "KcpEanpX82Cu6Dqh",
+  "flags": {}
+}

--- a/packs/core-perks/valetudinary.json
+++ b/packs/core-perks/valetudinary.json
@@ -18,8 +18,9 @@
             "predicate": [
               "self:state:desperation-1-2"
             ],
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "basic",
@@ -28,8 +29,9 @@
             "predicate": [
               "self:state:desperation-1-2"
             ],
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "basic",
@@ -38,8 +40,9 @@
             "predicate": [
               "self:state:desperation-1-2"
             ],
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "basic",
@@ -48,8 +51,9 @@
             "predicate": [
               "self:state:desperation-1-2"
             ],
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "basic",
@@ -58,8 +62,9 @@
             "predicate": [
               "self:state:desperation-1-2"
             ],
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "basic",
@@ -68,8 +73,18 @@
             "predicate": [
               "self:state:desperation-1-2"
             ],
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.modifiers.movement",
+            "value": 2,
+            "phase": "initial",
+            "predicate": [],
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -83,7 +98,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -95,13 +112,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "14.361",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.3.beta",
+        "systemVersion": "1.7.5.beta",
         "createdTime": 1757810214501,
-        "modifiedTime": 1757810458996,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1779315953649,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ],
   "system": {
@@ -118,11 +139,10 @@
     },
     "actions": [],
     "slug": "valetudinary",
-    "description": "<p><span style=\"font-family: -apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, &#x27;Noto Sans&#x27;, Helvetica, Arial, sans-serif, &#x27;Apple Color Emoji&#x27;, &#x27;Segoe UI Emoji&#x27;\">While the user meets the [Desperation 1/2] condition, they gain +2 default EVA and SPD Stages. lose -1 ATK. DEF, SPATK, SPDEF Stages, and gain +2 to all of their Movement Scores.</span></p>",
+    "description": "<p>While the user meets the [Desperation 1/2] condition, they gain +2 default EVA and SPD Stages. lose -1 ATK. DEF, SPATK, SPDEF Stages, and gain +2 to all of their Movement Scores.</p>",
     "traits": [
       "healer",
-      "desperation-1-2",
-      "partial-automation"
+      "desperation-1-2"
     ],
     "prerequisites": [],
     "autoUnlock": [],
@@ -151,7 +171,8 @@
         },
         "tier": null
       }
-    ]
+    ],
+    "traitWebs": []
   },
   "folder": "4UhJK1LInml07WJf"
 }

--- a/packs/core-summons/andante.json
+++ b/packs/core-summons/andante.json
@@ -1,0 +1,96 @@
+{
+  "name": "Andante",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "traits": [
+      "summon",
+      "partial-automation"
+    ],
+    "actions": [],
+    "baseAV": 150,
+    "duration": 3
+  },
+  "_id": "bCnh6SKOLrutRMRl",
+  "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
+  "effects": [
+    {
+      "name": "Andante",
+      "type": "summon",
+      "_id": "9IpfUqHTOMOrVrrq",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "remove-trait",
+            "value": "phasing",
+            "phase": "initial",
+            "predicate": [],
+            "key": "",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.movement.teleport.value",
+            "value": 0,
+            "phase": "initial",
+            "predicate": [],
+            "method": 3,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage",
+        "predicate": [],
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.361",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.5.beta",
+        "createdTime": 1779316615722,
+        "modifiedTime": 1779316615722,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}


### PR DESCRIPTION
Adds Metamove: Effect Penetration and Unown Song: Andante.
- Update Perk: Metamove: Guarded Strike
- Update Perk: Healing Hands
- Update Consumable: Potion
- Update Perk: Valetudinary
- Update Perk: Don't Interrupt Me
- Update Perk: Duelist's Eye
- Update Perk: Duelist's Glory
- Update Summon: Andante
- Update Perk: Unown Song: Andante
- Update Perk: Metamove: Effect Penetration