### PR TITLE
Foundry Data Sync - Boss Effect Touch-Ups and Additions

### DIFF
--- a/packs/core-effects-new/boss-dr.json
+++ b/packs/core-effects-new/boss-dr.json
@@ -18,7 +18,8 @@
         "priority": null,
         "ignored": false,
         "suboptions": [],
-        "method": 2
+        "method": 2,
+        "phase": "initial"
       },
       {
         "type": "basic",
@@ -29,37 +30,27 @@
         ],
         "priority": null,
         "ignored": false,
-        "method": 2
+        "method": 2,
+        "phase": "initial"
       }
     ],
-    "slug": null,
+    "slug": "boss-dr",
     "traits": [],
-    "removeAfterCombat": true,
-    "removeOnRecall": false,
-    "stacks": 0,
-    "description": "<p>Adds a togglable 75% damage reduction from all sources to this Boss. </p><p>The toggle can be found in the Effects tab under 'Toggles'</p>"
+    "removeAfterCombat": true
   },
   "disabled": false,
   "duration": {
     "units": "turns",
-    "value": null
+    "value": null,
+    "expiry": null,
+    "expired": false
   },
-  "description": "<p>Adds a togglable 75% damage reduction from all sources to this Boss. </p><p>The toggle can be found in the Effects tab under 'Toggles'</p>",
+  "description": "<p>Adds a togglable 75% damage reduction from all sources to this Boss.</p><p>The toggle can be found in the Effects tab under 'Toggles'</p>",
   "origin": null,
   "tint": "#ffffff",
   "transfer": true,
   "statuses": [],
-  "sort": 0,
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.331",
-    "systemId": "ptr2e",
-    "systemVersion": "1.1.2.beta",
-    "createdTime": 1734210390162,
-    "modifiedTime": 1743595876869,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "folder": "QUgx4S1LlBbCXWnX"
+  "folder": "QUgx4S1LlBbCXWnX",
+  "start": null,
+  "showIcon": 1
 }

--- a/packs/core-effects-new/boss-ehr.json
+++ b/packs/core-effects-new/boss-ehr.json
@@ -1,0 +1,55 @@
+{
+  "folder": "QUgx4S1LlBbCXWnX",
+  "name": "Boss EHR",
+  "type": "passive",
+  "_id": "Xg5SKd4VRo4STsaF",
+  "img": "icons/svg/card-joker.svg",
+  "system": {
+    "changes": [
+      {
+        "type": "roll-option",
+        "value": "boss-ehr-active",
+        "predicate": [],
+        "domain": "all",
+        "toggleable": true,
+        "count": false,
+        "state": true,
+        "alwaysActive": false,
+        "priority": null,
+        "phase": "initial",
+        "key": "",
+        "method": 2,
+        "ignored": false,
+        "suboptions": []
+      },
+      {
+        "type": "basic",
+        "key": "system.modifiers.effectHitRate",
+        "value": 40,
+        "phase": "initial",
+        "predicate": [
+          "boss-ehr-active"
+        ],
+        "method": 2,
+        "ignored": false
+      }
+    ],
+    "traits": [],
+    "removeAfterCombat": true
+  },
+  "disabled": false,
+  "start": null,
+  "duration": {
+    "value": null,
+    "units": "seconds",
+    "expiry": null,
+    "expired": false
+  },
+  "description": "<p>Adds a togglable 40% EHR increase to this Boss.</p><p>The toggle can be found in the Effects tab under 'Toggles'</p>",
+  "origin": null,
+  "tint": "#ffffff",
+  "transfer": false,
+  "statuses": [],
+  "showIcon": 1,
+  "flags": {}
+}

--- a/packs/core-effects-new/boss-on-hit-advancement.json
+++ b/packs/core-effects-new/boss-on-hit-advancement.json
@@ -6,53 +6,60 @@
   "system": {
     "changes": [
       {
+        "type": "roll-option",
+        "value": "boss-hit-advance:active",
+        "phase": "initial",
+        "predicate": [],
+        "domain": "all",
+        "toggleable": true,
+        "count": false,
+        "state": true,
+        "alwaysActive": false,
+        "key": "",
+        "method": 2,
+        "ignored": false,
+        "suboptions": []
+      },
+      {
         "type": "roll-effect",
         "key": "attack",
         "value": "Compendium.ptr2e.core-effects.Item.delayconditiitem",
-        "predicate": [],
+        "predicate": [
+          "boss-hit-advance:active"
+        ],
         "chance": 100,
         "affects": "defensive",
         "dontMerge": true,
         "alterations": [
           {
+            "method": 5,
             "property": "system.amount",
-            "value": "5 + clamp(-3 * @actor.system.attributes.spe.stage, -5, 18)",
-            "method": 5
+            "value": "5 + clamp(-3 * @actor.system.attributes.spe.stage, -5, 18)"
           }
         ],
         "priority": null,
-        "ignored": false,
-        "method": 2
+        "phase": "initial",
+        "isFixedChance": false,
+        "method": 2,
+        "ignored": false
       }
     ],
-    "slug": null,
-    "traits": [],
-    "removeAfterCombat": false,
-    "removeOnRecall": false,
-    "stacks": 0,
-    "description": "<p>This effect makes it so that Bosses gain Action Advancement whenever they are hit, it scales with the amount of speed stages it has; providing no benefit if the boss is at 2 or more positive stages, and the most at -6 speed.</p><pre><code>Action Advancement% = 5 + clamp(-3 * speedStage, -5, 18)</code></pre>"
+    "slug": "boss-on-hit-advancement",
+    "traits": []
   },
   "disabled": false,
   "duration": {
     "units": "turns",
-    "value": null
+    "value": null,
+    "expiry": null,
+    "expired": false
   },
   "description": "<p>This effect makes it so that Bosses gain Action Advancement whenever they are hit, it scales with the amount of speed stages it has; providing no benefit if the boss is at 2 or more positive stages, and the most at -6 speed.</p><pre><code>Action Advancement% = 5 + clamp(-3 * speedStage, -5, 18)</code></pre>",
   "origin": null,
   "tint": "#ffffff",
   "transfer": true,
   "statuses": [],
-  "sort": 0,
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "coreVersion": "12.331",
-    "systemId": "ptr2e",
-    "systemVersion": "1.1.3.beta",
-    "createdTime": 1743594347046,
-    "modifiedTime": 1743595986616,
-    "lastModifiedBy": "tXAZ3QUgjuwX4gdV"
-  },
-  "folder": "QUgx4S1LlBbCXWnX"
+  "folder": "QUgx4S1LlBbCXWnX",
+  "start": null,
+  "showIcon": 1
 }

--- a/packs/core-effects-new/boss-res.json
+++ b/packs/core-effects-new/boss-res.json
@@ -6,44 +6,50 @@
   "system": {
     "changes": [
       {
+        "type": "roll-option",
+        "value": "boss-res-active",
+        "predicate": [],
+        "domain": "all",
+        "toggleable": true,
+        "count": false,
+        "state": true,
+        "alwaysActive": false,
+        "priority": null,
+        "phase": "initial",
+        "key": "",
+        "method": 2,
+        "ignored": false,
+        "suboptions": []
+      },
+      {
         "type": "basic",
         "key": "system.modifiers.effectResistance",
         "value": 30,
-        "predicate": [],
-        "ignored": false,
-        "method": 2
+        "predicate": [
+          "boss-res-active"
+        ],
+        "phase": "initial",
+        "method": 2,
+        "ignored": false
       }
     ],
-    "slug": null,
+    "slug": "boss-res",
     "traits": [],
-    "removeAfterCombat": true,
-    "removeOnRecall": false,
-    "removeAfterAttacking": false,
-    "removeAfterAttacked": false,
-    "stacks": 0,
-    "description": "<p>This effect grants bosses a passive +30% RES.</p>"
+    "removeAfterCombat": true
   },
   "disabled": false,
   "duration": {
     "units": "turns",
-    "value": null
+    "value": null,
+    "expiry": null,
+    "expired": false
   },
-  "description": "",
+  "description": "<p>Adds a togglable 30% RES increase to this Boss.</p><p>The toggle can be found in the Effects tab under 'Toggles'</p>",
   "origin": null,
   "tint": "#ffffff",
   "transfer": true,
   "statuses": [],
-  "sort": 0,
-  "flags": {},
-  "_stats": {
-    "compendiumSource": null,
-    "duplicateSource": null,
-    "exportSource": null,
-    "coreVersion": "13.347",
-    "systemId": "ptr2e",
-    "systemVersion": "1.4.2.beta",
-    "lastModifiedBy": "mK35yvCqCgiTUvKf",
-    "modifiedTime": 1754603715329
-  },
-  "folder": "QUgx4S1LlBbCXWnX"
+  "folder": "QUgx4S1LlBbCXWnX",
+  "start": null,
+  "showIcon": 1
 }

--- a/packs/core-perks/boss-effects.json
+++ b/packs/core-perks/boss-effects.json
@@ -1,0 +1,625 @@
+{
+  "name": "Boss Effects",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Boss Initiative",
+        "slug": "boss-initiative",
+        "description": "<p>Allows the Boss to cast the @UUID[Compendium.ptr2e.core-summons.ylRMiJ1vZuKrKbtC]{Boss Initiative} Summon.</p>",
+        "traits": [],
+        "type": "attack",
+        "img": "icons/magic/movement/abstract-ribbons-red-orange.webp",
+        "cost": {
+          "activation": "free",
+          "powerPoints": 6
+        },
+        "summon": "Compendium.ptr2e.core-summons.Item.ylRMiJ1vZuKrKbtC",
+        "range": {
+          "target": "self",
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": []
+      }
+    ],
+    "slug": "boss-effects",
+    "description": "<p>This Perk contains all of the Boss effects, all slotted on this convenient Perk.</p>",
+    "traits": [],
+    "prerequisites": [
+      "GM Permission"
+    ],
+    "autoUnlock": [],
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": []
+  },
+  "_id": "jq8voieQNkaWsOAi",
+  "img": "icons/magic/unholy/strike-body-explode-disintegrate.webp",
+  "effects": [
+    {
+      "name": "Boss Delay Reduction",
+      "type": "passive",
+      "_id": "wBuI7C5YBUwDMfyE",
+      "img": "icons/magic/defensive/barrier-shield-dome-pink.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "special:boss-delay",
+            "predicate": [],
+            "domain": "all",
+            "toggleable": true,
+            "count": false,
+            "priority": null,
+            "state": true,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          }
+        ],
+        "slug": "boss-delay-reduction",
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
+      },
+      "disabled": false,
+      "duration": {
+        "units": "turns",
+        "value": null,
+        "expiry": null,
+        "expired": false
+      },
+      "description": "<p>This effect makes it so that Bosses can't be delayed more then 30% per Activation.</p><blockquote><p>Note: This is referring to the <strong>total</strong> delay, if you first advance the boss by say 10%, that means it at that point can be delayed by 40%, it just can never be advanced more then -30% from its base value.</p></blockquote>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "core": {}
+      },
+      "_stats": {
+        "coreVersion": "14.365",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1786117082054,
+        "modifiedTime": 1786117082054,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "folder": "QUgx4S1LlBbCXWnX",
+      "start": null,
+      "showIcon": 1
+    },
+    {
+      "name": "Boss On-Hit Advancement",
+      "type": "passive",
+      "_id": "17DsLjut68l9nHRk",
+      "img": "icons/magic/time/clock-stopwatch-white-blue.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "boss-hit-advance:active",
+            "phase": "initial",
+            "predicate": [],
+            "domain": "all",
+            "toggleable": true,
+            "count": false,
+            "state": true,
+            "alwaysActive": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "roll-effect",
+            "key": "attack",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advancecondition",
+            "predicate": [
+              "boss-hit-advance:active"
+            ],
+            "chance": 100,
+            "affects": "defensive",
+            "dontMerge": true,
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": "5 + clamp(-3 * @actor.system.attributes.spe.stage, -5, 15)"
+              }
+            ],
+            "priority": null,
+            "phase": "initial",
+            "isFixedChance": false,
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": "boss-on-hit-advancement",
+        "traits": [],
+        "removeAfterCombat": false,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
+      },
+      "disabled": false,
+      "duration": {
+        "units": "turns",
+        "value": null,
+        "expiry": null,
+        "expired": false
+      },
+      "description": "<p>This effect makes it so that Bosses gain Action Advancement whenever they are hit, it scales with the amount of speed stages it has; providing no benefit if the boss is at 2 or more positive stages, and the most at -6 speed.</p><pre><code>Action Advancement% = 5 + clamp(-3 * speedStage, -5, 18)</code></pre>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "core": {}
+      },
+      "_stats": {
+        "coreVersion": "14.365",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1786117082054,
+        "modifiedTime": 1786117082054,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "folder": "QUgx4S1LlBbCXWnX",
+      "start": null,
+      "showIcon": 1
+    },
+    {
+      "name": "Boss DR",
+      "type": "passive",
+      "_id": "4AZcTXGUaNdQ0CNO",
+      "img": "icons/magic/defensive/shield-barrier-glowing-blue.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "key": "",
+            "value": "boss-dr-active",
+            "predicate": [],
+            "domain": "all",
+            "toggleable": true,
+            "count": false,
+            "state": true,
+            "alwaysActive": false,
+            "priority": null,
+            "ignored": false,
+            "suboptions": [],
+            "method": 2,
+            "phase": "initial"
+          },
+          {
+            "type": "basic",
+            "key": "system.modifiers.vulnerabilityMultiplier",
+            "value": -0.75,
+            "predicate": [
+              "boss-dr-active"
+            ],
+            "priority": null,
+            "ignored": false,
+            "method": 2,
+            "phase": "initial"
+          }
+        ],
+        "slug": "boss-dr",
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
+      },
+      "disabled": false,
+      "duration": {
+        "units": "turns",
+        "value": null,
+        "expiry": null,
+        "expired": false
+      },
+      "description": "<p>Adds a togglable 75% damage reduction from all sources to this Boss.</p><p>The toggle can be found in the Effects tab under 'Toggles'</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "core": {}
+      },
+      "_stats": {
+        "coreVersion": "14.365",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1786117082054,
+        "modifiedTime": 1786117082054,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "folder": "QUgx4S1LlBbCXWnX",
+      "start": null,
+      "showIcon": 1
+    },
+    {
+      "folder": "QUgx4S1LlBbCXWnX",
+      "name": "Boss EHR",
+      "type": "passive",
+      "_id": "uuvkUK0efTxNaoD5",
+      "img": "icons/svg/card-joker.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "boss-ehr-active",
+            "predicate": [],
+            "domain": "all",
+            "toggleable": true,
+            "count": false,
+            "state": true,
+            "alwaysActive": false,
+            "priority": null,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "basic",
+            "key": "system.modifiers.effectHitRate",
+            "value": 40,
+            "phase": "initial",
+            "predicate": [
+              "boss-ehr-active"
+            ],
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "<p>Adds a togglable 40% EHR increase to this Boss.</p><p>The toggle can be found in the Effects tab under 'Toggles'</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": false,
+      "statuses": [],
+      "showIcon": 1,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.365",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1786117082054,
+        "modifiedTime": 1786117082054,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    },
+    {
+      "name": "Boss RES",
+      "type": "passive",
+      "_id": "76ShLa90tnZ8llU0",
+      "img": "icons/svg/teleport.svg",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "boss-res-active",
+            "predicate": [],
+            "domain": "all",
+            "toggleable": true,
+            "count": false,
+            "state": true,
+            "alwaysActive": false,
+            "priority": null,
+            "phase": "initial",
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "basic",
+            "key": "system.modifiers.effectResistance",
+            "value": 30,
+            "predicate": [
+              "boss-res-active"
+            ],
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": "boss-res",
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "duration": {
+        "units": "turns",
+        "value": null,
+        "expiry": null,
+        "expired": false
+      },
+      "description": "<p>Adds a togglable 30% RES increase to this Boss.</p><p>The toggle can be found in the Effects tab under 'Toggles'</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "core": {
+          "sourceId": "Compendium.ptr2e.core-effects-new.Item.LJjDOxRCEQmV8oId"
+        }
+      },
+      "_stats": {
+        "coreVersion": "14.365",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "modifiedTime": 1786117082054,
+        "createdTime": 1786117082054,
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "folder": "QUgx4S1LlBbCXWnX",
+      "start": null,
+      "showIcon": 1
+    },
+    {
+      "name": "Full IV Booster for Bosses",
+      "type": "passive",
+      "_id": "ajDaGReCVYRIA6Km",
+      "img": "systems/ptr2e/img/icons/class_feat_icon.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "basic",
+            "key": "system.attributes.atk.ivs",
+            "value": 30,
+            "predicate": [],
+            "priority": null,
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.attributes.def.ivs",
+            "value": 30,
+            "predicate": [],
+            "priority": null,
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.attributes.hp.ivs",
+            "value": 30,
+            "predicate": [],
+            "priority": null,
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.attributes.spa.ivs",
+            "value": 30,
+            "predicate": [],
+            "priority": null,
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.attributes.spd.ivs",
+            "value": 30,
+            "predicate": [],
+            "priority": null,
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          },
+          {
+            "type": "basic",
+            "key": "system.attributes.spe.ivs",
+            "value": 30,
+            "predicate": [],
+            "priority": null,
+            "phase": "initial",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": "full-iv-booster-for-bosses",
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "stacks": 0,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false
+      },
+      "disabled": false,
+      "duration": {
+        "units": "turns",
+        "value": null,
+        "expiry": null,
+        "expired": false
+      },
+      "description": "<p>Add 30 IVs in all stats. Meant for Bosses.</p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "core": {
+          "sourceId": "Compendium.ptr2e.core-effects-new.Item.cwnxDKZUoQdmE4lP"
+        }
+      },
+      "_stats": {
+        "coreVersion": "14.365",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1786117082054,
+        "modifiedTime": 1786117082054,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      },
+      "folder": "QUgx4S1LlBbCXWnX",
+      "start": null,
+      "showIcon": 1
+    },
+    {
+      "name": "Boss Initiative",
+      "type": "passive",
+      "_id": "3UR2F4TGj87hzrZo",
+      "img": "icons/magic/movement/abstract-ribbons-red-orange.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "iterative-activate:active",
+            "phase": "initial",
+            "predicate": [],
+            "label": "Boss Iterative Activation",
+            "domain": "all",
+            "toggleable": true,
+            "count": false,
+            "state": true,
+            "alwaysActive": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advancecondition",
+            "phase": "initial",
+            "predicate": [
+              "effect:summon:boss-initiative",
+              "iterative-activate:active"
+            ],
+            "chance": 30,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 100
+              }
+            ],
+            "dontMerge": true,
+            "key": "attack",
+            "label": "Iterative Activation",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.365",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1786117723453,
+        "modifiedTime": 1786117723453,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.nv7n12ocpkfLlMJr.ActiveEffect.KHnagu8oB9CZSmQh",
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-perks/boss-initiative.json
+++ b/packs/core-perks/boss-initiative.json
@@ -1,0 +1,144 @@
+{
+  "name": "Boss Initiative",
+  "type": "perk",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "actions": [
+      {
+        "name": "Boss Initiative",
+        "slug": "boss-initiative",
+        "description": "<p>Allows the Boss to cast the @UUID[Compendium.ptr2e.core-summons.ylRMiJ1vZuKrKbtC]{Boss Initiative} Summon.</p>",
+        "traits": [],
+        "type": "attack",
+        "img": "icons/magic/movement/abstract-ribbons-red-orange.webp",
+        "cost": {
+          "activation": "free",
+          "powerPoints": 6
+        },
+        "summon": "Compendium.ptr2e.core-summons.Item.ylRMiJ1vZuKrKbtC",
+        "range": {
+          "target": "self",
+          "unit": "m"
+        },
+        "types": [
+          "untyped"
+        ],
+        "category": "status",
+        "free": true,
+        "predicate": []
+      }
+    ],
+    "slug": "boss-initiative",
+    "description": "<p>Allows the Boss to cast the Boss Initiative Summon.</p>",
+    "traits": [],
+    "prerequisites": [],
+    "autoUnlock": [],
+    "design": {
+      "arena": null,
+      "approach": null,
+      "archetype": null
+    },
+    "global": true,
+    "webs": [],
+    "traitWebs": [],
+    "nodes": []
+  },
+  "_id": "nv7n12ocpkfLlMJr",
+  "img": "icons/magic/movement/abstract-ribbons-red-orange.webp",
+  "effects": [
+    {
+      "name": "Boss Initiative",
+      "type": "passive",
+      "_id": "KHnagu8oB9CZSmQh",
+      "img": "icons/magic/movement/abstract-ribbons-red-orange.webp",
+      "system": {
+        "changes": [
+          {
+            "type": "roll-option",
+            "value": "iterative-activate:active",
+            "phase": "initial",
+            "predicate": [],
+            "label": "Boss Iterative Activation",
+            "domain": "all",
+            "toggleable": true,
+            "count": false,
+            "state": true,
+            "alwaysActive": false,
+            "key": "",
+            "method": 2,
+            "ignored": false,
+            "suboptions": []
+          },
+          {
+            "type": "roll-effect",
+            "value": "Compendium.ptr2e.core-effects-new.ActiveEffect.advancecondition",
+            "phase": "initial",
+            "predicate": [
+              "effect:summon:boss-initiative",
+              "iterative-activate:active"
+            ],
+            "chance": 30,
+            "isFixedChance": true,
+            "affects": "self",
+            "alterations": [
+              {
+                "method": 5,
+                "property": "system.amount",
+                "value": 100
+              }
+            ],
+            "dontMerge": true,
+            "key": "attack",
+            "label": "Iterative Activation",
+            "method": 2,
+            "ignored": false
+          }
+        ],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 0,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.365",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1786117169415,
+        "modifiedTime": 1786117369709,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": "Compendium.ptr2e.core-perks.Item.nv7n12ocpkfLlMJr.ActiveEffect.KHnagu8oB9CZSmQh",
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}

--- a/packs/core-summons/boss-initiative.json
+++ b/packs/core-summons/boss-initiative.json
@@ -1,0 +1,76 @@
+{
+  "name": "Boss Initiative",
+  "type": "summon",
+  "system": {
+    "_migration": {
+      "version": 0.113,
+      "previous": null
+    },
+    "publication": {
+      "source": "",
+      "authors": [],
+      "notes": ""
+    },
+    "slug": "boss-initiative",
+    "traits": [],
+    "description": "<p>While Active, Bosses with @UUID[Compendium.ptr2e.core-perks.nv7n12ocpkfLlMJr]{Boss Initiative} or @UUID[Compendium.ptr2e.core-perks.jq8voieQNkaWsOAi]{Boss Effects} have a 30% (default) chance to gain @Affliction[advance 100] after their Attacks.</p>",
+    "actions": [],
+    "baseAV": 200,
+    "duration": 1
+  },
+  "_id": "ylRMiJ1vZuKrKbtC",
+  "img": "icons/magic/movement/abstract-ribbons-red-orange.webp",
+  "effects": [
+    {
+      "name": "Boss Initiative",
+      "type": "summon",
+      "_id": "fPLgq7mSuPssKMhp",
+      "img": "icons/magic/movement/abstract-ribbons-red-orange.webp",
+      "system": {
+        "changes": [],
+        "slug": null,
+        "traits": [],
+        "removeAfterCombat": true,
+        "removeOnRecall": false,
+        "removeAfterAttacking": false,
+        "removeAfterAttacked": false,
+        "stacks": 0,
+        "priority": 50,
+        "formula": "",
+        "type": "damage",
+        "predicate": [],
+        "targetType": "all",
+        "targetUuid": null
+      },
+      "disabled": false,
+      "start": null,
+      "duration": {
+        "value": null,
+        "units": "seconds",
+        "expiry": null,
+        "expired": false
+      },
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "showIcon": 1,
+      "folder": null,
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "coreVersion": "14.365",
+        "systemId": "ptr2e",
+        "systemVersion": "1.7.6.beta",
+        "createdTime": 1786117211391,
+        "modifiedTime": 1786117211391,
+        "lastModifiedBy": "dgye2I5sN06rQmNS",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+      }
+    }
+  ],
+  "flags": {}
+}


### PR DESCRIPTION
Existing Boss Effects given toggles for ease of use.
Addition of a Boss EHR effect, an "iterative activation" effect+summon to assist with single entity bosses and getting them multiple turns, and a perk that gives all of these effects in one package.
- Update Passive: Boss DR
- Update Passive: Boss EHR
- Update Passive: Boss On-Hit Advancement
- Update Passive: Boss RES
- Update Perk: Boss Initiative
- Update Summon: Boss Initiative
- Update Perk: Boss Effects