### PR TITLE
Foundry Data Sync - Assorted Automations and Fixes

### DIFF
--- a/packs/core-abilities/analytic.json
+++ b/packs/core-abilities/analytic.json
@@ -17,11 +17,11 @@
           "unit": "m",
           "distance": 10
         },
-        "description": "<p>Effect: When the Analytic Toggle is activated, your damaging attacks use the target's Speed stat as your attacking stat. Deactivating this toggle restores normal behaviour.</p>",
+        "description": "<p>Effect: The user may utilize the target's SPD as the Attacking Stat for their Attacks (using the Analytic toggle to toggle this effect on or off).</p>",
         "img": "icons/magic/time/hourglass-tilted-gray.webp"
       }
     ],
-    "description": "<p>Effect: When the Analytic Toggle is activated, your damaging attacks use the target's Speed stat as your attacking stat. Deactivating this toggle restores normal behaviour.</p>",
+        "description": "<p>Effect: The user may utilize the target's SPD as the Attacking Stat for their Attacks (using the Analytic toggle to toggle this effect on or off).</p>",
     "traits": [],
     "slug": "analytic",
     "_migration": {

--- a/packs/core-abilities/analytic.json
+++ b/packs/core-abilities/analytic.json
@@ -14,13 +14,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Effect: Increases the Power of the user's attacks by 30% against targets that have a higher BaseAV than the user.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: When the Analytic Toggle is activated, your damaging attacks use the target's Speed stat as your attacking stat. Deactivating this toggle restores normal behaviour.</p>",
+        "img": "icons/magic/time/hourglass-tilted-gray.webp"
       }
     ],
-    "description": "<p>Effect: Increases the Power of the user's attacks by 30% against targets that have a higher BaseAV than the user.</p>",
+    "description": "<p>Effect: When the Analytic Toggle is activated, your damaging attacks use the target's Speed stat as your attacking stat. Deactivating this toggle restores normal behaviour.</p>",
     "traits": [],
     "slug": "analytic",
     "_migration": {
@@ -31,9 +32,97 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "ikUYMCR8N1knppzn",
-  "effects": []
+  "effects": [
+    {
+      "name": "Analytic",
+      "type": "passive",
+      "_id": "nLVqcRy2x2LfKDNE",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "alter-attack",
+            "value": "spe",
+            "phase": "initial",
+            "predicate": [],
+            "property": "offensiveStat",
+            "definition": [
+              "analytic:active"
+            ],
+            "key": "damaging-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "alter-attack",
+            "value": "use-opponents-stats",
+            "phase": "initial",
+            "predicate": [],
+            "key": "damaging-attack",
+            "property": "traits",
+            "definition": [
+              "analytic:active"
+            ],
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-option",
+            "value": "analytic:active",
+            "phase": "initial",
+            "predicate": [],
+            "domain": "all",
+            "toggleable": true,
+            "count": false,
+            "state": true,
+            "alwaysActive": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.363",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1779625653282,
+        "modifiedTime": 1779625748714,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/arena-trap.json
+++ b/packs/core-abilities/arena-trap.json
@@ -65,7 +65,7 @@
             "radius": 5,
             "effects": [
               {
-                "uuid": "Compendium.ptr2e.core-effects.Item.mH3mrRSypE6N3USQ",
+                "uuid": "Compendium.ptr2e.core-effects-new.ActiveEffect.mH3mrRSypE6N3USQ",
                 "affects": "enemies",
                 "events": [
                   "enter"
@@ -88,11 +88,11 @@
               "texture": null
             },
             "mergeExisting": true,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-option",
-            "key": "",
             "value": "arena-trap:active",
             "predicate": [],
             "domain": "all",
@@ -101,9 +101,11 @@
             "count": false,
             "state": true,
             "alwaysActive": false,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
             "ignored": false,
-            "suboptions": [],
-            "method": 2
+            "suboptions": []
           }
         ],
         "slug": null,
@@ -117,7 +119,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -129,13 +133,17 @@
         "compendiumSource": "Compendium.ptr2e.core-abilities.Item.iotInErMkWzaKpKP.ActiveEffect.ZpcUpVdnRuoUIMDr",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
-        "systemVersion": "1.5.0.beta",
+        "systemVersion": "1.7.6.beta",
         "createdTime": 1765275704215,
-        "modifiedTime": 1772808782967,
-        "lastModifiedBy": "Bk6N5iKyebvEVXhL"
-      }
+        "modifiedTime": 1779617019495,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-abilities/aroma-veil.json
+++ b/packs/core-abilities/aroma-veil.json
@@ -19,11 +19,11 @@
           "distance": 5,
           "unit": "m"
         },
-        "description": "<p>Effect: The user and allies within range have a 50% chance of being cured of 1 @Trait[minor-affliction] and a 10% chance of being cured of 1 @Trait[major-affliction] at the end of their Activations, the oldest Afflictions being cured first.</p>",
+        "description": "<p>Effect: The user and allies within range are immune to @Trait[attention] afflictions.</p>",
         "img": "icons/magic/nature/lotus-glow-pink.webp"
       }
     ],
-    "description": "<p>Effect: The user and allies within range have a 50% chance of being cured of 1 @Trait[minor-affliction] and a 10% chance of being cured of 1 @Trait[major-affliction] at the end of their Activations, the oldest Afflictions being cured first.</p>",
+    "description": "<p>Effect: The user and allies within range are immune to @Trait[attention] afflictions.</p>",
     "traits": [
       "aura"
     ],
@@ -41,5 +41,104 @@
     }
   },
   "_id": "cvRJdwFqTqvf2K9X",
-  "effects": []
+  "effects": [
+    {
+      "name": "Aroma Veil",
+      "type": "passive",
+      "_id": "AIf5lYPoCTV15Xio",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "aroma-veil:active",
+            "phase": "initial",
+            "predicate": [],
+            "domain": "all",
+            "toggleable": true,
+            "count": false,
+            "state": true,
+            "alwaysActive": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "aura",
+            "key": "",
+            "value": 0,
+            "predicate": [],
+            "priority": null,
+            "ignored": false,
+            "radius": 5,
+            "effects": [
+              {
+                "uuid": "Compendium.ptr2e.core-effects-new.ActiveEffect.SZ9PfqfA96YcbKnW",
+                "affects": "allies",
+                "events": [
+                  "enter"
+                ],
+                "removeOnExit": true,
+                "includesSelf": true,
+                "appliesSelfOnly": false,
+                "predicate": [
+                  "friend-guard"
+                ]
+              }
+            ],
+            "appearance": {
+              "border": {
+                "color": "#FF0000",
+                "alpha": 0.75
+              },
+              "highlight": {
+                "color": "user-color",
+                "alpha": 0.25
+              },
+              "texture": null
+            },
+            "mergeExisting": true,
+            "method": 2,
+            "phase": "initial"
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.363",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1779630712941,
+        "modifiedTime": 1779630759438,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-abilities/atomic-burst.json
+++ b/packs/core-abilities/atomic-burst.json
@@ -21,40 +21,13 @@
           "unit": "m",
           "distance": 10
         },
-        "description": "<p>The user is hit by a super effective Attack or by a Critical Hit.</p><p>Effect: The user freely uses Gamma Ray.</p>",
-        "img": "icons/svg/explosion.svg"
-      },
-      {
-        "slug": "gamma-ray",
-        "name": "Gamma Ray",
-        "type": "attack",
-        "traits": [
-          "ray"
-        ],
-        "range": {
-          "target": "creature",
-          "distance": 5,
-          "unit": "m"
-        },
-        "cost": {
-          "activation": "complex",
-          "powerPoints": 1
-        },
-        "category": "special",
-        "power": 35,
-        "accuracy": 100,
-        "types": [
-          "nuclear"
-        ],
-        "free": true,
-        "img": "icons/svg/explosion.svg",
-        "predicate": []
+        "description": "<p>Trigger: The user is hit by a @Trait[contact] attack.</p><p>Effect: The attacker suffers @Tick[-2] and -1 Special Attack for 5 activations, unless shielded.</p>",
+        "img": "systems/ptr2e/img/svg/nuclear_icon.svg"
       }
     ],
-    "description": "<p>The user is hit by a super effective Attack or by a Critical Hit.</p><p>Effect: Connection - Gamma Ray. The user freely uses Gamma Ray.</p>",
+    "description": "<p>Trigger: The user is hit by a @Trait[contact] attack.</p><p>Effect: The attacker suffers @Tick[-2] and -1 Special Attack for 5 activations, unless shielded.</p>",
     "traits": [
-      "defensive",
-      "connection"
+      "defensive"
     ],
     "slug": "atomic-burst",
     "_migration": {
@@ -75,28 +48,22 @@
       "name": "Atomic Burst",
       "type": "passive",
       "_id": "m92XAt5vEzXdM8AF",
-      "img": "systems/ptr2e/img/icons/effect_icon.webp",
+      "img": "systems/ptr2e/img/svg/nuclear_icon.svg",
       "system": {
         "changes": [
           {
-            "type": "grant-item",
-            "key": "",
-            "value": "Compendium.ptr2e.core-moves.Item.WVPzbqV4kQo9e29K",
-            "predicate": [
-              "ability:atomic-burst:active"
-            ],
-            "allowDuplicate": false,
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.7lE4m5eWaezOeW1q",
+            "phase": "initial",
+            "predicate": [],
+            "key": "contact-trait-attack",
+            "affects": "origin",
             "alterations": [],
-            "onDeleteActions": {
-              "grantee": "detach",
-              "granter": "cascade"
-            },
-            "reevaluateOnUpdate": true,
-            "ignored": false,
-            "inMemoryOnly": false,
-            "track": false,
-            "replaceSelf": false,
-            "method": 2
+            "chance": 100,
+            "isFixedChance": false,
+            "dontMerge": false,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -110,7 +77,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -123,13 +92,16 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.2.beta",
+        "systemVersion": "1.7.6.beta",
         "createdTime": 1754316775050,
-        "modifiedTime": 1754316808266,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1779630540255,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ],
   "folder": "0nG9TRDSwrmcTFwO"

--- a/packs/core-abilities/atomic-burst.json
+++ b/packs/core-abilities/atomic-burst.json
@@ -21,11 +21,11 @@
           "unit": "m",
           "distance": 10
         },
-        "description": "<p>Trigger: The user is hit by a @Trait[contact] attack.</p><p>Effect: The attacker suffers @Tick[-2] and -1 Special Attack for 5 activations, unless shielded.</p>",
+        "description": "<p>Trigger: The user is hit by a @Trait[contact] Attack.</p><p>Effect: The source of the triggering Attack loses@Tick[-2] and -1 SPATK Stage for 5 Activations If this creature is not Shielded.</p>",
         "img": "systems/ptr2e/img/svg/nuclear_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user is hit by a @Trait[contact] attack.</p><p>Effect: The attacker suffers @Tick[-2] and -1 Special Attack for 5 activations, unless shielded.</p>",
+     "description": "<p>Trigger: The user is hit by a @Trait[contact] Attack.</p><p>Effect: The source of the triggering Attack loses@Tick[-2] and -1 SPATK Stage for 5 Activations If this creature is not Shielded.</p>",
     "traits": [
       "defensive"
     ],

--- a/packs/core-abilities/beast-boost.json
+++ b/packs/core-abilities/beast-boost.json
@@ -13,7 +13,6 @@
         "type": "generic",
         "cost": {
           "activation": "free",
-          "powerPoints": 2,
           "trigger": "<p>The user causes at least one creature to gain @Affliction[fainted].</p>"
         },
         "range": {
@@ -21,12 +20,12 @@
           "unit": "m"
         },
         "description": "<p>Trigger: The user causes at least one creature to gain @Affliction[fainted]</p><p>Effect: The user's highest stat increases by +1 Stage for 5 Activations. If two or more highest stats are tied, the user chooses which one this Ability affects.</p>",
-        "img": "icons/svg/explosion.svg"
+        "img": "systems/ptr2e/img/conditions/vortex.svg"
       }
     ],
     "description": "<p>Trigger: The user causes at least one creature to gain @Affliction[fainted]</p><p>Effect: The user's highest stat increases by +1 Stage for 5 Activations. If two or more highest stats are tied, the user chooses which one this Ability affects.</p>",
     "traits": [
-      "legendary"
+      "ultra"
     ],
     "slug": "beast-boost",
     "_migration": {
@@ -37,7 +36,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "rpWKSVHIyULSZn4a",

--- a/packs/core-abilities/flower-gift.json
+++ b/packs/core-abilities/flower-gift.json
@@ -63,7 +63,7 @@
             "radius": 5,
             "effects": [
               {
-                "uuid": "Compendium.ptr2e.core-effects.Item.NxRv9tB4DzNuKc12",
+                "uuid": "Compendium.ptr2e.core-effects-new.ActiveEffect.NxRv9tB4DzNuKc12",
                 "affects": "allies",
                 "events": [
                   "enter"
@@ -88,7 +88,8 @@
               "texture": null
             },
             "mergeExisting": true,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -102,7 +103,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -114,13 +117,17 @@
         "compendiumSource": "Compendium.ptr2e.core-abilities.Item.CzvgRhfvDuRjrtA1.ActiveEffect.WPH789V0rRrGKYvw",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
+        "systemVersion": "1.7.6.beta",
         "createdTime": 1765277606084,
-        "modifiedTime": 1765277677553,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1779617075769,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-abilities/friend-guard.json
+++ b/packs/core-abilities/friend-guard.json
@@ -61,7 +61,7 @@
             "radius": 5,
             "effects": [
               {
-                "uuid": "Compendium.ptr2e.core-effects.Item.AUlSkFUziUM3nxww",
+                "uuid": "Compendium.ptr2e.core-effects-new.ActiveEffect.AUlSkFUziUM3nxww",
                 "affects": "allies",
                 "events": [
                   "enter"
@@ -86,7 +86,8 @@
               "texture": null
             },
             "mergeExisting": true,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-option",
@@ -101,7 +102,8 @@
             "alwaysActive": false,
             "ignored": false,
             "suboptions": [],
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -115,7 +117,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -127,14 +131,17 @@
       "_stats": {
         "compendiumSource": "Compendium.ptr2e.core-abilities.Item.CzvgRhfvDuRjrtA1.ActiveEffect.WPH789V0rRrGKYvw",
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
-        "systemVersion": "1.3.8.beta",
+        "systemVersion": "1.7.6.beta",
         "createdTime": 1741605625285,
-        "modifiedTime": 1752340875722,
-        "lastModifiedBy": "Kc3DOunCh3ClAeHS",
+        "modifiedTime": 1779616907295,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/majestic-moth.json
+++ b/packs/core-abilities/majestic-moth.json
@@ -17,13 +17,14 @@
         },
         "range": {
           "target": "self",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
-        "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: The user's highest stat has its default Stage increased by +1.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Trigger: The user enters battle.</p><p>Effect: The user's highest stat has its default Stage increased by +1.</p>",
+        "img": "systems/ptr2e/img/svg/bug_icon.svg"
       }
     ],
-    "description": "<p>Trigger: The user enters battle, or emerges from stealth.</p><p>Effect: The user's highest stat has its default Stage increased by +1.</p>",
+    "description": "<p>Trigger: The user enters battle.</p><p>Effect: The user's highest stat has its default Stage increased by +1.</p>",
     "traits": [],
     "slug": "majestic-moth",
     "_migration": {
@@ -34,7 +35,8 @@
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
     }
   },
   "_id": "Oro59rqa2BhDn8Ik",

--- a/packs/core-abilities/man-eater.json
+++ b/packs/core-abilities/man-eater.json
@@ -20,11 +20,11 @@
           "unit": "m",
           "distance": 10
         },
-        "description": "<p>Effect: The user's [Contact] attacks gain the [Drain 1/16] Trait.</p>",
-        "img": "icons/svg/explosion.svg"
+        "description": "<p>Effect: The user's [Contact] attacks gain the [Drain 1/10] Trait.</p>",
+        "img": "systems/ptr2e/img/item-icons/razor%20fang.webp"
       }
     ],
-    "description": "<p>Effect: The user's [Contact] attacks gain the [Drain 1/16] Trait.</p>",
+    "description": "<p>Effect: The user's [Contact] attacks gain the [Drain 1/10] Trait.</p>",
     "traits": [
       "defensive",
       "healing"
@@ -54,12 +54,13 @@
           {
             "type": "alter-attack",
             "key": "contact-trait-attack",
-            "value": "drain-1-16",
+            "value": "drain-1-10",
             "predicate": [],
-            "ignored": false,
             "property": "traits",
             "definition": [],
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -73,7 +74,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -85,13 +88,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
+        "systemVersion": "1.7.6.beta",
         "createdTime": 1765280712689,
-        "modifiedTime": 1765280742787,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1779639928386,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-abilities/power-spot.json
+++ b/packs/core-abilities/power-spot.json
@@ -62,7 +62,8 @@
             "alwaysActive": false,
             "ignored": false,
             "suboptions": [],
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "aura",
@@ -75,7 +76,7 @@
             "radius": 5,
             "effects": [
               {
-                "uuid": "Compendium.ptr2e.core-effects.Item.uQhAsBqwwK8UspsW",
+                "uuid": "Compendium.ptr2e.core-effects-new.ActiveEffect.uQhAsBqwwK8UspsW",
                 "affects": "allies",
                 "events": [
                   "enter"
@@ -99,7 +100,8 @@
             },
             "mergeExisting": true,
             "priority": null,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -113,7 +115,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -126,13 +130,16 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
-        "systemVersion": "1.3.8.beta",
+        "systemVersion": "1.7.6.beta",
         "createdTime": 1753016752091,
-        "modifiedTime": 1753017703344,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1779617109226,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-abilities/radiance.json
+++ b/packs/core-abilities/radiance.json
@@ -55,7 +55,7 @@
             "radius": 5,
             "effects": [
               {
-                "uuid": "Compendium.ptr2e.core-effects.Item.kdGYOBLwfWuVC71W",
+                "uuid": "Compendium.ptr2e.core-effects-new.ActiveEffect.kdGYOBLwfWuVC71W",
                 "affects": "allies",
                 "events": [
                   "enter"
@@ -80,7 +80,8 @@
               "texture": null
             },
             "mergeExisting": true,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-option",
@@ -95,7 +96,8 @@
             "alwaysActive": false,
             "ignored": false,
             "suboptions": [],
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -109,7 +111,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -121,13 +125,17 @@
         "compendiumSource": "Compendium.ptr2e.core-abilities.Item.CzvgRhfvDuRjrtA1.ActiveEffect.WPH789V0rRrGKYvw",
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
+        "systemVersion": "1.7.6.beta",
         "createdTime": 1765284273911,
-        "modifiedTime": 1765284329243,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf"
-      }
+        "modifiedTime": 1779617138283,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null,
+      "flags": {}
     }
   ]
 }

--- a/packs/core-abilities/shadow-tag.json
+++ b/packs/core-abilities/shadow-tag.json
@@ -61,7 +61,7 @@
             "radius": 5,
             "effects": [
               {
-                "uuid": "Compendium.ptr2e.core-effects.Item.8GlD03CzKP8ofSE4",
+                "uuid": "Compendium.ptr2e.core-effects-new.ActiveEffect.8GlD03CzKP8ofSE4",
                 "affects": "enemies",
                 "events": [
                   "enter"
@@ -84,7 +84,8 @@
               "texture": null
             },
             "mergeExisting": true,
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           },
           {
             "type": "roll-option",
@@ -99,7 +100,8 @@
             "alwaysActive": false,
             "ignored": false,
             "suboptions": [],
-            "method": 2
+            "method": 2,
+            "phase": "initial"
           }
         ],
         "slug": null,
@@ -113,7 +115,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -124,8 +128,18 @@
       "flags": {},
       "_stats": {
         "compendiumSource": null,
-        "duplicateSource": null
-      }
+        "duplicateSource": null,
+        "coreVersion": "14.363",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1779617173674,
+        "modifiedTime": 1779617173674,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "exportSource": null
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-effects-new/arena-trap-aura-effect.json
+++ b/packs/core-effects-new/arena-trap-aura-effect.json
@@ -2,7 +2,7 @@
   "name": "Arena Trap (Aura Effect)",
   "type": "passive",
   "_id": "mH3mrRSypE6N3USQ",
-  "img": "systems/ptr2e/img/icons/effect_icon.webp",
+  "img": "systems/ptr2e/img/perk-icons/Hunting.svg",
   "system": {
     "changes": [
       {
@@ -21,7 +21,8 @@
         "inMemoryOnly": false,
         "track": false,
         "replaceSelf": false,
-        "method": 2
+        "method": 2,
+        "phase": "initial"
       },
       {
         "type": "grant-effect",
@@ -39,7 +40,8 @@
         "inMemoryOnly": false,
         "track": false,
         "replaceSelf": false,
-        "method": 2
+        "method": 2,
+        "phase": "initial"
       },
       {
         "type": "basic",
@@ -47,38 +49,27 @@
         "value": -2,
         "predicate": [],
         "ignored": false,
-        "method": 2
+        "method": 2,
+        "phase": "initial"
       }
     ],
-    "slug": null,
+    "slug": "arena-trap-aura-effect",
     "traits": [],
-    "removeAfterCombat": true,
-    "removeOnRecall": false,
-    "removeAfterAttacking": false,
-    "removeAfterAttacked": false,
-    "stacks": 0
+    "removeAfterCombat": true
   },
   "disabled": false,
   "duration": {
     "units": "turns",
-    "value": null
+    "value": null,
+    "expiry": null,
+    "expired": false
   },
   "description": "",
   "origin": null,
   "tint": "#ffffff",
   "transfer": true,
   "statuses": [],
-  "sort": 0,
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "exportSource": null,
-    "coreVersion": "13.351",
-    "systemId": "ptr2e",
-    "systemVersion": "1.4.6.beta",
-    "createdTime": 1765275590825,
-    "modifiedTime": 1765275656693,
-    "lastModifiedBy": "mK35yvCqCgiTUvKf"
-  },
-  "folder": "sP8yfpABdpdAz4aV"
+  "folder": "sP8yfpABdpdAz4aV",
+  "start": null,
+  "showIcon": 1
 }

--- a/packs/core-effects-new/aroma-veil-aura-effect.json
+++ b/packs/core-effects-new/aroma-veil-aura-effect.json
@@ -1,0 +1,42 @@
+{
+  "folder": "sP8yfpABdpdAz4aV",
+  "name": "Aroma Veil (Aura Effect)",
+  "type": "passive",
+  "_id": "SZ9PfqfA96YcbKnW",
+  "img": "icons/magic/nature/lotus-glow-pink.webp",
+  "system": {
+    "changes": [
+      {
+        "type": "roll-option",
+        "value": "trait:attention",
+        "phase": "initial",
+        "predicate": [],
+        "domain": "immunities",
+        "toggleable": false,
+        "count": false,
+        "key": "",
+        "method": 2,
+        "ignored": false,
+        "suboptions": [],
+        "state": true
+      }
+    ],
+    "traits": [],
+    "removeAfterCombat": true
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "flags": {}
+}

--- a/packs/core-effects-new/atomic-burst-effect-self-deleting.json
+++ b/packs/core-effects-new/atomic-burst-effect-self-deleting.json
@@ -1,0 +1,84 @@
+{
+  "name": "Atomic Burst Effect (Self-Deleting)",
+  "type": "affliction",
+  "_id": "7lE4m5eWaezOeW1q",
+  "img": "systems/ptr2e/img/svg/nuclear_icon.svg",
+  "system": {
+    "changes": [
+      {
+        "type": "grant-effect",
+        "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+        "phase": "initial",
+        "predicate": [
+          {
+            "not": "self:state:shielded"
+          }
+        ],
+        "alterations": [
+          {
+            "method": 5,
+            "property": "system.changes.0.value",
+            "value": -2
+          }
+        ],
+        "onDeleteActions": {
+          "grantee": "detach",
+          "granter": "cascade"
+        },
+        "key": "hpTickEffect",
+        "method": 2,
+        "ignored": false,
+        "reevaluateOnUpdate": false,
+        "inMemoryOnly": false,
+        "allowDuplicate": true,
+        "track": false,
+        "replaceSelf": false
+      },
+      {
+        "type": "grant-effect",
+        "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.1JXumQz0QqthT9Iv",
+        "phase": "initial",
+        "predicate": [
+          {
+            "not": "self:state:shielded"
+          }
+        ],
+        "alterations": [],
+        "onDeleteActions": {
+          "grantee": "detach",
+          "granter": "detach"
+        },
+        "replaceSelf": true,
+        "key": "1SpecialAttackStage",
+        "method": 2,
+        "ignored": false,
+        "reevaluateOnUpdate": false,
+        "inMemoryOnly": false,
+        "allowDuplicate": true,
+        "track": false
+      }
+    ],
+    "traits": [],
+    "removeAfterCombat": true,
+    "priority": 50,
+    "type": "damage",
+    "predicate": [
+      "[\"[]\"]"
+    ]
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": 1,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "flags": {}
+}

--- a/packs/core-effects-new/boss-on-hit-advancement.json
+++ b/packs/core-effects-new/boss-on-hit-advancement.json
@@ -8,51 +8,41 @@
       {
         "type": "roll-effect",
         "key": "attack",
-        "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
+        "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advancecondition",
         "predicate": [],
         "chance": 100,
         "affects": "defensive",
         "dontMerge": true,
         "alterations": [
           {
+            "method": 5,
             "property": "system.amount",
-            "value": "5 + clamp(-3 * @actor.system.attributes.spe.stage, -5, 18)",
-            "method": 5
+            "value": "5 + clamp(-3 * @actor.system.attributes.spe.stage, -5, 18)"
           }
         ],
         "priority": null,
-        "ignored": false,
-        "method": 2
+        "phase": "initial",
+        "isFixedChance": false,
+        "method": 2,
+        "ignored": false
       }
     ],
-    "slug": null,
-    "traits": [],
-    "removeAfterCombat": false,
-    "removeOnRecall": false,
-    "stacks": 0,
-    "description": "<p>This effect makes it so that Bosses gain Action Advancement whenever they are hit, it scales with the amount of speed stages it has; providing no benefit if the boss is at 2 or more positive stages, and the most at -6 speed.</p><pre><code>Action Advancement% = 5 + clamp(-3 * speedStage, -5, 18)</code></pre>"
+    "slug": "boss-on-hit-advancement",
+    "traits": []
   },
   "disabled": false,
   "duration": {
     "units": "turns",
-    "value": null
+    "value": null,
+    "expiry": null,
+    "expired": false
   },
   "description": "<p>This effect makes it so that Bosses gain Action Advancement whenever they are hit, it scales with the amount of speed stages it has; providing no benefit if the boss is at 2 or more positive stages, and the most at -6 speed.</p><pre><code>Action Advancement% = 5 + clamp(-3 * speedStage, -5, 18)</code></pre>",
   "origin": null,
   "tint": "#ffffff",
   "transfer": true,
   "statuses": [],
-  "sort": 0,
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.331",
-    "systemId": "ptr2e",
-    "systemVersion": "1.1.3.beta",
-    "createdTime": 1743594347046,
-    "modifiedTime": 1743595986616,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "folder": "QUgx4S1LlBbCXWnX"
+  "folder": "QUgx4S1LlBbCXWnX",
+  "start": null,
+  "showIcon": 1
 }

--- a/packs/core-effects-new/muse-effect.json
+++ b/packs/core-effects-new/muse-effect.json
@@ -1,0 +1,26 @@
+{
+  "name": "Muse (Effect)",
+  "type": "passive",
+  "_id": "lwmhs2uaFBOk5of6",
+  "img": "systems/ptr2e/img/conditions/cheered.svg",
+  "system": {
+    "changes": [],
+    "traits": [],
+    "removeAfterCombat": true
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 2,
+  "flags": {}
+}

--- a/packs/core-effects-new/pokerface-effect.json
+++ b/packs/core-effects-new/pokerface-effect.json
@@ -1,0 +1,57 @@
+{
+  "name": "Pokerface  (Effect)",
+  "type": "affliction",
+  "_id": "95oc9ctkAhNCvthw",
+  "img": "icons/sundries/gaming/playing-cards-grey.webp",
+  "system": {
+    "changes": [
+      {
+        "type": "percentile-modifier",
+        "value": 20,
+        "phase": "initial",
+        "predicate": [],
+        "key": "damaging-attack-power",
+        "method": 2,
+        "ignored": false,
+        "hideIfDisabled": false
+      },
+      {
+        "type": "roll-effect",
+        "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advancecondition",
+        "phase": "initial",
+        "predicate": [],
+        "key": "status-attack",
+        "chance": 100,
+        "isFixedChance": false,
+        "affects": "self",
+        "alterations": [],
+        "dontMerge": false,
+        "method": 2,
+        "ignored": false
+      }
+    ],
+    "traits": [],
+    "removeAfterCombat": true,
+    "removeAfterAttacking": true,
+    "priority": 50,
+    "type": "damage",
+    "predicate": [
+      "[\"[\\\"[\\\\\\\"[]\\\\\\\"]\\\"]\"]"
+    ]
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "flags": {}
+}

--- a/packs/core-effects-new/rebound-1-2-ephemeral.json
+++ b/packs/core-effects-new/rebound-1-2-ephemeral.json
@@ -1,0 +1,38 @@
+{
+  "name": "Rebound 1/2 Ephemeral",
+  "type": "passive",
+  "_id": "dGyw246s9I3XAu4U",
+  "img": "icons/svg/aura.svg",
+  "system": {
+    "changes": [
+      {
+        "type": "alter-attack",
+        "value": "recoil-1-2",
+        "phase": "initial",
+        "predicate": [],
+        "property": "traits",
+        "definition": [],
+        "key": "damaging-attack",
+        "method": 2,
+        "ignored": false
+      }
+    ],
+    "traits": [],
+    "removeAfterCombat": true
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "flags": {}
+}

--- a/packs/core-effects-new/rebound-1-2.json
+++ b/packs/core-effects-new/rebound-1-2.json
@@ -1,0 +1,41 @@
+{
+  "name": "Rebound 1/2",
+  "type": "affliction",
+  "_id": "RvlrSPs39gvowRAv",
+  "img": "icons/svg/holy-shield.svg",
+  "system": {
+    "changes": [
+      {
+        "type": "ephemeral-effect",
+        "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.dGyw246s9I3XAu4U",
+        "phase": "initial",
+        "predicate": [],
+        "affects": "origin",
+        "alterations": [],
+        "key": "damaging-attack",
+        "method": 2,
+        "ignored": false
+      }
+    ],
+    "traits": [],
+    "removeAfterCombat": true,
+    "priority": 50,
+    "type": "damage",
+    "predicate": []
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 2,
+  "flags": {}
+}

--- a/packs/core-effects-new/rebound-1-4-ephemeral.json
+++ b/packs/core-effects-new/rebound-1-4-ephemeral.json
@@ -1,0 +1,38 @@
+{
+  "name": "Rebound 1/4 Ephemeral",
+  "type": "passive",
+  "_id": "BECoPKmYaNs4hCqz",
+  "img": "icons/svg/aura.svg",
+  "system": {
+    "changes": [
+      {
+        "type": "alter-attack",
+        "value": "recoil-1-4",
+        "phase": "initial",
+        "predicate": [],
+        "property": "traits",
+        "definition": [],
+        "key": "damaging-attack",
+        "method": 2,
+        "ignored": false
+      }
+    ],
+    "traits": [],
+    "removeAfterCombat": true
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "flags": {}
+}

--- a/packs/core-moves/substitute.json
+++ b/packs/core-moves/substitute.json
@@ -14,8 +14,7 @@
           "substitute"
         ],
         "range": {
-          "target": "creature",
-          "distance": 0,
+          "target": "self",
           "unit": "m"
         },
         "cost": {
@@ -23,27 +22,114 @@
           "powerPoints": 2
         },
         "category": "status",
-        "power": null,
-        "accuracy": null,
         "types": [
           "normal"
         ],
-        "description": "<p>Effect: The user sacrifices HP equal to 1/4 of their Max HP and creates a Substitute. The Substitute's HP is equal to the HP sacrificed.</p>",
-        "contestType": "",
-        "contestEffect": "",
-        "free": false,
-        "slot": null
+        "description": "<p>Effect: The user loses @Tick[-4] HP and gains @Tick[4 shield].</p>",
+        "img": "systems/ptr2e/img/svg/normal_icon.svg",
+        "predicate": []
       }
     ],
-    "container": null,
     "grade": "D",
     "publication": {
       "source": "PTR 2e Core",
       "authors": [
         "PTR 2e Team"
-      ]
+      ],
+      "notes": ""
+    },
+    "traits": [],
+    "_migration": {
+      "version": null,
+      "previous": null
     }
   },
   "_id": "wlCtO7DEZMMbEwcn",
-  "effects": []
+  "effects": [
+    {
+      "name": "Substitute",
+      "type": "passive",
+      "_id": "Eje4kzk6ficHrJpq",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.4DlXFTVooz07YcDm",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": -4
+              }
+            ],
+            "dontMerge": false,
+            "key": "substitute-attack",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.k1FukpHKnZGqjSNc",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.changes.0.value",
+                "value": 4
+              }
+            ],
+            "dontMerge": false,
+            "key": "substitute-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.363",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1779662627911,
+        "modifiedTime": 1779662687025,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ]
 }

--- a/packs/core-perks/gaean-retribution.json
+++ b/packs/core-perks/gaean-retribution.json
@@ -42,12 +42,93 @@
         "tier": null
       }
     ],
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "traitWebs": []
   },
   "img": "icons/magic/nature/root-vine-beanstolk-green.webp",
-  "effects": [],
-  "flags": {},
+  "effects": [
+    {
+      "name": "Gaean Retribution",
+      "type": "passive",
+      "_id": "2uqlNr2StpF0Dt8R",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "aura",
+            "key": "",
+            "value": 0,
+            "predicate": [
+              "effect:rebound"
+            ],
+            "priority": null,
+            "ignored": false,
+            "radius": 5,
+            "effects": [
+              {
+                "uuid": "Compendium.ptr2e.core-effects-new.ActiveEffect.RvlrSPs39gvowRAv",
+                "affects": "allies",
+                "events": [
+                  "enter"
+                ],
+                "removeOnExit": true,
+                "includesSelf": false,
+                "appliesSelfOnly": false,
+                "predicate": []
+              }
+            ],
+            "appearance": {
+              "border": {
+                "color": "#FF0000",
+                "alpha": 0.75
+              },
+              "highlight": {
+                "color": "user-color",
+                "alpha": 0.25
+              },
+              "texture": null
+            },
+            "mergeExisting": true,
+            "method": 2,
+            "phase": "initial"
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.363",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1779613373012,
+        "modifiedTime": 1779613472805,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
   "_id": "f4j32ICrKkHuDBB0"
 }

--- a/packs/core-perks/muse.json
+++ b/packs/core-perks/muse.json
@@ -6,7 +6,24 @@
       "version": 0.107,
       "previous": null
     },
-    "actions": [],
+    "actions": [
+      {
+        "name": "Muse",
+        "slug": "muse",
+        "description": "<p>Effect: The user maintains a Muse Clock with a size of 6 Spans. As a Simple Action, the user designates an ally as their Muse, setting the Muse Clock to 0 Spans.<br><br>When the user's designated Muse ends an Activation, increment one Span on the Muse Clock. For every Span that is filled, the user's Attacks have their Power increased by 20% and their EHR is increased 10%, up to a max increase of 100% and 50% respectively. When the Muse Clock is filled, the user is healed of all Afflictions with the @Trait[major-affliction] or @Trait[minor-affliction] traits and gains @Tick[3], and the Muse Clock is emptied.</p><p>The Muse Clock is emptied if either the user or their Muse leaves combat or is @Affliction[fainted], or if combat ends.</p>",
+        "traits": [],
+        "type": "generic",
+        "img": "systems/ptr2e/img/conditions/cheered.svg",
+        "cost": {
+          "activation": "simple"
+        },
+        "range": {
+          "target": "ally",
+          "distance": 10,
+          "unit": "m"
+        }
+      }
+    ],
     "description": "<p>Effect: The user maintains a Muse Clock with a size of 6 Spans. As a Simple Action, the user designates an ally as their Muse, setting the Muse Clock to 0 Spans.<br><br>When the user's designated Muse ends an Activation, increment one Span on the Muse Clock. For every Span that is filled, the user's Attacks have their Power increased by 20% and their EHR is increased 10%, up to a max increase of 100% and 50% respectively. When the Muse Clock is filled, the user is healed of all Afflictions with the @Trait[major-affliction] or @Trait[minor-affliction] traits and gains @Tick[3], and the Muse Clock is emptied.</p><p>The Muse Clock is emptied if either the user or their Muse leaves combat or is @Affliction[fainted], or if combat ends.</p>",
     "traits": [],
     "prerequisites": [],
@@ -54,7 +71,8 @@
         "PTR 2e Team"
       ],
       "notes": ""
-    }
+    },
+    "traitWebs": []
   },
   "img": "systems/ptr2e/img/conditions/cheered.svg",
   "effects": [
@@ -74,8 +92,9 @@
             "color": "#c2f55f",
             "private": false,
             "label": "Muse",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
           },
           {
             "type": "percentile-modifier",
@@ -83,9 +102,10 @@
             "value": "min(100,0+20*@actor.clocks.museClockUser000)",
             "predicate": [],
             "label": "Muse",
+            "phase": "initial",
+            "method": 2,
             "ignored": false,
-            "hideIfDisabled": false,
-            "method": 2
+            "hideIfDisabled": false
           },
           {
             "type": "basic",
@@ -93,8 +113,23 @@
             "value": "min(50,0+10*@actor.clocks.museClockUser000)",
             "predicate": [],
             "label": "Muse",
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.lwmhs2uaFBOk5of6",
+            "phase": "initial",
+            "predicate": [],
+            "chance": 100,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "muse-generic",
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
@@ -108,7 +143,9 @@
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -120,14 +157,17 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.351",
+        "coreVersion": "14.363",
         "systemId": "ptr2e",
-        "systemVersion": "1.4.6.beta",
+        "systemVersion": "1.7.6.beta",
         "createdTime": 1765585453387,
-        "modifiedTime": 1766013643261,
-        "lastModifiedBy": "5ImYyhOS2D6D7ypO"
+        "modifiedTime": 1779651768991,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR"
       },
-      "showIcon": 0
+      "showIcon": 0,
+      "start": null,
+      "folder": null,
+      "flags": {}
     }
   ],
   "_id": "OXVqgQQ78QUgRinK",

--- a/packs/core-perks/saprophyte.json
+++ b/packs/core-perks/saprophyte.json
@@ -47,10 +47,72 @@
         "type": "normal",
         "tier": null
       }
-    ]
+    ],
+    "slug": "saprophyte"
   },
   "img": "systems/ptr2e/img/conditions/seeded.svg",
-  "effects": [],
-  "flags": {},
+  "effects": [
+    {
+      "name": "Saprophyte",
+      "type": "passive",
+      "_id": "rOHZkleGp7ATPTgL",
+      "img": "icons/svg/aura.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.leechcondition00",
+            "phase": "initial",
+            "predicate": [
+              "origin:enemy"
+            ],
+            "chance": 20,
+            "isFixedChance": false,
+            "affects": "target",
+            "alterations": [],
+            "dontMerge": false,
+            "key": "grass-attack",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.363",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1779612038341,
+        "modifiedTime": 1779612068564,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
   "_id": "tp0M0uU1IcTgLugr"
 }


### PR DESCRIPTION
Kinda hard to pin down a specific title on this cause I've just thrown stuff together as I've gone along.
- Update Perk: Saprophyte
- Update Passive: Rebound 1/2 Ephemeral
- Update Passive: Rebound 1/4 Ephemeral
- Update Affliction: Rebound 1/2
- Update Perk: Gaean Retribution
- Update Ability: Friend Guard
- Update Ability: Arena Trap
- Update Passive: Arena Trap (Aura Effect)
- Update Ability: Flower Gift
- Update Ability: Power Spot
- Update Ability: Radiance
- Update Ability: Shadow Tag
- Update Ability: Analytic
- Update Affliction: Atomic Burst Effect (Self-Deleting)
- Update Ability: Atomic Burst
- Update Passive: Aroma Veil (Aura Effect)
- Update Ability: Aroma Veil
- Update Ability: Beast Boost
- Update Ability: Majestic Moth
- Update Ability: Man-Eater
- Update Passive: Muse (Effect)
- Update Perk: Muse
- Update Passive: Boss On-Hit Advancement
- Update Affliction: Pokerface  (Effect)
- Update Move: Substitute