### PR TITLE
Fix gear carry slot filtering

### DIFF
--- a/src/module/apps/compendium-browser/tabs/gear.ts
+++ b/src/module/apps/compendium-browser/tabs/gear.ts
@@ -104,7 +104,8 @@ export class CompendiumBrowserGearTab extends CompendiumBrowserTab {
       worn: "PTR2E.FIELDS.gear.equipped.slot.worn",
       accessory: "PTR2E.FIELDS.gear.equipped.slot.accessory",
       belt: "PTR2E.FIELDS.gear.equipped.slot.belt",
-      backpack: "PTR2E.FIELDS.gear.equipped.slot.backpack"
+      backpack: "PTR2E.FIELDS.gear.equipped.slot.backpack",
+      slotless: "PTR2E.FIELDS.gear.equipped.slot.slotless"
     });
     this.filterData.multiselects.traits.options = this.generateMultiselectOptions(traits.reduce((acc, trait) => {
       const traitData = game.ptr.data.traits.getTrait(trait);
@@ -163,6 +164,9 @@ export class CompendiumBrowserGearTab extends CompendiumBrowserTab {
     else {
       if(!(entry.fling?.accuracy >= sliders.accuracy.values.min && entry.fling?.accuracy <= sliders.accuracy.values.max)) return false;
     }
+
+    // Carry Slot
+    if(checkboxes.carrySlot.selected.length && !checkboxes.carrySlot.selected.includes(entry.slot)) return false;
 
     // Traits
     if (!this.filterTraits(entry.traits, multiselects.traits.selected, multiselects.traits.conjunction)) return false;

--- a/src/module/data/models/equipped.ts
+++ b/src/module/data/models/equipped.ts
@@ -34,7 +34,7 @@ class EquipmentData extends foundry.abstract.DataModel {
 interface EquipmentData extends foundry.abstract.DataModel {
     carryType: PTRCONSTS.CarryType;
     handsHeld: number;
-    slot: "held" | "worn" | "accessory" | "belt" | "backpack";
+    slot: "held" | "worn" | "accessory" | "belt" | "backpack" | "slotless";
 }
 
 export default EquipmentData;


### PR DESCRIPTION
## Summary
- Apply the Gear tab Carry Slot checkbox filter to compendium browser results.
- Add the missing `slotless` carry slot option to the filter.
- Update the `EquipmentData.slot` TypeScript union to match the schema's supported slot values.

## Details
The Gear tab already stores `system.equipped.slot` as `entry.slot` in the compendium browser index, and the UI exposes a Carry Slot filter. However, `filterIndexData` never checks `checkboxes.carrySlot.selected`, so selecting Held/Worn/Belt/etc does not affect the result list.

The equipped schema also accepts `slotless`, but the Gear tab filter did not include it as an available Carry Slot option.