### PR TITLE
Foundry Data Sync - Fixing Perk Attacks To Generics, Resorting Nu-Crafting Perks To Gear Folder

### DIFF
--- a/packs/core-perks/ball-tinkerer.json
+++ b/packs/core-perks/ball-tinkerer.json
@@ -47,10 +47,12 @@
         "type": "normal",
         "tier": null
       }
-    ]
+    ],
+    "slug": "ball-tinkerer",
+    "traitWebs": []
   },
   "img": "systems/ptr2e/img/perk-icons/Crafting.svg",
   "effects": [],
-  "flags": {},
-  "_id": "TX3utCX5xuC3iUlR"
+  "_id": "TX3utCX5xuC3iUlR",
+  "folder": "oMMIXyKwOCIxMHrK"
 }

--- a/packs/core-perks/berry-garden.json
+++ b/packs/core-perks/berry-garden.json
@@ -49,10 +49,12 @@
         "type": "normal",
         "tier": null
       }
-    ]
+    ],
+    "slug": "berry-garden",
+    "traitWebs": []
   },
   "img": "systems/ptr2e/img/item-icons/portable%20grower.webp",
   "effects": [],
-  "flags": {},
-  "_id": "ozGMX1SYPR1vhZQ9"
+  "_id": "ozGMX1SYPR1vhZQ9",
+  "folder": "oMMIXyKwOCIxMHrK"
 }

--- a/packs/core-perks/climate-capture.json
+++ b/packs/core-perks/climate-capture.json
@@ -48,10 +48,12 @@
         "type": "normal",
         "tier": null
       }
-    ]
+    ],
+    "slug": "climate-capture",
+    "traitWebs": []
   },
   "img": "systems/ptr2e/img/perk-icons/Crafting.svg",
   "effects": [],
-  "flags": {},
-  "_id": "bRAozSA9RapLc2ZA"
+  "_id": "bRAozSA9RapLc2ZA",
+  "folder": "oMMIXyKwOCIxMHrK"
 }

--- a/packs/core-perks/jailbreaker.json
+++ b/packs/core-perks/jailbreaker.json
@@ -48,10 +48,12 @@
         "type": "normal",
         "tier": null
       }
-    ]
+    ],
+    "slug": "jailbreaker",
+    "traitWebs": []
   },
   "img": "systems/ptr2e/img/perk-icons/Crafting.svg",
   "effects": [],
-  "flags": {},
-  "_id": "QtGag8YIvdLQ2DU6"
+  "_id": "QtGag8YIvdLQ2DU6",
+  "folder": "oMMIXyKwOCIxMHrK"
 }

--- a/packs/core-perks/masters-whip.json
+++ b/packs/core-perks/masters-whip.json
@@ -11,33 +11,16 @@
         "slug": "masters-whip",
         "description": "<p>You may advance a targeted ally's activation forward by 30% as a Simple Action, costing 3PP.</p>",
         "traits": [],
-        "type": "attack",
+        "type": "generic",
         "range": {
           "target": "ally",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "simple",
           "powerPoints": 3
         },
-        "img": "systems/ptr2e/img/perk-icons/Taskmaster.svg",
-        "types": [
-          "untyped"
-        ],
-        "category": "status",
-        "free": true,
-        "predicate": [],
-        "variant": null,
-        "ephemeralVariant": false,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": "",
-        "offensiveStat": null,
-        "defensiveStat": null
+        "img": "systems/ptr2e/img/perk-icons/Taskmaster.svg"
       }
     ],
     "slug": "masters-whip",
@@ -99,9 +82,7 @@
       ],
       "notes": ""
     },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "traitWebs": []
   },
   "effects": [
     {
@@ -113,35 +94,41 @@
         "changes": [
           {
             "type": "roll-effect",
-            "key": "masters-whip-attack",
+            "key": "masters-whip-generic",
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advancecondition",
             "predicate": [],
             "chance": 100,
             "affects": "target",
             "alterations": [
               {
+                "method": 5,
                 "property": "system.amount",
-                "value": 30,
-                "method": 5
+                "value": 30
               }
             ],
             "label": "Master's Whip",
             "dontMerge": false,
             "priority": null,
-            "ignored": false,
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -153,14 +140,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "14.364",
         "systemId": "ptr2e",
-        "systemVersion": "1.2.1.beta",
+        "systemVersion": "1.7.6.beta",
         "createdTime": 1742128847826,
-        "modifiedTime": 1745186004290,
-        "lastModifiedBy": "mK35yvCqCgiTUvKf",
+        "modifiedTime": 1784210590443,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-perks/the-meaning-of-haste.json
+++ b/packs/core-perks/the-meaning-of-haste.json
@@ -11,33 +11,16 @@
         "slug": "the-meaning-of-haste",
         "description": "<p>All allied creatures gain +2 SPD stages for 5 Activations.</p>",
         "traits": [],
-        "type": "attack",
+        "type": "generic",
         "range": {
           "target": "field",
-          "unit": "m",
-          "distance": 0
+          "unit": "m"
         },
         "cost": {
           "activation": "complex",
           "powerPoints": 6
         },
-        "img": "systems/ptr2e/img/perk-icons/Orders_Training.svg",
-        "types": [
-          "untyped"
-        ],
-        "category": "status",
-        "predicate": [],
-        "free": true,
-        "variant": null,
-        "ephemeralVariant": false,
-        "contestType": "",
-        "contestEffect": "",
-        "slot": null,
-        "summon": null,
-        "defaultVariant": null,
-        "flingItemId": "",
-        "offensiveStat": null,
-        "defensiveStat": null
+        "img": "systems/ptr2e/img/perk-icons/Orders_Training.svg"
       }
     ],
     "slug": "the-meaning-of-haste",
@@ -94,9 +77,7 @@
       ],
       "notes": ""
     },
-    "originSlug": null,
-    "variant": null,
-    "mode": null
+    "traitWebs": []
   },
   "effects": [
     {
@@ -108,28 +89,34 @@
         "changes": [
           {
             "type": "roll-effect",
-            "key": "the-meaning-of-haste-attack",
+            "key": "the-meaning-of-haste-generic",
             "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.XeiSuS3APUcN0MLZ",
             "predicate": [],
             "chance": 100,
             "affects": "target",
             "priority": null,
-            "ignored": false,
             "alterations": [],
             "dontMerge": false,
-            "method": 2
+            "phase": "initial",
+            "isFixedChance": false,
+            "method": 2,
+            "ignored": false
           }
         ],
         "slug": null,
         "traits": [],
         "removeAfterCombat": true,
         "removeOnRecall": false,
-        "stacks": 0
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
       },
       "disabled": false,
       "duration": {
         "units": "turns",
-        "value": null
+        "value": null,
+        "expiry": null,
+        "expired": false
       },
       "description": "",
       "origin": null,
@@ -141,14 +128,17 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.342",
+        "coreVersion": "14.364",
         "systemId": "ptr2e",
-        "systemVersion": "0.10.0-alpha.5.1.2",
+        "systemVersion": "1.7.6.beta",
         "createdTime": 1736877838885,
-        "modifiedTime": 1736877883752,
-        "lastModifiedBy": "IcBpMqhFuTck9VpX",
+        "modifiedTime": 1784210540583,
+        "lastModifiedBy": "VGuCUKsxs9UY3xDR",
         "exportSource": null
-      }
+      },
+      "start": null,
+      "showIcon": 1,
+      "folder": null
     }
   ]
 }

--- a/packs/core-perks/unown-song-sanctuary-ward.json
+++ b/packs/core-perks/unown-song-sanctuary-ward.json
@@ -20,21 +20,17 @@
         "slug": "unown-song-sanctuary-ward",
         "description": "<p>Through your mastery of the Arcane, you can conjure a choir of Unown to perform a Sanctuary Ward. This effect grants you and your allies on the field +15% RES for the duration of 3 rounds.</p>",
         "traits": [],
-        "type": "attack",
+        "type": "generic",
         "img": "systems/ptr2e/img/perk-icons/Arcana.svg",
         "range": {
           "target": "enemy",
-          "unit": "m"
+          "unit": "m",
+          "distance": 10
         },
         "cost": {
           "activation": "complex",
           "powerPoints": 3
         },
-        "types": [
-          "untyped"
-        ],
-        "category": "status",
-        "predicate": [],
         "summon": "Compendium.ptr2e.core-summons.gA98zyh1nExOnwEP"
       }
     ],

--- a/packs/core-perks/victory-march.json
+++ b/packs/core-perks/victory-march.json
@@ -20,7 +20,7 @@
         "slug": "victory-march",
         "description": "<p>Effect: By spending @PP[-4] as a Complex Action, the user may may activate the Victory March summon, which grants allies on the field +20% Damage and +20% Damage Reduction for 3 rounds.</p>",
         "traits": [],
-        "type": "attack",
+        "type": "generic",
         "img": "icons/sundries/flags/banner-flag-red-white.webp",
         "cost": {
           "activation": "complex",
@@ -29,14 +29,9 @@
         "summon": "Compendium.ptr2e.core-summons.fFAxckcMfiygtqxM",
         "range": {
           "target": "field",
-          "unit": "m"
-        },
-        "types": [
-          "untyped"
-        ],
-        "category": "status",
-        "free": true,
-        "predicate": []
+          "unit": "m",
+          "distance": 10
+        }
       }
     ],
     "description": "<p>Effect: By spending @PP[-5] as a Complex Action, the user may may activate the @UUID[Compendium.ptr2e.core-summons.fFAxckcMfiygtqxM]{Victory March Summon}, which grants allies on the field +20% Damage and +20% Damage Reduction for 3 rounds.</p>",


### PR DESCRIPTION
Auto Generated message for PTR2e Foundry Data Github Sync.
- Update Perk: Unown Song: Sanctuary Ward
- Update Perk: Victory March
- Update Perk: The Meaning of Haste
- Update Perk: Master's Whip
- Update Perk: Ball Tinkerer
- Update Perk: Berry Garden
- Update Perk: Climate Capture
- Update Perk: Jailbreaker